### PR TITLE
fix(ci): harden GitHub Actions Gradle startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Verify MeshLink SDK
         run: |
+          # The hosted macOS runner currently exposes only 3 CPUs; keep verification
+          # single-worker so iOS compilation does not starve timing-sensitive test tasks.
           ./gradlew \
             :meshlink:allTests \
             :meshlink:detekt \
@@ -48,6 +50,7 @@ jobs:
             :meshlink:koverVerify \
             verifyDocs \
             checkAgp9Invariants \
+            --max-workers=1 \
             --console=plain
 
       - name: Upload verification reports

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,34 @@
 pluginManagement {
+    // Resolve plugin ids directly to their implementation artifacts so CI does not depend on
+    // separate marker-module lookups during cold starts.
+    val directPluginImplementationModules =
+        mapOf(
+            "org.jetbrains.kotlin.multiplatform" to "org.jetbrains.kotlin:kotlin-gradle-plugin",
+            "org.jetbrains.kotlin.plugin.allopen" to "org.jetbrains.kotlin:kotlin-allopen",
+            "org.jetbrains.kotlin.plugin.power-assert" to "org.jetbrains.kotlin:kotlin-power-assert",
+            "org.jetbrains.kotlin.plugin.serialization" to "org.jetbrains.kotlin:kotlin-serialization",
+            "org.jetbrains.kotlin.plugin.compose" to "org.jetbrains.kotlin:compose-compiler-gradle-plugin",
+            "com.android.kotlin.multiplatform.library" to "com.android.tools.build:gradle",
+            "com.android.application" to "com.android.tools.build:gradle",
+            "org.jetbrains.compose" to "org.jetbrains.compose:compose-gradle-plugin",
+            "io.gitlab.arturbosch.detekt" to "io.gitlab.arturbosch.detekt:detekt-gradle-plugin",
+            "com.ncorti.ktfmt.gradle" to "com.ncorti.ktfmt.gradle:plugin",
+            "org.jetbrains.dokka" to "org.jetbrains.dokka:dokka-gradle-plugin",
+            "co.touchlab.skie" to "co.touchlab.skie:gradle-plugin",
+            "org.jetbrains.kotlinx.benchmark" to "org.jetbrains.kotlinx:kotlinx-benchmark-plugin",
+            "org.jetbrains.kotlinx.binary-compatibility-validator" to
+                "org.jetbrains.kotlinx:binary-compatibility-validator",
+            "org.jetbrains.kotlinx.kover" to "org.jetbrains.kotlinx:kover-gradle-plugin",
+        )
+
+    resolutionStrategy {
+        eachPlugin {
+            val moduleCoordinate = directPluginImplementationModules[requested.id.id] ?: return@eachPlugin
+            val pluginVersion = requested.version ?: return@eachPlugin
+            useModule("$moduleCoordinate:$pluginVersion")
+        }
+    }
+
     repositories {
         google()
         gradlePluginPortal()


### PR DESCRIPTION
## Summary
- resolve plugin ids directly to implementation modules during Gradle settings resolution
- avoid separate plugin marker lookups during cold CI starts
- run the GitHub Actions verification job with `--max-workers=1` to reduce timing-related flakes on the 3-core macOS runner

## Verification
- `GRADLE_USER_HOME=$(mktemp -d) ./gradlew :meshlink:allTests :meshlink:detekt :meshlink:apiCheck :meshlink:koverVerify verifyDocs checkAgp9Invariants --no-daemon --console=plain`
- `yamllint -c .yamllint.yml .github/workflows/ci.yml`
- `./gradlew :meshlink:allTests :meshlink:detekt :meshlink:apiCheck :meshlink:koverVerify verifyDocs checkAgp9Invariants --max-workers=1 --console=plain`
- GitHub Actions push run `26680570217` passed on `fix/harden-plugin-resolution`