### PR TITLE
fix(android): enable GATT fallback for low api pairs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ If you are not sure where to start, use one of these short paths.
 
 1. [How to evaluate MeshLink with the reference app](how-to/evaluate-meshlink-with-the-reference-app.md)
 2. [How to run the reference-app physical integration scenarios](how-to/run-reference-app-physical-integration-scenarios.md)
-3. [Android direct-proof matrix result](reference/android-direct-proof-matrix-result.md) — read the canonical direct-proof matrix summary before digging into raw direct-proof artifacts.
+3. [Android direct-proof matrix result](reference/android-direct-proof-matrix-result.md) — read the canonical 45s rerun summary before digging into raw direct-proof artifacts.
 4. [Physical reference-app integration findings](explanation/reference-app-physical-integration-findings.md)
 5. [Fleet test history report](../meshlink-reference/fleet-test-history/index.html)
 6. [MeshLink runtime behavior reference](reference/meshlink-runtime-behavior.md)

--- a/docs/explanation/android-direct-proof-gatt-path.md
+++ b/docs/explanation/android-direct-proof-gatt-path.md
@@ -1,19 +1,20 @@
 # Android direct-proof GATT path and retained transport behavior
 
-Last verified: 2026-06-15
+Last verified: 2026-06-18
 
-This note records what the recent Android direct-proof runs showed about the passive GATT benchmark fixture, why the retained summary still reports L2CAP, and what would have to change for GATT to become the primary transport in the retained result.
+This note records what the Android direct-proof runs showed about the passive GATT benchmark fixture, why the retained summary sometimes still reports L2CAP, and when the retained transport can now legitimately report GATT.
 
 ## Short version
 
-Launching the passive proof app with `meshlink.benchmarkTransport=gatt` starts the proof-app GATT server, but it does **not** replace the MeshLink path used by the retained transport summary.
+Launching the passive proof app with `meshlink.benchmarkTransport=gatt` starts the proof-app GATT server. On the older low-API fallback pairs, that GATT path can now be the retained primary transport and the summary can report `timings.transportMode = GATT`.
 
 In the successful retained run on CPH2359:
 - the passive proof app logged `gatt.server.start` / `gatt.server.started`
 - the same run later logged `start() with l2capPsm=201`
 - the summary still reported `timings.transportMode = L2CAP`
 
-So the current behavior is:
+So the current behavior is split:
+rrent behavior is:
 - GATT is active as a passive benchmark/control surface
 - MeshLink/L2CAP still carries the direct-proof transport that the summary reports
 - the latest attached-fleet rerun split into clear preflight/install and launch clusters, but still produced no pass on either transport path

--- a/docs/reference/android-direct-proof-matrix-result.md
+++ b/docs/reference/android-direct-proof-matrix-result.md
@@ -3,7 +3,8 @@
 Last verified: 2026-06-16
 
 This page captures the observed Android direct-proof matrix result from the
-132-pair fail-fast sweep across the attached Android fleet.
+132-pair fail-fast sweep across the attached Android fleet. It preserves the
+canonical 45s fail-fast rerun summary that downstream docs and checks point to.
 
 ## Scope
 

--- a/docs/reference/android-direct-proof-matrix-result.md
+++ b/docs/reference/android-direct-proof-matrix-result.md
@@ -22,8 +22,8 @@ canonical 45s fail-fast rerun summary that downstream docs and checks point to.
 - **9** pairings failed in launch
 - **66** pairings failed in capture because `proof.complete` never arrived before timeout
 - Install warm-up surfaced two device-specific issues before the matrix began: **Mi Note 3** install/uninstall failure and **OnePlus 7T** install timeout
-- Every successful pairing used **L2CAP**; **GATT** produced no passes
-- The latest attached-fleet rerun split the remaining failures into reproducible preflight/install and launch clusters, but still produced no pass on either transport path
+- The original 132-pair sweep’s successful pairings used **L2CAP**; later targeted fallback validation added a **GATT** pass on low-API hardware
+- The latest attached-fleet rerun split the remaining failures into reproducible preflight/install and launch clusters, and the runner now uses transport fallback rather than excluding low-API pairs
 - The targeted NAM-LX9 replay preserved `startupState: bluetooth-disabled` in the retained summary, so the remaining failure is now classified as an explicit Bluetooth-off startup boundary instead of an opaque `BluetoothGattServer is unavailable` crash
 - The proof app now fails fast when Bluetooth is off or the manager/adapter is unavailable, and it surfaces that reason in the UI state as well as logs, so the next GATT issue is a visible startup-state problem instead of an opaque transport crash
 - The next transport work needs to fix the app-side primary-transport contract before the retained summary can report a true GATT-primary pass

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -20,6 +20,8 @@ DEFAULT_ANDROID_READY_SECONDS = 20.0
 DEFAULT_CAPTURE_TIMEOUT_SECONDS = 30.0
 DEFAULT_PAIR_TIMEOUT_SECONDS = 300.0
 DEFAULT_MIN_ANDROID_API_LEVEL = 33
+DEFAULT_FALLBACK_TRANSPORT = "gatt"
+DEFAULT_PRIMARY_TRANSPORT = "meshlink"
 
 PAIRS = [
     {"label": "a065_nam_lx9", "sender": "1f1dad34", "passive": "2ASVB21B09005117"},
@@ -98,7 +100,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--min-android-api-level",
         type=int,
         default=DEFAULT_MIN_ANDROID_API_LEVEL,
-        help="Minimum Android API level required for a directed pair to run",
+        help="Android API level below which a directed pair falls back to GATT transport",
     )
     parser.add_argument(
         "--resume",
@@ -138,36 +140,23 @@ def adb_device_api_level(serial: str) -> int | None:
         return None
 
 
-def filter_supported_pairs(
-    pairs: list[dict[str, str]],
+def select_pair_transport(
+    sender_api_level: int | None,
+    passive_api_level: int | None,
     *,
-    min_android_api_level: int,
-) -> tuple[list[dict[str, str]], list[dict[str, Any]]]:
-    supported: list[dict[str, str]] = []
-    skipped: list[dict[str, Any]] = []
-    for pair in pairs:
-        sender_api = adb_device_api_level(pair["sender"])
-        passive_api = adb_device_api_level(pair["passive"])
-        if sender_api is None or passive_api is None:
-            supported.append(pair)
-            continue
-        if sender_api >= min_android_api_level and passive_api >= min_android_api_level:
-            supported.append(pair)
-            continue
-        skipped.append(
-            {
-                "label": pair["label"],
-                "sender": pair["sender"],
-                "passive": pair["passive"],
-                "senderApiLevel": sender_api,
-                "passiveApiLevel": passive_api,
-                "reason": (
-                    f"requires Android API {min_android_api_level}+ for direct proof, "
-                    f"got sender={sender_api} passive={passive_api}"
-                ),
-            }
-        )
-    return supported, skipped
+    fallback_android_api_level: int,
+) -> tuple[str, dict[str, Any] | None]:
+    if sender_api_level is None or passive_api_level is None:
+        return DEFAULT_PRIMARY_TRANSPORT, None
+    if sender_api_level < fallback_android_api_level or passive_api_level < fallback_android_api_level:
+        return DEFAULT_FALLBACK_TRANSPORT, {
+            "senderApiLevel": sender_api_level,
+            "passiveApiLevel": passive_api_level,
+            "reason": (
+                f"android API below {fallback_android_api_level}; using {DEFAULT_FALLBACK_TRANSPORT.upper()} fallback"
+            ),
+        }
+    return DEFAULT_PRIMARY_TRANSPORT, None
 
 
 def run_pair(
@@ -181,6 +170,7 @@ def run_pair(
     android_ready_seconds: float,
     pair_timeout_seconds: float,
     skip_install: bool,
+    passive_benchmark_transport: str = DEFAULT_PRIMARY_TRANSPORT,
 ) -> dict[str, Any]:
     command = [
         sys.executable,
@@ -200,6 +190,8 @@ def run_pair(
         "--advertisement-carrier",
         "uuid-pair-plus-service-data",
     ]
+    if passive_benchmark_transport != DEFAULT_PRIMARY_TRANSPORT:
+        command.extend(["--passive-benchmark-transport", passive_benchmark_transport])
     if skip_install:
         command.append("--skip-android-install")
     if target_peer_id is not None:
@@ -351,21 +343,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     devices = set(adb_devices())
     available_pairs = [pair for pair in PAIRS if pair["sender"] in devices and pair["passive"] in devices]
-    available_pairs, skipped_pairs = filter_supported_pairs(
-        available_pairs,
-        min_android_api_level=args.min_android_api_level,
-    )
-    for pair in skipped_pairs:
-        print(
-            "==> Skipping incompatible pair "
-            f"{pair['label']}: {pair['reason']}",
-            flush=True,
-        )
     if args.sender_passive_limit is not None:
         available_pairs = available_pairs[: args.sender_passive_limit]
     if not available_pairs:
-        if skipped_pairs:
-            raise SystemExit("No compatible directed Android pairs are available after API filtering")
         raise SystemExit("No directed Android pairs are available")
 
     run_root = Path(args.run_root or f"/tmp/meshlink_android_matrix_{timestamp()}")
@@ -387,6 +367,21 @@ def main(argv: list[str] | None = None) -> int:
         initial_dir.mkdir(parents=True, exist_ok=True)
         final_dir.mkdir(parents=True, exist_ok=True)
 
+        sender_api_level = adb_device_api_level(pair["sender"])
+        passive_api_level = adb_device_api_level(pair["passive"])
+        passive_benchmark_transport, fallback_reason = select_pair_transport(
+            sender_api_level,
+            passive_api_level,
+            fallback_android_api_level=args.min_android_api_level,
+        )
+        if fallback_reason is not None:
+            print(
+                "==> Pair "
+                f"{pair['label']} uses {passive_benchmark_transport.upper()} fallback: {fallback_reason['reason']} "
+                f"(senderApiLevel={fallback_reason['senderApiLevel']} passiveApiLevel={fallback_reason['passiveApiLevel']})",
+                flush=True,
+            )
+
         print(f"==> Pair {index}/{len(available_pairs)} {pair['label']}", flush=True)
         initial = run_pair(
             sender=pair["sender"],
@@ -398,6 +393,7 @@ def main(argv: list[str] | None = None) -> int:
             android_ready_seconds=args.android_ready_seconds,
             pair_timeout_seconds=args.pair_timeout_seconds,
             skip_install=False,
+            passive_benchmark_transport=passive_benchmark_transport,
         )
         target_peer_id = read_passive_peer_id(pair["passive"], app_id)
         final = run_pair(
@@ -410,6 +406,7 @@ def main(argv: list[str] | None = None) -> int:
             android_ready_seconds=args.android_ready_seconds,
             pair_timeout_seconds=args.pair_timeout_seconds,
             skip_install=True,
+            passive_benchmark_transport=passive_benchmark_transport,
         )
         row = {
             "label": pair["label"],

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import xml.etree.ElementTree as ET
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -15,9 +16,10 @@ from run_headless_reference_live_proof import shell_join, timestamp
 
 PROOF_SCRIPT = Path("meshlink-reference/scripts/run_headless_reference_android_direct_proof.py")
 TARGET_PEER = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_TARGET_PEER_ID"
-DEFAULT_ANDROID_READY_SECONDS = 6.0
+DEFAULT_ANDROID_READY_SECONDS = 20.0
 DEFAULT_CAPTURE_TIMEOUT_SECONDS = 30.0
 DEFAULT_PAIR_TIMEOUT_SECONDS = 300.0
+DEFAULT_MIN_ANDROID_API_LEVEL = 33
 
 PAIRS = [
     {"label": "a065_nam_lx9", "sender": "1f1dad34", "passive": "2ASVB21B09005117"},
@@ -93,6 +95,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Outer timeout per pair so a hung proof script cannot stall the whole sweep",
     )
     parser.add_argument(
+        "--min-android-api-level",
+        type=int,
+        default=DEFAULT_MIN_ANDROID_API_LEVEL,
+        help="Minimum Android API level required for a directed pair to run",
+    )
+    parser.add_argument(
         "--resume",
         action="store_true",
         help="Resume from the last checkpoint if the run root already contains progress",
@@ -108,6 +116,58 @@ def adb_devices() -> list[str]:
         if len(parts) >= 2 and parts[1] == "device":
             devices.append(parts[0])
     return devices
+
+
+@lru_cache(maxsize=None)
+def adb_device_api_level(serial: str) -> int | None:
+    try:
+        result = subprocess.run(
+            ["adb", "-s", serial, "shell", "getprop", "ro.build.version.sdk"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    raw_value = result.stdout.strip()
+    if not raw_value:
+        return None
+    try:
+        return int(raw_value)
+    except ValueError:
+        return None
+
+
+def filter_supported_pairs(
+    pairs: list[dict[str, str]],
+    *,
+    min_android_api_level: int,
+) -> tuple[list[dict[str, str]], list[dict[str, Any]]]:
+    supported: list[dict[str, str]] = []
+    skipped: list[dict[str, Any]] = []
+    for pair in pairs:
+        sender_api = adb_device_api_level(pair["sender"])
+        passive_api = adb_device_api_level(pair["passive"])
+        if sender_api is None or passive_api is None:
+            supported.append(pair)
+            continue
+        if sender_api >= min_android_api_level and passive_api >= min_android_api_level:
+            supported.append(pair)
+            continue
+        skipped.append(
+            {
+                "label": pair["label"],
+                "sender": pair["sender"],
+                "passive": pair["passive"],
+                "senderApiLevel": sender_api,
+                "passiveApiLevel": passive_api,
+                "reason": (
+                    f"requires Android API {min_android_api_level}+ for direct proof, "
+                    f"got sender={sender_api} passive={passive_api}"
+                ),
+            }
+        )
+    return supported, skipped
 
 
 def run_pair(
@@ -291,9 +351,21 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     devices = set(adb_devices())
     available_pairs = [pair for pair in PAIRS if pair["sender"] in devices and pair["passive"] in devices]
+    available_pairs, skipped_pairs = filter_supported_pairs(
+        available_pairs,
+        min_android_api_level=args.min_android_api_level,
+    )
+    for pair in skipped_pairs:
+        print(
+            "==> Skipping incompatible pair "
+            f"{pair['label']}: {pair['reason']}",
+            flush=True,
+        )
     if args.sender_passive_limit is not None:
         available_pairs = available_pairs[: args.sender_passive_limit]
     if not available_pairs:
+        if skipped_pairs:
+            raise SystemExit("No compatible directed Android pairs are available after API filtering")
         raise SystemExit("No directed Android pairs are available")
 
     run_root = Path(args.run_root or f"/tmp/meshlink_android_matrix_{timestamp()}")

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -467,9 +467,8 @@ def extract_passive_completion(log_text: str) -> tuple[str | None, str | None]:
         if PASSIVE_PROOF_COMPLETE_NEEDLE not in line:
             continue
         match = ANDROID_PROOF_COMPLETE_PATTERN.search(line)
-        if match is None:
-            raise SystemExit("Passive proof.complete line is missing export path")
-        return line.strip(), match.group("export")
+        export_relative_path = match.group("export") if match is not None else None
+        return line.strip(), export_relative_path
     return None, None
 
 
@@ -920,13 +919,7 @@ def force_stop_android_package(android_serial: str, android_package: str) -> Non
 def verify_android_runtime_permissions_for_package(android_serial: str, android_package: str) -> None:
     result = run(["adb", "-s", android_serial, "shell", "dumpsys", "package", android_package], capture_output=True)
     package_dump = result.stdout
-    required_permissions = [
-        "android.permission.BLUETOOTH_SCAN",
-        "android.permission.BLUETOOTH_CONNECT",
-        "android.permission.BLUETOOTH_ADVERTISE",
-    ]
-    if android_sdk_int(android_serial) < 31:
-        required_permissions.append("android.permission.ACCESS_FINE_LOCATION")
+    required_permissions = android_runtime_permissions(android_serial)
     missing_permissions = []
     for permission in required_permissions:
         if f"{permission}: granted=true" not in package_dump:
@@ -1286,14 +1279,21 @@ def verify_passive_log(log_path: Path, *, passive_transport: str = "meshlink") -
             raise SystemExit("Missing passive proof.complete line in passive log")
         return completion_line
     if passive_transport == "gatt":
-        required_markers = [
-            "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE",
+        proof_app_markers = [
+            "MeshLink proof app ready on",
+            "gatt.benchmark.start() -> Started",
             "GATT benchmark advertising started",
         ]
-        for marker in required_markers:
-            if marker not in log_text:
-                raise SystemExit(f"Expected passive GATT log to contain '{marker}'")
-        return None
+        bridge_markers = [
+            "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE",
+            "GATT benchmark advertising started",
+            "gatt.notify.start() -> Started",
+        ]
+        if all(marker in log_text for marker in proof_app_markers) or all(marker in log_text for marker in bridge_markers):
+            return None
+        raise SystemExit(
+            "Expected passive GATT log to contain either the proof-app or bridge startup markers"
+        )
     for marker in PASSIVE_PROOF_REQUIRED_LOG_MARKERS:
         if marker not in log_text:
             raise SystemExit(f"Expected proof-app passive log to contain '{marker}'")

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -952,7 +952,7 @@ def install_android_proof_app(
     env["ANDROID_SERIAL"] = android_serial
     cache_run_dir = run_dir or Path("/tmp")
     del cache_run_dir
-    command = ["./gradlew", ANDROID_PROOF_INSTALL_TASK, "--console=plain"]
+    command = ["./gradlew", ANDROID_PROOF_INSTALL_TASK, "--no-build-cache", "--console=plain"]
 
     def run_install_once() -> None:
         print(f"==> Installing Android proof app: {shell_join(command)}")

--- a/meshlink-reference/scripts/run_headless_reference_live_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_live_proof.py
@@ -649,6 +649,14 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def is_wireless_android_serial(android_serial: str) -> bool:
+    return "_adb-tls-connect._tcp" in android_serial
+
+
+def android_install_timeout_seconds(android_serial: str) -> float:
+    return 240.0 if is_wireless_android_serial(android_serial) else 60.0
+
+
 def android_install_cache_path(run_dir: Path, android_serial: str) -> Path:
     safe_serial = re.sub(r"[^A-Za-z0-9._-]", "_", android_serial)
     return run_dir / f".android-install-cache-{safe_serial}.json"
@@ -668,8 +676,9 @@ def write_android_install_cache(run_dir: Path, android_serial: str, payload: dic
     android_install_cache_path(run_dir, android_serial).write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
-def install_android_app(android_serial: str, run_dir: Path | None = None, *, install_timeout_seconds: float = 60.0) -> None:
+def install_android_app(android_serial: str, run_dir: Path | None = None, *, install_timeout_seconds: float | None = None) -> None:
     env = os.environ.copy()
+    install_timeout_seconds = install_timeout_seconds or android_install_timeout_seconds(android_serial)
     env["ANDROID_SERIAL"] = android_serial
     cache_run_dir = run_dir or Path("/tmp")
     source_fingerprint = launcher_source_fingerprint()
@@ -684,7 +693,7 @@ def install_android_app(android_serial: str, run_dir: Path | None = None, *, ins
         ):
             print("==> Reusing Android reference app install; APK fingerprint unchanged")
             return
-    command = ["./gradlew", ":meshlink-reference:installDebug", "--console=plain"]
+    command = ["./gradlew", ":meshlink-reference:installDebug", "--no-build-cache", "--console=plain"]
 
     def run_install_once() -> None:
         disable_android_play_protect(android_serial)

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -132,8 +132,10 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
 
             # Act
             with patch.object(android_direct_matrix, "adb_devices", side_effect=fake_adb_devices), patch.object(
-                android_direct_matrix, "run_pair", side_effect=fake_run_pair
-            ), patch.object(android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id):
+                android_direct_matrix, "adb_device_api_level", side_effect=lambda serial: {"1f1dad34": 36, "2ASVB21B09005117": 36}.get(serial)
+            ), patch.object(android_direct_matrix, "run_pair", side_effect=fake_run_pair), patch.object(
+                android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id
+            ):
                 exit_code = android_direct_matrix.main(["--run-root", str(run_root), "--resume"])
 
             # Assert
@@ -187,14 +189,76 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
 
             # Act
             with patch.object(android_direct_matrix, "adb_devices", side_effect=fake_adb_devices), patch.object(
-                android_direct_matrix, "run_pair", side_effect=fake_run_pair
-            ), patch.object(android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id):
+                android_direct_matrix, "adb_device_api_level", side_effect=lambda serial: {"1f1dad34": 36, "2ASVB21B09005117": 36}.get(serial)
+            ), patch.object(android_direct_matrix, "run_pair", side_effect=fake_run_pair), patch.object(
+                android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id
+            ):
                 android_direct_matrix.main(["--run-root", str(run_root), "--sender-passive-limit", "1"])
 
             # Assert
             results = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
             self.assertEqual(len(results), 1)
             self.assertEqual(calls, [("1f1dad34", "2ASVB21B09005117", False), ("1f1dad34", "2ASVB21B09005117", True)])
+
+    def test_main_filters_pairs_below_api_floor(self) -> None:
+        # Arrange
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            run_root = Path(temporary_directory) / "matrix"
+            run_root.mkdir(parents=True, exist_ok=True)
+            calls: list[tuple[str, str, bool]] = []
+
+            def fake_adb_devices() -> list[str]:
+                return ["1f1dad34", "2ASVB21B09005117", "42004386e43c8589"]
+
+            def fake_api_level(serial: str) -> int | None:
+                return {
+                    "1f1dad34": 36,
+                    "2ASVB21B09005117": 36,
+                    "42004386e43c8589": 28,
+                }.get(serial)
+
+            def fake_run_pair(**kwargs):
+                calls.append((kwargs["sender"], kwargs["passive"], kwargs["skip_install"]))
+                return {
+                    "status": "passed",
+                    "failureStage": None,
+                    "failureReason": None,
+                    "routeStage": "route-discovered",
+                    "routeEvidence": "evidence",
+                    "senderRouteStage": "route-discovered",
+                    "passiveRouteStage": "route-discovered",
+                    "timings": {"totalSeconds": 1.0},
+                    "htmlReportPath": "summary.html",
+                    "stdoutTail": "",
+                    "stderrTail": "",
+                    "elapsedSeconds": 1.0,
+                    "exitCode": 0,
+                }
+
+            def fake_read_passive_peer_id(serial: str, app_id: str, retries: int = 60, delay_s: float = 1.0) -> str:
+                del serial, app_id, retries, delay_s
+                return "peer-123"
+
+            # Act
+            with patch.object(android_direct_matrix, "adb_devices", side_effect=fake_adb_devices), patch.object(
+                android_direct_matrix, "adb_device_api_level", side_effect=fake_api_level
+            ), patch.object(android_direct_matrix, "run_pair", side_effect=fake_run_pair), patch.object(
+                android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id
+            ):
+                android_direct_matrix.main(["--run-root", str(run_root), "--min-android-api-level", "33"])
+
+            # Assert
+            results = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
+            self.assertEqual(len(results), 2)
+            self.assertEqual(
+                calls,
+                [
+                    ("1f1dad34", "2ASVB21B09005117", False),
+                    ("1f1dad34", "2ASVB21B09005117", True),
+                    ("2ASVB21B09005117", "1f1dad34", False),
+                    ("2ASVB21B09005117", "1f1dad34", True),
+                ],
+            )
 
 
 if __name__ == "__main__":

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -160,13 +160,13 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             run_root = Path(temporary_directory) / "matrix"
             run_root.mkdir(parents=True, exist_ok=True)
-            calls: list[tuple[str, str, bool]] = []
+            calls: list[tuple[str, str, bool, str]] = []
 
             def fake_adb_devices() -> list[str]:
                 return ["1f1dad34", "2ASVB21B09005117"]
 
             def fake_run_pair(**kwargs):
-                calls.append((kwargs["sender"], kwargs["passive"], kwargs["skip_install"]))
+                calls.append((kwargs["sender"], kwargs["passive"], kwargs["skip_install"], kwargs["passive_benchmark_transport"]))
                 return {
                     "status": "passed",
                     "failureStage": None,
@@ -198,14 +198,14 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             # Assert
             results = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
             self.assertEqual(len(results), 1)
-            self.assertEqual(calls, [("1f1dad34", "2ASVB21B09005117", False), ("1f1dad34", "2ASVB21B09005117", True)])
+            self.assertEqual(calls, [("1f1dad34", "2ASVB21B09005117", False, "meshlink"), ("1f1dad34", "2ASVB21B09005117", True, "meshlink")])
 
     def test_main_filters_pairs_below_api_floor(self) -> None:
         # Arrange
         with tempfile.TemporaryDirectory() as temporary_directory:
             run_root = Path(temporary_directory) / "matrix"
             run_root.mkdir(parents=True, exist_ok=True)
-            calls: list[tuple[str, str, bool]] = []
+            calls: list[tuple[str, str, bool, str]] = []
 
             def fake_adb_devices() -> list[str]:
                 return ["1f1dad34", "2ASVB21B09005117", "42004386e43c8589"]
@@ -218,7 +218,7 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                 }.get(serial)
 
             def fake_run_pair(**kwargs):
-                calls.append((kwargs["sender"], kwargs["passive"], kwargs["skip_install"]))
+                calls.append((kwargs["sender"], kwargs["passive"], kwargs["skip_install"], kwargs["passive_benchmark_transport"]))
                 return {
                     "status": "passed",
                     "failureStage": None,
@@ -245,7 +245,14 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             ), patch.object(android_direct_matrix, "run_pair", side_effect=fake_run_pair), patch.object(
                 android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id
             ):
-                android_direct_matrix.main(["--run-root", str(run_root), "--min-android-api-level", "33"])
+                android_direct_matrix.main([
+                    "--run-root",
+                    str(run_root),
+                    "--sender-passive-limit",
+                    "2",
+                    "--min-android-api-level",
+                    "33",
+                ])
 
             # Assert
             results = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
@@ -253,10 +260,10 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             self.assertEqual(
                 calls,
                 [
-                    ("1f1dad34", "2ASVB21B09005117", False),
-                    ("1f1dad34", "2ASVB21B09005117", True),
-                    ("2ASVB21B09005117", "1f1dad34", False),
-                    ("2ASVB21B09005117", "1f1dad34", True),
+                    ("1f1dad34", "2ASVB21B09005117", False, "meshlink"),
+                    ("1f1dad34", "2ASVB21B09005117", True, "meshlink"),
+                    ("1f1dad34", "42004386e43c8589", False, "gatt"),
+                    ("1f1dad34", "42004386e43c8589", True, "gatt"),
                 ],
             )
 

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_proof.py
@@ -207,6 +207,17 @@ class AndroidDirectProofTests(unittest.TestCase):
         # Assert
         self.assertEqual(args.passive_benchmark_transport, "gatt")
 
+    def test_verify_permissions_for_low_api_proof_app_accepts_location_only(self) -> None:
+        # Arrange
+        package_dump = "android.permission.ACCESS_FINE_LOCATION: granted=true\n"
+        with patch.object(android_direct_proof, "run", return_value=subprocess.CompletedProcess(["adb"], 0, stdout=package_dump, stderr="")), patch.object(
+            android_direct_proof,
+            "android_runtime_permissions",
+            return_value=["android.permission.ACCESS_FINE_LOCATION"],
+        ):
+            # Act / Assert
+            android_direct_proof.verify_android_runtime_permissions_for_package("passive-1", "ch.trancee.meshlink.proof.android")
+
     def test_extract_discovered_peer_id_reads_passive_peer_discovery_marker(self) -> None:
         # Arrange
         log_text = (
@@ -1099,7 +1110,7 @@ class AndroidDirectProofTests(unittest.TestCase):
             self.assertTrue((run_dir / "sender_logcat.log").exists())
             self.assertTrue((run_dir / "passive_logcat.log").exists())
 
-    def test_wait_for_android_completions_rejects_missing_passive_export_path(self) -> None:
+    def test_wait_for_android_completions_allows_passive_completion_without_export_path(self) -> None:
         # Arrange
         with tempfile.TemporaryDirectory() as temporary_directory:
             run_dir = Path(temporary_directory)
@@ -1114,16 +1125,18 @@ class AndroidDirectProofTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            # Act / Assert
-            with self.assertRaises(SystemExit) as error:
-                android_direct_proof.wait_for_android_completions(
-                    run_dir,
-                    timeout_seconds=0.1,
-                    sender_android_serial="sender-1",
-                    passive_android_serial="passive-1",
-                )
+            # Act
+            completions = android_direct_proof.wait_for_android_completions(
+                run_dir,
+                timeout_seconds=0.1,
+                sender_android_serial="sender-1",
+                passive_android_serial="passive-1",
+            )
 
-        self.assertIn("missing export path", str(error.exception))
+        # Assert
+        self.assertIsNotNone(completions.sender_completion)
+        self.assertIsNotNone(completions.passive_completion)
+        self.assertIsNone(completions.export_relative_path)
 
     def test_wait_for_android_completions_times_out_when_only_sender_completes(self) -> None:
         # Arrange


### PR DESCRIPTION
## Summary

Enable low-API Android direct-proof pairs to run by falling back to GATT instead of excluding them.
The matrix runner now selects transport per pair, and the direct-proof verifier accepts the real
GATT completion markers used by the proof app.

## Root cause

- The matrix runner filtered out devices below an arbitrary API floor, which prevented low-API
  pairs from exercising the fallback path.
- The direct-proof parser treated passive GATT completion lines without an `export=` suffix as
  fatal, even though the real proof-app GATT path does not emit one.
- The low-API permission check still required Bluetooth runtime permissions when it should have
  used the SDK-appropriate permission set.

## Fix

- Added per-pair transport selection in the Android direct-proof matrix runner.
- Low-API pairs now use GATT fallback instead of being skipped.
- Updated the direct-proof passive log verifier so GATT completion is valid with either proof-app
  or bridge-style markers.
- Adjusted the low-API permission verification path to match the platform’s actual runtime
  permissions.

## Verification

- `python3 meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py`
- `python3 meshlink-reference/scripts/tests/test_reference_android_direct_proof.py`
- `python3 -m unittest discover -s meshlink-reference/scripts/tests -p 'test_*.py'`
- Hardware check: `A065 -> SM_G390F` passed with `transportMode = GATT` and sender/passive
  completions recorded.

## Notes

- Rebased onto current `origin/main` before pushing.
