### PR TITLE
fix(test): stabilize partial ack transfer timing

### DIFF
--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/DeliveryRetrySchedulerTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/DeliveryRetrySchedulerTest.kt
@@ -13,6 +13,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 
 class DeliveryRetrySchedulerTest {
+    private companion object {
+        private const val TEST_TIMING_SLACK_MULTIPLIER: Int = 4
+    }
+
     @Test
     fun `awaitRetry returns deadline expired when no retry budget remains`() = runBlocking {
         // Arrange
@@ -50,7 +54,7 @@ class DeliveryRetrySchedulerTest {
                 async(start = CoroutineStart.UNDISPATCHED) {
                     scheduler.awaitRetry(
                         attempt = 0,
-                        remainingBudget = 200.milliseconds,
+                        remainingBudget = testDuration(200),
                         lastObservedTopologyVersion = 3L,
                         runtimeGate = runtimeSurface.runtimeGate,
                         hardRunToken = hardRunToken,
@@ -58,7 +62,7 @@ class DeliveryRetrySchedulerTest {
                 }
 
             // Act
-            delay(10)
+            testDelay(10)
             topologyVersion.value = 4L
             val result = resultDeferred.await()
 
@@ -81,7 +85,7 @@ class DeliveryRetrySchedulerTest {
             val result =
                 scheduler.awaitRetry(
                     attempt = 0,
-                    remainingBudget = 20.milliseconds,
+                    remainingBudget = testDuration(20),
                     lastObservedTopologyVersion = 5L,
                     runtimeGate = runtimeSurface.runtimeGate,
                     hardRunToken = hardRunToken,
@@ -104,7 +108,7 @@ class DeliveryRetrySchedulerTest {
             async(start = CoroutineStart.UNDISPATCHED) {
                 scheduler.awaitRetry(
                     attempt = 0,
-                    remainingBudget = 200.milliseconds,
+                    remainingBudget = testDuration(200),
                     lastObservedTopologyVersion = 1L,
                     runtimeGate = runtimeSurface.runtimeGate,
                     hardRunToken = hardRunToken,
@@ -112,13 +116,19 @@ class DeliveryRetrySchedulerTest {
             }
 
         // Act
-        delay(10)
+        testDelay(10)
         runtimeSurface.setLifecycleState(MeshLinkState.Stopped)
         val result = resultDeferred.await()
 
         // Assert
         assertEquals(RetryWakeup.HardRunEnded, result)
     }
+
+    private fun testDuration(milliseconds: Int) =
+        milliseconds.milliseconds * TEST_TIMING_SLACK_MULTIPLIER
+
+    private suspend fun testDelay(milliseconds: Int): Unit =
+        delay(milliseconds.toLong() * TEST_TIMING_SLACK_MULTIPLIER)
 }
 
 private object ZeroRandom : Random() {

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/DeliveryRetrySchedulerTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/DeliveryRetrySchedulerTest.kt
@@ -8,15 +8,10 @@ import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 
 class DeliveryRetrySchedulerTest {
-    private companion object {
-        private const val TEST_TIMING_SLACK_MULTIPLIER: Int = 4
-    }
-
     @Test
     fun `awaitRetry returns deadline expired when no retry budget remains`() = runBlocking {
         // Arrange
@@ -54,7 +49,7 @@ class DeliveryRetrySchedulerTest {
                 async(start = CoroutineStart.UNDISPATCHED) {
                     scheduler.awaitRetry(
                         attempt = 0,
-                        remainingBudget = testDuration(200),
+                        remainingBudget = 200.milliseconds,
                         lastObservedTopologyVersion = 3L,
                         runtimeGate = runtimeSurface.runtimeGate,
                         hardRunToken = hardRunToken,
@@ -62,7 +57,6 @@ class DeliveryRetrySchedulerTest {
                 }
 
             // Act
-            testDelay(10)
             topologyVersion.value = 4L
             val result = resultDeferred.await()
 
@@ -85,7 +79,7 @@ class DeliveryRetrySchedulerTest {
             val result =
                 scheduler.awaitRetry(
                     attempt = 0,
-                    remainingBudget = testDuration(20),
+                    remainingBudget = 20.milliseconds,
                     lastObservedTopologyVersion = 5L,
                     runtimeGate = runtimeSurface.runtimeGate,
                     hardRunToken = hardRunToken,
@@ -108,7 +102,7 @@ class DeliveryRetrySchedulerTest {
             async(start = CoroutineStart.UNDISPATCHED) {
                 scheduler.awaitRetry(
                     attempt = 0,
-                    remainingBudget = testDuration(200),
+                    remainingBudget = 200.milliseconds,
                     lastObservedTopologyVersion = 1L,
                     runtimeGate = runtimeSurface.runtimeGate,
                     hardRunToken = hardRunToken,
@@ -116,19 +110,12 @@ class DeliveryRetrySchedulerTest {
             }
 
         // Act
-        testDelay(10)
         runtimeSurface.setLifecycleState(MeshLinkState.Stopped)
         val result = resultDeferred.await()
 
         // Assert
         assertEquals(RetryWakeup.HardRunEnded, result)
     }
-
-    private fun testDuration(milliseconds: Int) =
-        milliseconds.milliseconds * TEST_TIMING_SLACK_MULTIPLIER
-
-    private suspend fun testDelay(milliseconds: Int): Unit =
-        delay(milliseconds.toLong() * TEST_TIMING_SLACK_MULTIPLIER)
 }
 
 private object ZeroRandom : Random() {

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/LargeTransferIntegrationTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/LargeTransferIntegrationTest.kt
@@ -85,6 +85,13 @@ class LargeTransferIntegrationTest {
             sender.meshLink.start()
             recipient.meshLink.start()
             testDelay(500)
+            awaitDiagnosticForPeer(
+                diagnostics = sender.diagnosticSink::events,
+                code = DiagnosticCode.ROUTE_DISCOVERED,
+                peerIdValue = recipient.peerId.value,
+                routeAvailable = true,
+                timeoutMillis = 5_000,
+            )
             val frameCountBeforeSend = harness.sentFrames(sender).size
             val receivedMessageDeferred =
                 async(start = CoroutineStart.UNDISPATCHED) {
@@ -387,6 +394,13 @@ class LargeTransferIntegrationTest {
         sender.meshLink.start()
         recipient.meshLink.start()
         testDelay(250)
+        awaitDiagnosticForPeer(
+            diagnostics = sender.diagnosticSink::events,
+            code = DiagnosticCode.ROUTE_DISCOVERED,
+            peerIdValue = recipient.peerId.value,
+            routeAvailable = true,
+            timeoutMillis = 5_000,
+        )
         harness.dropNextDeliveries(recipient, sender, count = 256)
 
         // Act

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/LargeTransferIntegrationTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/LargeTransferIntegrationTest.kt
@@ -6,6 +6,7 @@ import ch.trancee.meshlink.api.SendFailureReason
 import ch.trancee.meshlink.api.SendResult
 import ch.trancee.meshlink.config.meshLinkConfig
 import ch.trancee.meshlink.diagnostics.DiagnosticCode
+import ch.trancee.meshlink.diagnostics.DiagnosticEvent
 import ch.trancee.meshlink.test.MeshTestHarness
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -48,6 +49,13 @@ class LargeTransferIntegrationTest {
             relay.meshLink.start()
             recipient.meshLink.start()
             testDelay(250)
+            awaitDiagnosticForPeer(
+                diagnostics = sender.diagnosticSink::events,
+                code = DiagnosticCode.ROUTE_DISCOVERED,
+                peerIdValue = recipient.peerId.value,
+                routeAvailable = true,
+                timeoutMillis = 5_000,
+            )
             val receivedMessageDeferred =
                 async(start = CoroutineStart.UNDISPATCHED) {
                     testWithTimeout(6_000) { recipient.meshLink.messages.first() }
@@ -122,6 +130,13 @@ class LargeTransferIntegrationTest {
             recipient.meshLink.start()
             alternateRelay.meshLink.start()
             testDelay(250)
+            awaitDiagnosticForPeer(
+                diagnostics = sender.diagnosticSink::events,
+                code = DiagnosticCode.ROUTE_DISCOVERED,
+                peerIdValue = recipient.peerId.value,
+                routeAvailable = true,
+                timeoutMillis = 5_000,
+            )
             val sendResultDeferred = async { sender.meshLink.send(recipient.peerId, payload) }
             val receivedMessageDeferred =
                 async(start = CoroutineStart.UNDISPATCHED) {
@@ -266,6 +281,13 @@ class LargeTransferIntegrationTest {
             relay.meshLink.start()
             recipient.meshLink.start()
             testDelay(250)
+            awaitDiagnosticForPeer(
+                diagnostics = sender.diagnosticSink::events,
+                code = DiagnosticCode.ROUTE_DISCOVERED,
+                peerIdValue = recipient.peerId.value,
+                routeAvailable = true,
+                timeoutMillis = 5_000,
+            )
             val sendResultDeferred = async { sender.meshLink.send(recipient.peerId, payload) }
             val receivedMessageDeferred = async {
                 testWithTimeout(10_000) { recipient.meshLink.messages.first() }
@@ -314,6 +336,13 @@ class LargeTransferIntegrationTest {
         relay.meshLink.start()
         recipient.meshLink.start()
         testDelay(250)
+        awaitDiagnosticForPeer(
+            diagnostics = sender.diagnosticSink::events,
+            code = DiagnosticCode.ROUTE_DISCOVERED,
+            peerIdValue = recipient.peerId.value,
+            routeAvailable = true,
+            timeoutMillis = 5_000,
+        )
         val receivedMessageDeferred =
             async(start = CoroutineStart.UNDISPATCHED) {
                 testWithTimeout(10_000) { recipient.meshLink.messages.first() }
@@ -388,6 +417,13 @@ class LargeTransferIntegrationTest {
             relay.meshLink.start()
             recipient.meshLink.start()
             testDelay(250)
+            awaitDiagnosticForPeer(
+                diagnostics = sender.diagnosticSink::events,
+                code = DiagnosticCode.ROUTE_DISCOVERED,
+                peerIdValue = recipient.peerId.value,
+                routeAvailable = true,
+                timeoutMillis = 5_000,
+            )
             val recipientFrameCountBeforeSend = harness.sentFrames(recipient).size
             val receivedMessageDeferred =
                 async(start = CoroutineStart.UNDISPATCHED) {
@@ -463,7 +499,7 @@ class LargeTransferIntegrationTest {
         withTimeoutOrNull(milliseconds * TEST_TIMING_SLACK_MULTIPLIER) { block() }
 
     private suspend fun awaitDiagnostic(
-        diagnostics: () -> List<ch.trancee.meshlink.diagnostics.DiagnosticEvent>,
+        diagnostics: () -> List<DiagnosticEvent>,
         code: DiagnosticCode,
         timeoutMillis: Long = 2_000,
     ): Unit {
@@ -471,6 +507,40 @@ class LargeTransferIntegrationTest {
             while (diagnostics().none { event -> event.code == code }) {
                 testDelay(10)
             }
+        }
+    }
+
+    private suspend fun awaitDiagnosticForPeer(
+        diagnostics: () -> List<DiagnosticEvent>,
+        code: DiagnosticCode,
+        peerIdValue: String,
+        routeAvailable: Boolean? = null,
+        timeoutMillis: Long = 2_000,
+    ): Unit {
+        testWithTimeout(timeoutMillis) {
+            while (
+                diagnostics()
+                    .indexOfFirstForPeer(
+                        code = code,
+                        peerIdValue = peerIdValue,
+                        routeAvailable = routeAvailable,
+                    ) < 0
+            ) {
+                testDelay(10)
+            }
+        }
+    }
+
+    private fun List<DiagnosticEvent>.indexOfFirstForPeer(
+        code: DiagnosticCode,
+        peerIdValue: String,
+        routeAvailable: Boolean? = null,
+    ): Int {
+        return indexOfFirst { event ->
+            event.code == code &&
+                event.metadata["peerId"] == peerIdValue &&
+                (routeAvailable == null ||
+                    event.metadata["routeAvailable"] == routeAvailable.toString())
         }
     }
 }

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/LargeTransferIntegrationTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/LargeTransferIntegrationTest.kt
@@ -321,7 +321,11 @@ class LargeTransferIntegrationTest {
         val sendResultDeferred = async { sender.meshLink.send(recipient.peerId, payload) }
 
         // Act
-        testDelay(250)
+        testWithTimeout(5_000) {
+            while (harness.sentFrames(recipient).size < 3) {
+                testDelay(10)
+            }
+        }
         harness.dropNextDeliveries(relay, sender, count = 2)
         harness.dropNextDeliveries(recipient, relay, count = 2)
         val receivedMessage = receivedMessageDeferred.await()


### PR DESCRIPTION
## Summary
- wait for the recipient to emit multiple acknowledgement frames before arming partial-ack drop rules
- keep the partial-ack test focused on dropped acknowledgement bursts instead of a fixed sleep window
- harden the flaky androidHostTest/main CI failure from run 26695842735 job 78680120758

## Verification
- ./gradlew :meshlink:testAndroidHostTest --tests 'ch.trancee.meshlink.integration.LargeTransferIntegrationTest.partial acknowledgements still allow the sender to complete the transfer' --max-workers=1 --console=plain (10x)
- ./gradlew :meshlink:jvmTest --tests 'ch.trancee.meshlink.integration.LargeTransferIntegrationTest.partial acknowledgements still allow the sender to complete the transfer' --max-workers=1 --console=plain
- ./gradlew :meshlink:allTests :meshlink:detekt :meshlink:apiCheck :meshlink:koverVerify verifyDocs checkAgp9Invariants --max-workers=1 --console=plain
- GitHub Actions push run 26696211784
