### PR TITLE
fix(ci): replace default CodeQL with advanced workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,147 @@
+name: codeql
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '**/*.java'
+      - '**/*.kt'
+      - '**/*.kts'
+      - '**/*.py'
+      - '**/*.swift'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - '**/project.yml'
+      - '**/*.xcodeproj/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '**/*.java'
+      - '**/*.kt'
+      - '**/*.kts'
+      - '**/*.py'
+      - '**/*.swift'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - '**/project.yml'
+      - '**/*.xcodeproj/**'
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      include_swift:
+        description: 'Also run the slower Swift scan'
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  pull-requests: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    if: >-
+      ${{
+        matrix.language != 'swift' ||
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && inputs.include_swift)
+      }}
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            runs_on: ubuntu-latest
+            timeout_minutes: 10
+            build_mode: none
+          - language: python
+            runs_on: ubuntu-latest
+            timeout_minutes: 10
+            build_mode: none
+          - language: java-kotlin
+            runs_on: ubuntu-latest
+            timeout_minutes: 20
+            build_mode: manual
+          - language: swift
+            runs_on: macos-latest
+            timeout_minutes: 35
+            build_mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Java
+        if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build_mode }}
+
+      - name: Build Java/Kotlin database
+        if: matrix.language == 'java-kotlin'
+        shell: bash
+        run: |
+          # The Java/Kotlin extractor only needs JVM and Android compilation commands.
+          # Avoid clean/full assemble so PR scans do not rebuild iOS/native artifacts.
+          ./gradlew \
+            :meshlink:jvmJar \
+            :meshlink:androidJar \
+            :benchmarks:jvmJar \
+            :meshlink-reference:jvmJar \
+            :meshlink-reference:bundleAndroidMainAar \
+            :meshlink-reference:android:compileDebugKotlin \
+            :meshlink-proof:android:compileDebugKotlin \
+            --no-daemon \
+            --console=plain
+
+      - name: Build Swift database
+        if: matrix.language == 'swift'
+        shell: bash
+        env:
+          CONFIGURATION: Debug
+          SDK_NAME: iphoneos
+        run: |
+          # Build the Kotlin framework once up front and tell Xcode to skip the always-run
+          # Gradle script phase. This keeps the slow Swift scan off PRs while still scanning
+          # the tracked iOS app sources on main and the weekly schedule.
+          ./gradlew \
+            :meshlink:embedAndSignAppleFrameworkForXcode \
+            --no-daemon \
+            --console=plain
+
+          xcodebuild build \
+            -project meshlink-proof/ios/ProofApp.xcodeproj \
+            -target ProofApp \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,16 +50,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
+  analyze-fast:
     name: Analyze (${{ matrix.language }})
-    if: >-
-      ${{
-        matrix.language != 'swift' ||
-        github.event_name == 'push' ||
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && inputs.include_swift)
-      }}
-    runs-on: ${{ matrix.runs_on }}
+    runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
 
     strategy:
@@ -67,20 +60,13 @@ jobs:
       matrix:
         include:
           - language: actions
-            runs_on: ubuntu-latest
             timeout_minutes: 10
             build_mode: none
           - language: python
-            runs_on: ubuntu-latest
             timeout_minutes: 10
             build_mode: none
           - language: java-kotlin
-            runs_on: ubuntu-latest
             timeout_minutes: 20
-            build_mode: manual
-          - language: swift
-            runs_on: macos-latest
-            timeout_minutes: 35
             build_mode: manual
 
     steps:
@@ -88,7 +74,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up Java
-        if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+        if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
@@ -118,8 +104,40 @@ jobs:
             --no-daemon \
             --console=plain
 
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  analyze-swift:
+    name: Analyze (swift)
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && inputs.include_swift)
+      }}
+    runs-on: macos-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Java
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: swift
+          build-mode: manual
+
       - name: Build Swift database
-        if: matrix.language == 'swift'
         shell: bash
         env:
           CONFIGURATION: Debug
@@ -144,4 +162,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:swift"


### PR DESCRIPTION
## Summary
- add an explicit CodeQL workflow with fast PR jobs for actions, python, and java-kotlin
- keep the expensive Swift scan off pull requests and run it only on main, schedule, or manual opt-in
- replace CodeQL autobuild for java-kotlin with a narrow manual Gradle compile that skips iOS/native work

## Verification
- `yamllint -c .yamllint.yml .github/workflows/codeql.yml`
- `./gradlew :meshlink:jvmJar :meshlink:androidJar :benchmarks:jvmJar :meshlink-reference:jvmJar :meshlink-reference:bundleAndroidMainAar :meshlink-reference:android:compileDebugKotlin :meshlink-proof:android:compileDebugKotlin --no-daemon --console=plain`
- `gh workflow run codeql.yml --ref fix/codeql-advanced-workflow -f include_swift=false`
- workflow dispatch run `26682008782` built the fast jobs and skipped Swift; upload failed because default CodeQL setup is still enabled (`CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`)

## Follow-up after merge
- disable GitHub default CodeQL setup so this advanced workflow becomes the only code scanning workflow