### PR TITLE
docs(android): track fleet sweep reports under reports

### DIFF
--- a/.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/REPORTS.md
+++ b/.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/REPORTS.md
@@ -1,0 +1,67 @@
+# Fleet matrix reports
+
+This workflow keeps the Android fleet sweep reports inside the repository so they can be reviewed, diffed, and committed alongside the code that produced them.
+
+## Default report location
+
+When `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py` runs without `--run-root`, it writes into:
+
+- `.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/`
+
+That directory becomes the canonical report bundle for the sweep.
+
+## Sample committed bundle layout
+
+The example layout below is committed in the repository as the workflow report bundle sample.
+It shows the shape the generated run directory should follow.
+
+```text
+.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/
+├── fleet.json
+├── fleet.md
+├── matrix-results.json
+├── matrix-report.md
+├── 01_a065_nam_lx9_report.md
+├── 01_a065_nam_lx9_initial/
+└── 01_a065_nam_lx9_final/
+```
+
+## Report bundle contents
+
+Each run produces:
+
+- `fleet.json` — the enumerated device inventory before the first pair starts
+- `fleet.md` — human-readable fleet inventory and directed pair list
+- `matrix-results.json` — structured per-pair summary data
+- `matrix-report.md` — end-of-run summary with pass/fail buckets, setup notes, and follow-up pointers
+- `NN_pairlabel_report.md` — one Markdown report per pair, including:
+  - setup details
+  - transport selection
+  - quirks and failure notes
+  - Mermaid sequence diagram
+  - artifact references
+  - nested timing JSON
+- `NN_pairlabel_initial/` and `NN_pairlabel_final/` — raw proof-run directories
+
+## Raw evidence referenced by the per-pair report
+
+The per-pair report points to the underlying proof artifacts so failures can be debugged without rerunning the sweep:
+
+- `summary.json`
+- `summary.html`
+- `sender_logcat.log`
+- `passive_logcat.log`
+- `sender_start.txt`
+- `passive_start.txt`
+- `android_history.json`
+- `android_export.json`
+
+## Review expectation
+
+The pair report should be sufficient to answer:
+
+- which devices were in scope
+- which transport path was used
+- how far the run got before it failed
+- which raw logs and evidence files should be inspected next
+- what fix should be planned from the evidence

--- a/.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/REPORTS.md
+++ b/.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/REPORTS.md
@@ -6,7 +6,7 @@ This workflow keeps the Android fleet sweep reports inside the repository so the
 
 When `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py` runs without `--run-root`, it writes into:
 
-- `.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/`
+- `reports/android-direct-proof-fleet/runs/<timestamp>/`
 
 That directory becomes the canonical report bundle for the sweep.
 
@@ -16,7 +16,7 @@ The example layout below is committed in the repository as the workflow report b
 It shows the shape the generated run directory should follow.
 
 ```text
-.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/
+reports/android-direct-proof-fleet/runs/<timestamp>/
 ├── fleet.json
 ├── fleet.md
 ├── matrix-results.json

--- a/.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/TRIAGE.md
+++ b/.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/TRIAGE.md
@@ -1,0 +1,73 @@
+# Triage: Android fleet matrix run
+
+## Expected behavior
+
+For the first run, the Android fleet sweep should:
+
+- enumerate the available devices before any pair starts so the run records the exact fleet in scope
+- iterate through all available directed device pairs
+- stop immediately on the first pair that fails
+- write a separate artifact for each pair using a Mermaid sequence diagram
+- include step timing, transport choice, and device quirks in the per-pair artifact
+- finish with a summary of results, issues, and next steps
+
+## Actual behavior
+
+The current matrix runner:
+
+- enumerates directed Android pairs in `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py`
+- writes aggregate artifacts only: `progress.json`, `matrix-results.json`, `state.json`, and `matrix-report.md`
+- stores per-pair run output under each pair's `*_initial` / `*_final` directories, but does not emit a dedicated Mermaid sequence-diagram file per pair
+- does not fail fast; the loop continues after a failed pair because there is no stop-on-first-failure branch in the main loop
+
+## Root cause
+
+The matrix runner is missing the orchestration and artifact layer needed by the requested workflow.
+
+Concretely:
+
+1. `run_headless_reference_android_direct_matrix.py` only records aggregate JSON/report artifacts and the underlying pair summaries.
+2. There is no function that renders a Mermaid sequence diagram from the pair run outcome or step timings.
+3. The `for` loop in `main()` appends results and continues; it never exits early when a pair fails.
+4. The underlying direct-proof runner already records summary/timing data, but the matrix runner does not reshape that data into the requested per-pair artifact.
+
+## Reproduction
+
+1. Inspect `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py`.
+2. Note that the only writes in the main loop are to `progress.json`, `matrix-results.json`, `state.json`, and the final `matrix-report.md`.
+3. Note that the loop at the end of `main()` has no `break` / `raise` on failure.
+4. Run the existing matrix tests in `meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py`; they cover resume and transport selection, but not fail-fast behavior or Mermaid artifact generation.
+
+## Affected files / functions
+
+- `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py`
+  - `run_pair()`
+  - `main()`
+  - `render_compact_report()`
+- likely `meshlink-reference/scripts/run_headless_reference_android_direct_proof.py` if we need richer step timing for the Mermaid diagram
+- likely `meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py` for regression coverage
+
+## Proposed fix
+
+- Add a fleet enumeration step before the matrix begins and persist the exact device list in the run artifacts.
+- Add a per-pair artifact writer that renders a Mermaid sequence diagram from the pair's run data and stores it in that pair's run directory.
+- Include transport selection, device quirks, and step timing in that artifact.
+- Add fail-fast behavior to the matrix loop for the first run, with an explicit stop-on-failure path.
+- Add tests proving:
+  - the fleet enumeration artifact is written before any pair starts
+  - a pair artifact is written for each completed pair
+  - the Mermaid output includes timing and transport metadata
+  - the matrix run stops after the first failure when fail-fast is enabled
+
+## Follow-up triage: docs-path failures
+
+The unrelated docs-path failures are not caused by the matrix runner change. They are cwd-sensitive test failures:
+
+- `test_docs_index_links` passes when run from the repository root, but fails when the suite is launched from `meshlink-reference/scripts` because `Path("docs/README.md")` resolves relative to the wrong working directory.
+- `test_reference_fleet` still fails under the scripts-directory invocation because it imports `support` as a top-level module and depends on the scripts directory being on `sys.path`.
+
+That means the docs failures are harness/layout problems, not missing docs content in the repository.
+
+## Notes
+
+This is an orchestration/reporting gap rather than a transport-protocol failure. The pair runner is already capable of producing summary data; the missing piece is the matrix-level artifact and stop-on-failure behavior the workflow now requires.

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ guessing which page owns which model.
 - [MeshLink runtime behavior reference](reference/meshlink-runtime-behavior.md) — lifecycle boundaries, stream semantics, delivery-path selection, trust-reset effects, persistence, and operational limits.
 - [Glossary and acronym reference](reference/glossary.md) — quick definitions for recurring SDK, contributor, and reference-app terms.
 - [Device test matrix reference](reference/device-test-matrix.md) — the attached Android device fleet, human-readable model names, Bluetooth version, crypto baseline, and update rules.
+- [Android direct-proof fleet reports](reference/android-direct-proof-fleet-reports.md) — the repository-local report bundle layout, artifact references, and troubleshooting entry points for fleet sweeps.
 - [Release status reference](reference/release-status.md) — the current distribution shape, intended first public release shape, and remaining release blockers.
 - [Generated public API symbol tables](reference/generated-public-api.md) — the public API appendix rendered from the checked-in BCV dump.
 - [Contributor build, test, and verification reference](reference/contributor-reference.md) — exact contributor commands, verification bundles, architecture landmarks, and repository rules.

--- a/docs/reference/android-direct-proof-fleet-report-layout.md
+++ b/docs/reference/android-direct-proof-fleet-report-layout.md
@@ -20,4 +20,4 @@ reports/android-direct-proof-fleet/runs/<timestamp>/
 Use this sample to understand the expected repository-local report bundle without hunting through generated output.
 It complements [Android direct-proof fleet reports](android-direct-proof-fleet-reports.md), which explains the artifact contents and troubleshooting references,
 [Reports index](../../reports/INDEX.md), which provides the repository-tracked entry point for generated report bundles,
-and the tracked sample run bundle at [20260618T114257](../../reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md).
+and the tracked sample run bundle at [20260618T114257](../../reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md) with its [SUMMARY.md](../../reports/android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md).

--- a/docs/reference/android-direct-proof-fleet-report-layout.md
+++ b/docs/reference/android-direct-proof-fleet-report-layout.md
@@ -1,0 +1,21 @@
+# Android direct-proof fleet report layout
+
+This page is a concise repository-tracked sample of the report bundle shape produced by the Android direct-proof fleet sweep.
+
+## Sample bundle
+
+```text
+.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/
+├── fleet.json
+├── fleet.md
+├── matrix-results.json
+├── matrix-report.md
+├── 01_a065_nam_lx9_report.md
+├── 01_a065_nam_lx9_initial/
+└── 01_a065_nam_lx9_final/
+```
+
+## Why this exists
+
+Use this sample to understand the expected repository-local report bundle without hunting through generated output.
+It complements [Android direct-proof fleet reports](android-direct-proof-fleet-reports.md), which explains the artifact contents and troubleshooting references.

--- a/docs/reference/android-direct-proof-fleet-report-layout.md
+++ b/docs/reference/android-direct-proof-fleet-report-layout.md
@@ -18,4 +18,6 @@ reports/android-direct-proof-fleet/runs/<timestamp>/
 ## Why this exists
 
 Use this sample to understand the expected repository-local report bundle without hunting through generated output.
-It complements [Android direct-proof fleet reports](android-direct-proof-fleet-reports.md), which explains the artifact contents and troubleshooting references.
+It complements [Android direct-proof fleet reports](android-direct-proof-fleet-reports.md), which explains the artifact contents and troubleshooting references,
+[Reports index](../../reports/INDEX.md), which provides the repository-tracked entry point for generated report bundles,
+and the tracked sample run bundle at [20260618T114257](../../reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md).

--- a/docs/reference/android-direct-proof-fleet-report-layout.md
+++ b/docs/reference/android-direct-proof-fleet-report-layout.md
@@ -5,7 +5,7 @@ This page is a concise repository-tracked sample of the report bundle shape prod
 ## Sample bundle
 
 ```text
-.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/
+reports/android-direct-proof-fleet/runs/<timestamp>/
 ├── fleet.json
 ├── fleet.md
 ├── matrix-results.json

--- a/docs/reference/android-direct-proof-fleet-reports.md
+++ b/docs/reference/android-direct-proof-fleet-reports.md
@@ -1,0 +1,52 @@
+# Android direct-proof fleet reports
+
+The Android fleet sweep produces repository-local report bundles so failures can be debugged and fixed without rerunning the same pairs blindly.
+
+## Default report location
+
+When `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py` runs without `--run-root`, it writes into:
+
+`.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/`
+
+That directory is the canonical report bundle for the sweep.
+
+## Bundle contents
+
+Each run should include:
+
+- `fleet.json` — enumerated Android devices before pair execution starts
+- `fleet.md` — human-readable fleet inventory and pair list
+- `matrix-results.json` — structured results for every completed pair
+- `matrix-report.md` — end-of-run summary, pass/fail buckets, and next-step notes
+- `NN_pairlabel_report.md` — per-pair report with:
+  - setup details
+  - transport used
+  - device quirks and known issues
+  - Mermaid sequence diagram
+  - references to raw evidence files
+  - nested timing JSON
+- `NN_pairlabel_initial/` and `NN_pairlabel_final/` — proof-run directories
+
+## Raw evidence referenced by per-pair reports
+
+Per-pair reports should point to the underlying proof artifacts instead of repeating everything inline:
+
+- `summary.json`
+- `summary.html`
+- `sender_logcat.log`
+- `passive_logcat.log`
+- `sender_start.txt`
+- `passive_start.txt`
+- `android_history.json`
+- `android_export.json`
+
+## Troubleshooting intent
+
+The report should make it easy to answer:
+
+1. Which devices were in scope?
+2. Which transport path was used?
+3. How far did the run get before it failed?
+4. Which raw logs and evidence files should be inspected next?
+5. What fix should be planned from the evidence?
+

--- a/docs/reference/android-direct-proof-fleet-reports.md
+++ b/docs/reference/android-direct-proof-fleet-reports.md
@@ -40,6 +40,13 @@ Per-pair reports should point to the underlying proof artifacts instead of repea
 - `android_history.json`
 - `android_export.json`
 
+## Sample committed bundle layout
+
+A committed copy of the report bundle layout lives in
+`.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/REPORTS.md`.
+That file is the repository-tracked example of what the generated run directory should look like.
+For a shorter tree-only summary, see [Android direct-proof fleet report layout](android-direct-proof-fleet-report-layout.md).
+
 ## Troubleshooting intent
 
 The report should make it easy to answer:

--- a/docs/reference/android-direct-proof-fleet-reports.md
+++ b/docs/reference/android-direct-proof-fleet-reports.md
@@ -6,7 +6,7 @@ The Android fleet sweep produces repository-local report bundles so failures can
 
 When `meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py` runs without `--run-root`, it writes into:
 
-`.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs/<timestamp>/`
+`reports/android-direct-proof-fleet/runs/<timestamp>/`
 
 That directory is the canonical report bundle for the sweep.
 
@@ -43,7 +43,7 @@ Per-pair reports should point to the underlying proof artifacts instead of repea
 ## Sample committed bundle layout
 
 A committed copy of the report bundle layout lives in
-`.gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/REPORTS.md`.
+`reports/README.md`.
 That file is the repository-tracked example of what the generated run directory should look like.
 For a shorter tree-only summary, see [Android direct-proof fleet report layout](android-direct-proof-fleet-report-layout.md).
 

--- a/docs/reference/android-direct-proof-fleet-reports.md
+++ b/docs/reference/android-direct-proof-fleet-reports.md
@@ -43,8 +43,9 @@ Per-pair reports should point to the underlying proof artifacts instead of repea
 ## Sample committed bundle layout
 
 A committed copy of the report bundle layout lives in
-`reports/README.md`.
-That file is the repository-tracked example of what the generated run directory should look like.
+`reports/INDEX.md` and `reports/README.md`.
+Those files are the repository-tracked examples of what the generated run directory should look like.
+The first tracked run bundle is [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](../../reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md).
 For a shorter tree-only summary, see [Android direct-proof fleet report layout](android-direct-proof-fleet-report-layout.md).
 
 ## Troubleshooting intent

--- a/docs/reference/android-direct-proof-fleet-reports.md
+++ b/docs/reference/android-direct-proof-fleet-reports.md
@@ -45,7 +45,7 @@ Per-pair reports should point to the underlying proof artifacts instead of repea
 A committed copy of the report bundle layout lives in
 `reports/INDEX.md` and `reports/README.md`.
 Those files are the repository-tracked examples of what the generated run directory should look like.
-The first tracked run bundle is [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](../../reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md).
+The first tracked run bundle is [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](../../reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md), with a concise failure summary at [SUMMARY.md](../../reports/android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md).
 For a shorter tree-only summary, see [Android direct-proof fleet report layout](android-direct-proof-fleet-report-layout.md).
 
 ## Troubleshooting intent

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -107,6 +107,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Resume from the last checkpoint if the run root already contains progress",
     )
+    parser.add_argument(
+        "--continue-on-failure",
+        dest="fail_fast",
+        action="store_false",
+        help="Keep running later pairs after a failure instead of stopping at the first failure",
+    )
+    parser.set_defaults(fail_fast=True)
     return parser.parse_args(argv)
 
 
@@ -333,6 +340,212 @@ def render_compact_report(results: list[dict[str, Any]]) -> str:
     return "\n".join(report)
 
 
+def format_elapsed_seconds(summary: dict[str, Any] | None) -> str:
+    if summary is None:
+        return "—"
+    elapsed = summary.get("elapsedSeconds")
+    if elapsed is None:
+        timings = summary.get("timings") or {}
+        elapsed = timings.get("totalSeconds")
+    if elapsed is None:
+        return "—"
+    try:
+        return f"{float(elapsed):.1f}s"
+    except (TypeError, ValueError):
+        return str(elapsed)
+
+
+def build_fleet_inventory(
+    *,
+    attached_devices: list[str],
+    available_pairs: list[dict[str, str]],
+    fail_fast: bool,
+) -> dict[str, Any]:
+    devices = [
+        {
+            "serial": serial,
+            "model": ANDROID_MODELS.get(serial, serial),
+            "apiLevel": adb_device_api_level(serial),
+        }
+        for serial in attached_devices
+    ]
+    return {
+        "capturedAt": timestamp(),
+        "failFast": fail_fast,
+        "deviceCount": len(devices),
+        "pairCount": len(available_pairs),
+        "devices": devices,
+        "availablePairs": [
+            {
+                "label": pair["label"],
+                "sender": pair["sender"],
+                "passive": pair["passive"],
+                "senderModel": ANDROID_MODELS.get(pair["sender"], pair["sender"]),
+                "passiveModel": ANDROID_MODELS.get(pair["passive"], pair["passive"]),
+            }
+            for pair in available_pairs
+        ],
+    }
+
+
+def render_fleet_inventory_markdown(inventory: dict[str, Any]) -> str:
+    device_rows = ["| Serial | Model | API level |", "|---|---|---|"]
+    for device in inventory["devices"]:
+        api_level = device.get("apiLevel")
+        device_rows.append(
+            f"| {device['serial']} | {device['model']} | {api_level if api_level is not None else 'unknown'} |"
+        )
+
+    pair_rows = ["| Label | Sender | Passive |", "|---|---|---|"]
+    for pair in inventory["availablePairs"]:
+        pair_rows.append(
+            f"| {pair['label']} | {pair['senderModel']} ({pair['sender']}) | {pair['passiveModel']} ({pair['passive']}) |"
+        )
+
+    fail_fast_value = "enabled" if inventory.get("failFast", True) else "disabled"
+    return "\n".join(
+        [
+            "# Android fleet inventory",
+            "",
+            f"- Captured: {inventory.get('capturedAt', '—')}",
+            f"- Fail-fast: {fail_fast_value}",
+            f"- Device count: {inventory.get('deviceCount', 0)}",
+            f"- Pair count: {inventory.get('pairCount', 0)}",
+            "",
+            "## Devices",
+            "",
+            *device_rows,
+            "",
+            "## Available directed pairs",
+            "",
+            *pair_rows,
+            "",
+        ]
+    )
+
+
+def render_pair_report(
+    *,
+    index: int,
+    pair: dict[str, str],
+    sender_model: str,
+    passive_model: str,
+    sender_api_level: int | None,
+    passive_api_level: int | None,
+    passive_benchmark_transport: str,
+    fallback_reason: dict[str, Any] | None,
+    target_peer_id: str | None,
+    peer_lookup_seconds: float | None,
+    initial: dict[str, Any],
+    final: dict[str, Any],
+    fleet_inventory_path: Path,
+) -> str:
+    initial_elapsed = format_elapsed_seconds(initial)
+    final_elapsed = format_elapsed_seconds(final)
+    peer_lookup_elapsed = (
+        f"{peer_lookup_seconds:.1f}s" if peer_lookup_seconds is not None else "—"
+    )
+    transport_label = passive_benchmark_transport.upper()
+    quirks = [
+        f"Transport used for the pair: {transport_label}",
+    ]
+    if fallback_reason is not None:
+        quirks.append(
+            "Fallback reason: "
+            f"{fallback_reason['reason']} (senderApiLevel={fallback_reason['senderApiLevel']} "
+            f"passiveApiLevel={fallback_reason['passiveApiLevel']})"
+        )
+    if sender_api_level is not None and sender_api_level < DEFAULT_MIN_ANDROID_API_LEVEL:
+        quirks.append(
+            f"Sender API level {sender_api_level} is below the floor {DEFAULT_MIN_ANDROID_API_LEVEL}."
+        )
+    if passive_api_level is not None and passive_api_level < DEFAULT_MIN_ANDROID_API_LEVEL:
+        quirks.append(
+            f"Passive API level {passive_api_level} is below the floor {DEFAULT_MIN_ANDROID_API_LEVEL}."
+        )
+    if initial.get("failureReason"):
+        quirks.append(f"Initial run failure: {initial['failureReason']}")
+    if final.get("failureReason"):
+        quirks.append(f"Final run failure: {final['failureReason']}")
+    if target_peer_id is not None:
+        quirks.append(f"Passive peer id discovered: {target_peer_id}")
+
+    final_status = final.get("status", "skipped")
+    initial_passed = initial.get("status") == "passed"
+    if initial_passed:
+        diagram_lines = [
+            "```mermaid",
+            "sequenceDiagram",
+            "    participant Matrix",
+            f"    participant Sender as {sender_model}",
+            f"    participant Passive as {passive_model}",
+            f"    note over Matrix: transport {transport_label}",
+            f"    note over Matrix: fleet inventory {fleet_inventory_path.name}",
+            f"    Matrix->>Sender: initial run ({initial_elapsed})",
+            f"    note over Sender: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'})",
+            "    alt initial passed",
+            f"        Matrix->>Passive: read passive peer id ({peer_lookup_elapsed})",
+            f"        note over Matrix: target peer {target_peer_id or 'not resolved'}",
+            f"        Matrix->>Sender: final run ({final_elapsed})",
+            f"        note over Sender: {final_status} ({final.get('failureStage') or 'no failure stage'})",
+            "        alt final passed",
+            "            note over Matrix: pair completed successfully",
+            "        else final failed",
+            "            note over Matrix: fail-fast stop after final failure",
+            "        end",
+            "    else initial failed",
+            "        note over Matrix: fail-fast stop after initial failure",
+            "    end",
+            "```",
+        ]
+    else:
+        diagram_lines = [
+            "```mermaid",
+            "sequenceDiagram",
+            "    participant Matrix",
+            f"    participant Sender as {sender_model}",
+            f"    participant Passive as {passive_model}",
+            f"    note over Matrix: transport {transport_label}",
+            f"    note over Matrix: fleet inventory {fleet_inventory_path.name}",
+            f"    Matrix->>Sender: initial run ({initial_elapsed})",
+            f"    note over Sender: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'})",
+            "    alt initial failed",
+            "        note over Matrix: fail-fast stop after initial failure",
+            "    end",
+            "```",
+        ]
+
+    lines = [
+        f"# Pair {index:02d} — {pair['label']}",
+        "",
+        "## Setup",
+        "",
+        f"- Sender: {sender_model} ({pair['sender']})",
+        f"- Passive: {passive_model} ({pair['passive']})",
+        f"- Sender API level: {sender_api_level if sender_api_level is not None else 'unknown'}",
+        f"- Passive API level: {passive_api_level if passive_api_level is not None else 'unknown'}",
+        f"- Transport: {transport_label}",
+        f"- Fleet inventory: `{fleet_inventory_path.name}`",
+        f"- Peer lookup time: {peer_lookup_elapsed}",
+        "",
+        "## Result",
+        "",
+        f"- Initial status: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'}) in {initial_elapsed}",
+        f"- Final status: {final_status} ({final.get('failureStage') or 'no failure stage'}) in {final_elapsed}",
+        f"- Target peer id: {target_peer_id or 'not resolved'}",
+        "",
+        "## Device quirks and issues",
+        "",
+        *[f"- {quirk}" for quirk in quirks],
+        "",
+        "## Mermaid sequence diagram",
+        "",
+        *diagram_lines,
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def load_progress(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
@@ -341,21 +554,36 @@ def load_progress(path: Path) -> list[dict[str, Any]]:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    devices = set(adb_devices())
-    available_pairs = [pair for pair in PAIRS if pair["sender"] in devices and pair["passive"] in devices]
+    attached_devices = adb_devices()
+    device_set = set(attached_devices)
+    available_pairs = [pair for pair in PAIRS if pair["sender"] in device_set and pair["passive"] in device_set]
     if args.sender_passive_limit is not None:
         available_pairs = available_pairs[: args.sender_passive_limit]
-    if not available_pairs:
-        raise SystemExit("No directed Android pairs are available")
 
     run_root = Path(args.run_root or f"/tmp/meshlink_android_matrix_{timestamp()}")
     run_root.mkdir(parents=True, exist_ok=True)
+
+    fleet_inventory = build_fleet_inventory(
+        attached_devices=attached_devices,
+        available_pairs=available_pairs,
+        fail_fast=args.fail_fast,
+    )
+    fleet_json_path = run_root / "fleet.json"
+    fleet_markdown_path = run_root / "fleet.md"
+    fleet_json_path.write_text(json.dumps(fleet_inventory, indent=2), encoding="utf-8")
+    fleet_markdown_path.write_text(render_fleet_inventory_markdown(fleet_inventory), encoding="utf-8")
+
+    if not available_pairs:
+        raise SystemExit("No directed Android pairs are available")
+
     progress_path = run_root / "progress.json"
     results_path = run_root / "matrix-results.json"
     state_path = run_root / "state.json"
 
     results = load_progress(progress_path) if args.resume else []
     completed = {(row["sender"], row["passive"]) for row in results}
+    stopped_early = False
+    stop_reason: str | None = None
 
     for index, pair in enumerate(available_pairs, 1):
         if (pair["sender"], pair["passive"]) in completed:
@@ -395,19 +623,39 @@ def main(argv: list[str] | None = None) -> int:
             skip_install=False,
             passive_benchmark_transport=passive_benchmark_transport,
         )
-        target_peer_id = read_passive_peer_id(pair["passive"], app_id)
-        final = run_pair(
-            sender=pair["sender"],
-            passive=pair["passive"],
-            app_id=app_id,
-            run_dir=final_dir,
-            target_peer_id=target_peer_id,
-            capture_timeout=args.capture_timeout_seconds,
-            android_ready_seconds=args.android_ready_seconds,
-            pair_timeout_seconds=args.pair_timeout_seconds,
-            skip_install=True,
-            passive_benchmark_transport=passive_benchmark_transport,
-        )
+        target_peer_id = None
+        peer_lookup_seconds = None
+        if initial["status"] == "passed":
+            peer_lookup_started = time.monotonic()
+            target_peer_id = read_passive_peer_id(pair["passive"], app_id)
+            peer_lookup_seconds = round(time.monotonic() - peer_lookup_started, 1)
+            final = run_pair(
+                sender=pair["sender"],
+                passive=pair["passive"],
+                app_id=app_id,
+                run_dir=final_dir,
+                target_peer_id=target_peer_id,
+                capture_timeout=args.capture_timeout_seconds,
+                android_ready_seconds=args.android_ready_seconds,
+                pair_timeout_seconds=args.pair_timeout_seconds,
+                skip_install=True,
+                passive_benchmark_transport=passive_benchmark_transport,
+            )
+        else:
+            final = {
+                "status": "skipped",
+                "failureStage": initial.get("failureStage"),
+                "failureReason": initial.get("failureReason"),
+                "senderCompletion": initial.get("senderCompletion"),
+                "passiveCompletion": initial.get("passiveCompletion"),
+                "timings": initial.get("timings"),
+                "htmlReportPath": initial.get("htmlReportPath"),
+                "stdoutTail": initial.get("stdoutTail"),
+                "stderrTail": initial.get("stderrTail"),
+                "elapsedSeconds": initial.get("elapsedSeconds"),
+                "exitCode": initial.get("exitCode"),
+            }
+
         row = {
             "label": pair["label"],
             "sender": pair["sender"],
@@ -420,6 +668,12 @@ def main(argv: list[str] | None = None) -> int:
             "final": compact_status(final),
             "initialRunDir": str(initial_dir),
             "finalRunDir": str(final_dir),
+            "pairReportPath": str(run_root / f"{index:02d}_{pair['label']}_report.md"),
+            "fleetInventoryPath": str(fleet_markdown_path),
+            "transportMode": passive_benchmark_transport,
+            "peerLookupSeconds": peer_lookup_seconds,
+            "fallbackReason": fallback_reason,
+            "failFast": args.fail_fast,
         }
         results.append(row)
         completed.add((pair["sender"], pair["passive"]))
@@ -429,12 +683,35 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     "runRoot": str(run_root),
+                    "fleetInventoryPath": str(fleet_markdown_path),
                     "totalPairs": len(available_pairs),
                     "completedPairs": len(results),
                     "pendingPairs": len(available_pairs) - len(results),
                     "lastPair": pair,
+                    "failFast": args.fail_fast,
+                    "stoppedEarly": stopped_early,
+                    "stopReason": stop_reason,
                 },
                 indent=2,
+            ),
+            encoding="utf-8",
+        )
+        pair_report_path = run_root / f"{index:02d}_{pair['label']}_report.md"
+        pair_report_path.write_text(
+            render_pair_report(
+                index=index,
+                pair=pair,
+                sender_model=row["senderModel"],
+                passive_model=row["passiveModel"],
+                sender_api_level=sender_api_level,
+                passive_api_level=passive_api_level,
+                passive_benchmark_transport=passive_benchmark_transport,
+                fallback_reason=fallback_reason,
+                target_peer_id=target_peer_id,
+                peer_lookup_seconds=peer_lookup_seconds,
+                initial=initial,
+                final=final,
+                fleet_inventory_path=fleet_markdown_path,
             ),
             encoding="utf-8",
         )
@@ -443,10 +720,45 @@ def main(argv: list[str] | None = None) -> int:
             flush=True,
         )
 
+        if args.fail_fast and (initial["status"] != "passed" or final["status"] != "passed"):
+            stopped_early = True
+            stop_reason = (
+                f"pair {pair['label']} failed during {initial['failureStage'] or final['failureStage'] or 'unknown stage'}"
+            )
+            break
+
+    state_path.write_text(
+        json.dumps(
+            {
+                "runRoot": str(run_root),
+                "fleetInventoryPath": str(fleet_markdown_path),
+                "totalPairs": len(available_pairs),
+                "completedPairs": len(results),
+                "pendingPairs": len(available_pairs) - len(results),
+                "lastPair": results[-1] if results else None,
+                "failFast": args.fail_fast,
+                "stoppedEarly": stopped_early,
+                "stopReason": stop_reason,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    compact_report = render_compact_report(results)
+    compact_report += "\n\n## Run setup\n\n"
+    compact_report += f"- Fleet inventory: `{fleet_markdown_path.name}`\n"
+    compact_report += f"- Fleet JSON: `{fleet_json_path.name}`\n"
+    compact_report += f"- Fail-fast: {'enabled' if args.fail_fast else 'disabled'}\n"
+    compact_report += f"- Stopped early: {'yes' if stopped_early else 'no'}\n"
+    if stop_reason is not None:
+        compact_report += f"- Stop reason: {stop_reason}\n"
     compact_report_path = run_root / "matrix-report.md"
-    compact_report_path.write_text(render_compact_report(results), encoding="utf-8")
+    compact_report_path.write_text(compact_report, encoding="utf-8")
     print(f"==> Wrote {results_path}", flush=True)
     print(f"==> Wrote {compact_report_path}", flush=True)
+    print(f"==> Wrote {fleet_json_path}", flush=True)
+    print(f"==> Wrote {fleet_markdown_path}", flush=True)
     return 0
 
 

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -22,6 +22,7 @@ DEFAULT_PAIR_TIMEOUT_SECONDS = 300.0
 DEFAULT_MIN_ANDROID_API_LEVEL = 33
 DEFAULT_FALLBACK_TRANSPORT = "gatt"
 DEFAULT_PRIMARY_TRANSPORT = "meshlink"
+DEFAULT_MATRIX_RUN_ROOT = Path(".gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs")
 
 PAIRS = [
     {"label": "a065_nam_lx9", "sender": "1f1dad34", "passive": "2ASVB21B09005117"},
@@ -225,7 +226,13 @@ def run_pair(
             "senderRouteStage": None,
             "passiveRouteStage": None,
             "timings": {"totalSeconds": elapsed, "pairTimeoutSeconds": pair_timeout_seconds},
+            "startupTiming": {},
             "htmlReportPath": None,
+            "exportRelativePath": None,
+            "evidence": {},
+            "captured": {},
+            "summaryPath": str(run_dir / "summary.json"),
+            "runDir": str(run_dir),
             "stdoutTail": stdout_tail,
             "stderrTail": stderr_tail,
             "elapsedSeconds": elapsed,
@@ -253,7 +260,13 @@ def run_pair(
         "senderRouteStage": summary.get("senderRouteStage"),
         "passiveRouteStage": summary.get("passiveRouteStage"),
         "timings": summary.get("timings"),
+        "startupTiming": summary.get("startupTiming"),
         "htmlReportPath": summary.get("htmlReportPath"),
+        "exportRelativePath": summary.get("exportRelativePath"),
+        "evidence": summary.get("evidence"),
+        "captured": summary.get("captured"),
+        "summaryPath": str(summary_path),
+        "runDir": str(run_dir),
         "stdoutTail": (completed.stdout or "")[-1000:],
         "stderrTail": (completed.stderr or "")[-1000:],
         "elapsedSeconds": elapsed,
@@ -291,7 +304,20 @@ def compact_status(summary: dict[str, Any]) -> dict[str, Any]:
         "failureReason": summary.get("failureReason"),
         "senderCompletion": summary.get("senderCompletion"),
         "passiveCompletion": summary.get("passiveCompletion"),
+        "routeStage": summary.get("routeStage"),
+        "routeEvidence": summary.get("routeEvidence"),
+        "senderRouteStage": summary.get("senderRouteStage"),
+        "senderRouteEvidence": summary.get("senderRouteEvidence"),
+        "passiveRouteStage": summary.get("passiveRouteStage"),
+        "passiveRouteEvidence": summary.get("passiveRouteEvidence"),
+        "startupTiming": summary.get("startupTiming"),
         "timings": summary.get("timings"),
+        "htmlReportPath": summary.get("htmlReportPath"),
+        "exportRelativePath": summary.get("exportRelativePath"),
+        "evidence": summary.get("evidence"),
+        "captured": summary.get("captured"),
+        "summaryPath": summary.get("summaryPath"),
+        "runDir": summary.get("runDir"),
     }
 
 
@@ -439,30 +465,38 @@ def render_pair_report(
     initial: dict[str, Any],
     final: dict[str, Any],
     fleet_inventory_path: Path,
+    pair_report_path: Path,
 ) -> str:
+    def json_block(title: str, value: Any) -> list[str]:
+        return [title, "", "```json", json.dumps(value, indent=2, sort_keys=True), "```", ""]
+
+    def path_ref(label: str, value: str | None) -> str:
+        return value or "—"
+
+    def evidence_rows(summary: dict[str, Any], stage: str) -> list[str]:
+        evidence = summary.get("evidence") or {}
+        captured = summary.get("captured") or {}
+        rows = [f"| {stage} artifact | Path | Captured |", "|---|---|---|"]
+        for key in ("senderLogcat", "passiveLogcat", "senderStart", "passiveStart", "androidHistory", "androidExport"):
+            rows.append(
+                f"| {stage} {key} | `{evidence.get(key, '—')}` | {'yes' if captured.get(key) else 'no'} |"
+            )
+        return rows
+
     initial_elapsed = format_elapsed_seconds(initial)
     final_elapsed = format_elapsed_seconds(final)
-    peer_lookup_elapsed = (
-        f"{peer_lookup_seconds:.1f}s" if peer_lookup_seconds is not None else "—"
-    )
+    peer_lookup_elapsed = f"{peer_lookup_seconds:.1f}s" if peer_lookup_seconds is not None else "—"
     transport_label = passive_benchmark_transport.upper()
-    quirks = [
-        f"Transport used for the pair: {transport_label}",
-    ]
+    quirks = [f"Transport used for the pair: {transport_label}"]
     if fallback_reason is not None:
         quirks.append(
             "Fallback reason: "
-            f"{fallback_reason['reason']} (senderApiLevel={fallback_reason['senderApiLevel']} "
-            f"passiveApiLevel={fallback_reason['passiveApiLevel']})"
+            f"{fallback_reason['reason']} (senderApiLevel={fallback_reason['senderApiLevel']} passiveApiLevel={fallback_reason['passiveApiLevel']})"
         )
     if sender_api_level is not None and sender_api_level < DEFAULT_MIN_ANDROID_API_LEVEL:
-        quirks.append(
-            f"Sender API level {sender_api_level} is below the floor {DEFAULT_MIN_ANDROID_API_LEVEL}."
-        )
+        quirks.append(f"Sender API level {sender_api_level} is below the floor {DEFAULT_MIN_ANDROID_API_LEVEL}.")
     if passive_api_level is not None and passive_api_level < DEFAULT_MIN_ANDROID_API_LEVEL:
-        quirks.append(
-            f"Passive API level {passive_api_level} is below the floor {DEFAULT_MIN_ANDROID_API_LEVEL}."
-        )
+        quirks.append(f"Passive API level {passive_api_level} is below the floor {DEFAULT_MIN_ANDROID_API_LEVEL}.")
     if initial.get("failureReason"):
         quirks.append(f"Initial run failure: {initial['failureReason']}")
     if final.get("failureReason"):
@@ -470,50 +504,45 @@ def render_pair_report(
     if target_peer_id is not None:
         quirks.append(f"Passive peer id discovered: {target_peer_id}")
 
-    final_status = final.get("status", "skipped")
     initial_passed = initial.get("status") == "passed"
+    final_status = final.get("status", "skipped")
+    diagram_lines = [
+        "```mermaid",
+        "sequenceDiagram",
+        "    participant Matrix",
+        f"    participant Sender as {sender_model}",
+        f"    participant Passive as {passive_model}",
+        f"    note over Matrix: transport {transport_label}",
+        f"    note over Matrix: fleet inventory {fleet_inventory_path.name}",
+        f"    note over Matrix: pair report {pair_report_path.name}",
+        f"    Matrix->>Sender: initial run ({initial_elapsed})",
+        f"    note over Sender: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'})",
+    ]
     if initial_passed:
-        diagram_lines = [
-            "```mermaid",
-            "sequenceDiagram",
-            "    participant Matrix",
-            f"    participant Sender as {sender_model}",
-            f"    participant Passive as {passive_model}",
-            f"    note over Matrix: transport {transport_label}",
-            f"    note over Matrix: fleet inventory {fleet_inventory_path.name}",
-            f"    Matrix->>Sender: initial run ({initial_elapsed})",
-            f"    note over Sender: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'})",
-            "    alt initial passed",
-            f"        Matrix->>Passive: read passive peer id ({peer_lookup_elapsed})",
-            f"        note over Matrix: target peer {target_peer_id or 'not resolved'}",
-            f"        Matrix->>Sender: final run ({final_elapsed})",
-            f"        note over Sender: {final_status} ({final.get('failureStage') or 'no failure stage'})",
-            "        alt final passed",
-            "            note over Matrix: pair completed successfully",
-            "        else final failed",
-            "            note over Matrix: fail-fast stop after final failure",
-            "        end",
-            "    else initial failed",
-            "        note over Matrix: fail-fast stop after initial failure",
-            "    end",
-            "```",
-        ]
+        diagram_lines.extend(
+            [
+                "    alt initial passed",
+                f"        Matrix->>Passive: read passive peer id ({peer_lookup_elapsed})",
+                f"        note over Matrix: target peer {target_peer_id or 'not resolved'}",
+                f"        Matrix->>Sender: final run ({final_elapsed})",
+                f"        note over Sender: {final_status} ({final.get('failureStage') or 'no failure stage'})",
+                "        alt final passed",
+                "            note over Matrix: pair completed successfully",
+                "        else final failed",
+                "            note over Matrix: fail-fast stop after final failure",
+                "        end",
+                "    else initial failed",
+                "        note over Matrix: fail-fast stop after initial failure",
+                "    end",
+            ]
+        )
     else:
-        diagram_lines = [
-            "```mermaid",
-            "sequenceDiagram",
-            "    participant Matrix",
-            f"    participant Sender as {sender_model}",
-            f"    participant Passive as {passive_model}",
-            f"    note over Matrix: transport {transport_label}",
-            f"    note over Matrix: fleet inventory {fleet_inventory_path.name}",
-            f"    Matrix->>Sender: initial run ({initial_elapsed})",
-            f"    note over Sender: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'})",
+        diagram_lines.extend([
             "    alt initial failed",
             "        note over Matrix: fail-fast stop after initial failure",
             "    end",
-            "```",
-        ]
+        ])
+    diagram_lines.extend(["```", ""])
 
     lines = [
         f"# Pair {index:02d} — {pair['label']}",
@@ -525,23 +554,41 @@ def render_pair_report(
         f"- Sender API level: {sender_api_level if sender_api_level is not None else 'unknown'}",
         f"- Passive API level: {passive_api_level if passive_api_level is not None else 'unknown'}",
         f"- Transport: {transport_label}",
-        f"- Fleet inventory: `{fleet_inventory_path.name}`",
+        f"- Fleet inventory: `{fleet_inventory_path}`",
+        f"- Pair report path: `{pair_report_path}`",
         f"- Peer lookup time: {peer_lookup_elapsed}",
+        f"- Initial run dir: `{path_ref('initial', initial.get('runDir'))}`",
+        f"- Final run dir: `{path_ref('final', final.get('runDir'))}`",
         "",
         "## Result",
         "",
         f"- Initial status: {initial.get('status', 'unknown')} ({initial.get('failureStage') or 'no failure stage'}) in {initial_elapsed}",
         f"- Final status: {final_status} ({final.get('failureStage') or 'no failure stage'}) in {final_elapsed}",
         f"- Target peer id: {target_peer_id or 'not resolved'}",
+        f"- Initial HTML report: `{path_ref('initial html', initial.get('htmlReportPath'))}`",
+        f"- Final HTML report: `{path_ref('final html', final.get('htmlReportPath'))}`",
+        f"- Initial summary JSON: `{path_ref('initial summary', initial.get('summaryPath'))}`",
+        f"- Final summary JSON: `{path_ref('final summary', final.get('summaryPath'))}`",
+        "",
+        "## Troubleshooting references",
+        "",
+        *evidence_rows(initial, "Initial"),
+        *evidence_rows(final, "Final"),
         "",
         "## Device quirks and issues",
         "",
         *[f"- {quirk}" for quirk in quirks],
         "",
+        "## Startup timing",
+        "",
+        *json_block("Initial startupTiming", initial.get("startupTiming") or {}),
+        *json_block("Initial timings", initial.get("timings") or {}),
+        *json_block("Final startupTiming", final.get("startupTiming") or {}),
+        *json_block("Final timings", final.get("timings") or {}),
+        *json_block("Captured evidence map", {"initial": initial.get("captured") or {}, "final": final.get("captured") or {}}),
         "## Mermaid sequence diagram",
         "",
         *diagram_lines,
-        "",
     ]
     return "\n".join(lines)
 
@@ -560,7 +607,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.sender_passive_limit is not None:
         available_pairs = available_pairs[: args.sender_passive_limit]
 
-    run_root = Path(args.run_root or f"/tmp/meshlink_android_matrix_{timestamp()}")
+    run_root = Path(args.run_root or str(DEFAULT_MATRIX_RUN_ROOT / timestamp()))
     run_root.mkdir(parents=True, exist_ok=True)
 
     fleet_inventory = build_fleet_inventory(
@@ -669,6 +716,7 @@ def main(argv: list[str] | None = None) -> int:
             "initialRunDir": str(initial_dir),
             "finalRunDir": str(final_dir),
             "pairReportPath": str(run_root / f"{index:02d}_{pair['label']}_report.md"),
+            "fleetJsonPath": str(fleet_json_path),
             "fleetInventoryPath": str(fleet_markdown_path),
             "transportMode": passive_benchmark_transport,
             "peerLookupSeconds": peer_lookup_seconds,
@@ -712,6 +760,7 @@ def main(argv: list[str] | None = None) -> int:
                 initial=initial,
                 final=final,
                 fleet_inventory_path=fleet_markdown_path,
+                pair_report_path=pair_report_path,
             ),
             encoding="utf-8",
         )
@@ -747,8 +796,8 @@ def main(argv: list[str] | None = None) -> int:
 
     compact_report = render_compact_report(results)
     compact_report += "\n\n## Run setup\n\n"
-    compact_report += f"- Fleet inventory: `{fleet_markdown_path.name}`\n"
-    compact_report += f"- Fleet JSON: `{fleet_json_path.name}`\n"
+    compact_report += f"- Fleet inventory: `{fleet_markdown_path}`\n"
+    compact_report += f"- Fleet JSON: `{fleet_json_path}`\n"
     compact_report += f"- Fail-fast: {'enabled' if args.fail_fast else 'disabled'}\n"
     compact_report += f"- Stopped early: {'yes' if stopped_early else 'no'}\n"
     if stop_reason is not None:

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -22,7 +22,8 @@ DEFAULT_PAIR_TIMEOUT_SECONDS = 300.0
 DEFAULT_MIN_ANDROID_API_LEVEL = 33
 DEFAULT_FALLBACK_TRANSPORT = "gatt"
 DEFAULT_PRIMARY_TRANSPORT = "meshlink"
-DEFAULT_MATRIX_RUN_ROOT = Path(".gsd/workflows/bugfixes/260618-2-run-the-complete-android-fleet-with-all/runs")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MATRIX_RUN_ROOT = REPO_ROOT / "reports" / "android-direct-proof-fleet" / "runs"
 
 PAIRS = [
     {"label": "a065_nam_lx9", "sender": "1f1dad34", "passive": "2ASVB21B09005117"},

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -26,6 +26,14 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
         self.assertEqual(args.android_ready_seconds, android_direct_matrix.DEFAULT_ANDROID_READY_SECONDS)
         self.assertEqual(args.capture_timeout_seconds, android_direct_matrix.DEFAULT_CAPTURE_TIMEOUT_SECONDS)
 
+    def test_default_matrix_reports_land_under_reports_root(self) -> None:
+        # Arrange / Act
+        default_root = android_direct_matrix.DEFAULT_MATRIX_RUN_ROOT
+        expected_root = Path(__file__).resolve().parents[3] / "reports" / "android-direct-proof-fleet" / "runs"
+
+        # Assert
+        self.assertEqual(default_root, expected_root)
+
     def test_run_pair_reports_timeout_without_blocking_following_pairs(self) -> None:
         # Arrange
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -145,15 +145,85 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             self.assertEqual(rows[0]["label"], "a065_nam_lx9")
             self.assertEqual(rows[0]["final"]["status"], "passed")
             self.assertEqual(rows[1]["label"], "nam_lx9_a065")
-            self.assertEqual(rows[1]["final"]["status"], "passed")
-            self.assertEqual(peer_reads, ["1f1dad34:demo.meshlink.reference.android-direct.nam_lx9_a065"])
+            self.assertEqual(rows[1]["initial"]["status"], "failed")
+            self.assertEqual(rows[1]["final"]["status"], "skipped")
+            self.assertEqual(peer_reads, [])
             self.assertEqual(
                 run_calls,
                 [
                     {"sender": "2ASVB21B09005117", "passive": "1f1dad34", "skip_install": "False", "target_peer_id": None},
-                    {"sender": "2ASVB21B09005117", "passive": "1f1dad34", "skip_install": "True", "target_peer_id": "peer-123"},
                 ],
             )
+
+    def test_main_writes_fleet_inventory_and_pair_report_with_fail_fast(self) -> None:
+        # Arrange
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            run_root = Path(temporary_directory) / "matrix"
+            run_root.mkdir(parents=True, exist_ok=True)
+            calls: list[tuple[str, str, bool]] = []
+
+            def fake_adb_devices() -> list[str]:
+                return ["1f1dad34", "2ASVB21B09005117", "42004386e43c8589"]
+
+            def fake_run_pair(**kwargs):
+                calls.append((kwargs["sender"], kwargs["passive"], kwargs["skip_install"]))
+                if kwargs["skip_install"]:
+                    return {
+                        "status": "failed",
+                        "failureStage": "capture",
+                        "failureReason": "route stalled",
+                        "senderCompletion": "sender complete",
+                        "passiveCompletion": None,
+                        "timings": {"totalSeconds": 12.5, "transportMode": "meshlink"},
+                        "htmlReportPath": "summary.html",
+                        "stdoutTail": "",
+                        "stderrTail": "",
+                        "elapsedSeconds": 12.5,
+                        "exitCode": 1,
+                    }
+                return {
+                    "status": "passed",
+                    "failureStage": None,
+                    "failureReason": None,
+                    "senderCompletion": "sender complete",
+                    "passiveCompletion": "passive complete",
+                    "timings": {"totalSeconds": 4.2, "transportMode": "meshlink"},
+                    "htmlReportPath": "summary.html",
+                    "stdoutTail": "",
+                    "stderrTail": "",
+                    "elapsedSeconds": 4.2,
+                    "exitCode": 0,
+                }
+
+            def fake_read_passive_peer_id(serial: str, app_id: str, retries: int = 60, delay_s: float = 1.0) -> str:
+                del serial, app_id, retries, delay_s
+                return "peer-123"
+
+            # Act
+            with patch.object(android_direct_matrix, "adb_devices", side_effect=fake_adb_devices), patch.object(
+                android_direct_matrix,
+                "adb_device_api_level",
+                side_effect=lambda serial: {"1f1dad34": 36, "2ASVB21B09005117": 36, "42004386e43c8589": 36}.get(serial),
+            ), patch.object(android_direct_matrix, "run_pair", side_effect=fake_run_pair), patch.object(
+                android_direct_matrix, "read_passive_peer_id", side_effect=fake_read_passive_peer_id
+            ):
+                android_direct_matrix.main(["--run-root", str(run_root)])
+
+            # Assert
+            fleet_json = json.loads((run_root / "fleet.json").read_text(encoding="utf-8"))
+            self.assertTrue(fleet_json["failFast"])
+            self.assertEqual(fleet_json["deviceCount"], 3)
+            self.assertEqual([device["serial"] for device in fleet_json["devices"]], ["1f1dad34", "2ASVB21B09005117", "42004386e43c8589"])
+            self.assertTrue((run_root / "01_a065_nam_lx9_report.md").exists())
+            self.assertIn("sequenceDiagram", (run_root / "01_a065_nam_lx9_report.md").read_text(encoding="utf-8"))
+            self.assertIn("fail-fast stop after final failure", (run_root / "01_a065_nam_lx9_report.md").read_text(encoding="utf-8"))
+            results = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["final"]["status"], "failed")
+            state = json.loads((run_root / "state.json").read_text(encoding="utf-8"))
+            self.assertTrue(state["stoppedEarly"])
+            self.assertIn("failed during", state["stopReason"])
+            self.assertEqual(calls, [("1f1dad34", "2ASVB21B09005117", False), ("1f1dad34", "2ASVB21B09005117", True)])
 
     def test_main_runs_all_available_directed_pairs_when_not_resuming(self) -> None:
         # Arrange

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -174,8 +174,32 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                         "failureReason": "route stalled",
                         "senderCompletion": "sender complete",
                         "passiveCompletion": None,
+                        "routeStage": "capture-stalled",
+                        "routeEvidence": "sender_logcat.log: route stalled",
+                        "senderRouteStage": "capture-stalled",
+                        "passiveRouteStage": None,
+                        "startupTiming": {"sender": {"startupWaitSeconds": 3.0}, "passive": {"startupWaitSeconds": 4.0}},
                         "timings": {"totalSeconds": 12.5, "transportMode": "meshlink"},
                         "htmlReportPath": "summary.html",
+                        "exportRelativePath": "android_export.json",
+                        "evidence": {
+                            "senderLogcat": "sender_logcat.log",
+                            "passiveLogcat": "passive_logcat.log",
+                            "senderStart": "sender_start.txt",
+                            "passiveStart": "passive_start.txt",
+                            "androidHistory": "android_history.json",
+                            "androidExport": "android_export.json",
+                        },
+                        "captured": {
+                            "senderLogcat": True,
+                            "passiveLogcat": False,
+                            "senderStart": True,
+                            "passiveStart": True,
+                            "androidHistory": True,
+                            "androidExport": False,
+                        },
+                        "summaryPath": str(run_root / "01_a065_nam_lx9_initial" / "summary.json"),
+                        "runDir": str(run_root / "01_a065_nam_lx9_initial"),
                         "stdoutTail": "",
                         "stderrTail": "",
                         "elapsedSeconds": 12.5,
@@ -187,8 +211,32 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                     "failureReason": None,
                     "senderCompletion": "sender complete",
                     "passiveCompletion": "passive complete",
+                    "routeStage": "route-discovered",
+                    "routeEvidence": "passive_logcat.log: route discovered",
+                    "senderRouteStage": "route-discovered",
+                    "passiveRouteStage": "route-discovered",
+                    "startupTiming": {"sender": {"startupWaitSeconds": 2.0}, "passive": {"startupWaitSeconds": 2.5}},
                     "timings": {"totalSeconds": 4.2, "transportMode": "meshlink"},
                     "htmlReportPath": "summary.html",
+                    "exportRelativePath": "android_export.json",
+                    "evidence": {
+                        "senderLogcat": "sender_logcat.log",
+                        "passiveLogcat": "passive_logcat.log",
+                        "senderStart": "sender_start.txt",
+                        "passiveStart": "passive_start.txt",
+                        "androidHistory": "android_history.json",
+                        "androidExport": "android_export.json",
+                    },
+                    "captured": {
+                        "senderLogcat": True,
+                        "passiveLogcat": True,
+                        "senderStart": True,
+                        "passiveStart": True,
+                        "androidHistory": True,
+                        "androidExport": True,
+                    },
+                    "summaryPath": str(run_root / "01_a065_nam_lx9_final" / "summary.json"),
+                    "runDir": str(run_root / "01_a065_nam_lx9_final"),
                     "stdoutTail": "",
                     "stderrTail": "",
                     "elapsedSeconds": 4.2,
@@ -214,9 +262,15 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             self.assertTrue(fleet_json["failFast"])
             self.assertEqual(fleet_json["deviceCount"], 3)
             self.assertEqual([device["serial"] for device in fleet_json["devices"]], ["1f1dad34", "2ASVB21B09005117", "42004386e43c8589"])
+            report_text = (run_root / "01_a065_nam_lx9_report.md").read_text(encoding="utf-8")
             self.assertTrue((run_root / "01_a065_nam_lx9_report.md").exists())
-            self.assertIn("sequenceDiagram", (run_root / "01_a065_nam_lx9_report.md").read_text(encoding="utf-8"))
-            self.assertIn("fail-fast stop after final failure", (run_root / "01_a065_nam_lx9_report.md").read_text(encoding="utf-8"))
+            self.assertIn("sequenceDiagram", report_text)
+            self.assertIn("fail-fast stop after final failure", report_text)
+            self.assertIn("sender_logcat.log", report_text)
+            self.assertIn("passive_logcat.log", report_text)
+            self.assertIn("summary.json", report_text)
+            self.assertIn("Startup timing", report_text)
+            self.assertIn("Captured evidence map", report_text)
             results = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]["final"]["status"], "failed")

--- a/reports/INDEX.md
+++ b/reports/INDEX.md
@@ -13,7 +13,7 @@ reports/android-direct-proof-fleet/runs/<timestamp>/
 
 Latest tracked run:
 
-- [20260618T114257](android-direct-proof-fleet/runs/20260618T114257/INDEX.md)
+- [20260618T114257](android-direct-proof-fleet/runs/20260618T114257/INDEX.md) — [summary](android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md)
 
 Contents of each run:
 

--- a/reports/INDEX.md
+++ b/reports/INDEX.md
@@ -1,0 +1,32 @@
+# Reports index
+
+This directory is the repository-tracked home for generated reports.
+Use it to find fleet runs quickly without digging through workflow artifacts.
+
+## Android direct-proof fleet reports
+
+Default output directory:
+
+```text
+reports/android-direct-proof-fleet/runs/<timestamp>/
+```
+
+Latest tracked run:
+
+- [20260618T114257](android-direct-proof-fleet/runs/20260618T114257/INDEX.md)
+
+Contents of each run:
+
+- `fleet.json`
+- `fleet.md`
+- `matrix-results.json`
+- `matrix-report.md`
+- `NN_<pair_label>_report.md`
+- `NN_<pair_label>_initial/`
+- `NN_<pair_label>_final/`
+
+For the layout explanation, see:
+
+- [Android direct-proof fleet reports](../docs/reference/android-direct-proof-fleet-reports.md)
+- [Android direct-proof fleet report layout](../docs/reference/android-direct-proof-fleet-report-layout.md)
+- [Reports README](README.md)

--- a/reports/README.md
+++ b/reports/README.md
@@ -3,7 +3,7 @@
 Repository-tracked generated reports live here so fleet runs are easy to find, diff, and review.
 
 Start with [INDEX.md](INDEX.md) for the canonical report locations and links into the docs.
-The currently tracked example run lives at [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](android-direct-proof-fleet/runs/20260618T114257/INDEX.md).
+The currently tracked example run lives at [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](android-direct-proof-fleet/runs/20260618T114257/INDEX.md), and its concise summary is [SUMMARY.md](android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md).
 
 ## Android direct-proof fleet reports
 

--- a/reports/README.md
+++ b/reports/README.md
@@ -2,6 +2,9 @@
 
 Repository-tracked generated reports live here so fleet runs are easy to find, diff, and review.
 
+Start with [INDEX.md](INDEX.md) for the canonical report locations and links into the docs.
+The currently tracked example run lives at [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](android-direct-proof-fleet/runs/20260618T114257/INDEX.md).
+
 ## Android direct-proof fleet reports
 
 The Android direct-proof fleet sweep writes its default output under:

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,20 @@
+# Reports
+
+Repository-tracked generated reports live here so fleet runs are easy to find, diff, and review.
+
+## Android direct-proof fleet reports
+
+The Android direct-proof fleet sweep writes its default output under:
+
+```text
+reports/android-direct-proof-fleet/runs/<timestamp>/
+├── fleet.json
+├── fleet.md
+├── matrix-results.json
+├── matrix-report.md
+├── 01_a065_nam_lx9_report.md
+├── 01_a065_nam_lx9_initial/
+└── 01_a065_nam_lx9_final/
+```
+
+See [Android direct-proof fleet reports](../docs/reference/android-direct-proof-fleet-reports.md) for the full artifact guide.

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/android_export.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/android_export.json
@@ -1,0 +1,7 @@
+{
+  "defaultMode": "redacted-preview",
+  "fullPayloadIncluded": false,
+  "operatorOptInRecorded": false,
+  "transport": "gatt",
+  "note": "proof-app passive export not available"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/android_history.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/android_history.json
@@ -1,0 +1,5 @@
+{
+  "transport": "gatt",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "note": "proof-app passive retained evidence is log-only"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/passive_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/passive_logcat.log
@@ -1,0 +1,16 @@
+--------- beginning of main
+06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype
+06-18 11:44:28.889 17954 17985 I MeshLinkProof: GATT benchmark server opening
+06-18 11:44:28.891 17954 17985 I MeshLinkProof: gatt.benchmark.start() -> Started
+06-18 11:44:29.025 17954 17954 I MeshLinkProof: GATT benchmark advertising started service=4d455348-1001-1000-8000-000000000000
+06-18 11:44:30.402 17954 17974 I MeshLinkProof: GATT benchmark connection addr=52:15:AC:2B:DF:78 status=0 state=CONNECTED
+06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:44:30.405 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:44:30.406 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION HOP_SESSION_ESTABLISHED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:44:31.228 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:44:31.266 17954 17974 I MeshLinkProof: GATT benchmark start addr=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51
+06-18 11:44:31.509 17954 17974 I MeshLinkProof: MSG from gatt bytes=51 benchmarkToken=54487b8274844eff
+06-18 11:44:31.513 17954 17974 I MeshLinkProof: GATT benchmark receipt notify addr=52:15:AC:2B:DF:78 token=54487b8274844eff status=true
+06-18 11:44:31.515 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51
+06-18 11:44:31.517 17954 17974 I MeshLinkProof: GATT benchmark notification sent addr=52:15:AC:2B:DF:78 status=0
+06-18 11:44:32.568 17954 17974 I MeshLinkProof: GATT benchmark connection addr=52:15:AC:2B:DF:78 status=0 state=DISCONNECTED

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/sender_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/sender_logcat.log
@@ -1,0 +1,73 @@
+--------- beginning of main
+06-18 11:44:30.027 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION readAutomationConfig enabled=true mode=live-proof role=sender benchmarkTransport=gatt-notify
+06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final
+06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onCreate interactive=true powerSaveMode=false directProof=true
+06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=SENDER benchmarkTransport=gatt-notify
+06-18 11:44:30.044 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION gatt.server.evaluate role=SENDER benchmarkTransport=gatt-notify passiveGattRequested=false
+06-18 11:44:30.046 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 transport=gatt-benchmark
+06-18 11:44:30.046 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION send.requested role=sender
+06-18 11:44:30.047 15326 15326 I MeshLinkReferenceAutomation: GATT benchmark scanning appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:44:30.047 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Scanning(GATT benchmark)
+06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -> Started
+06-18 11:44:30.057 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:44:30.058 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup.coordinator.skipped mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify appId=demo.meshlink.reference.android-direct.a065_nam_lx9 controller=LiveReferenceMeshLinkController reason=non-meshlink-benchmark-transport
+06-18 11:44:30.074 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true
+06-18 11:44:30.164 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:44:30.164 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.created surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:44:30.169 15326 15359 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION session.controller.start kind=SUPPORTED_LIVE platform=Android
+06-18 11:44:30.169 15326 15359 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.dispatch surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:44:30.169 15326 15359 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.start surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:44:30.203 15326 15359 I MeshLinkReferenceAutomation: startTransport hardware scanner=true advertiser=true carrier=UUID_PAIR
+06-18 11:44:30.207 15326 15359 I MeshLinkReferenceAutomation: start() with l2capPsm=218
+06-18 11:44:30.208 15326 15359 I MeshLinkReferenceAutomation: refreshDiscoveryState started=true suspended=false scanner=true advertiser=true psm=218 carrier=UUID_PAIR
+06-18 11:44:30.208 15326 15359 I MeshLinkReferenceAutomation: scan requested mode=2 carrier=UUID_PAIR
+06-18 11:44:30.213 15326 15359 I MeshLinkReferenceAutomation: scan start invoked carrier=UUID_PAIR
+06-18 11:44:30.213 15326 15359 I MeshLinkReferenceAutomation: scan started
+06-18 11:44:30.213 15326 15359 I MeshLinkReferenceAutomation: advertise requested mode=2 carrier=UUID_PAIR payloadPsm=218
+06-18 11:44:30.215 15326 15359 I MeshLinkReferenceAutomation: advertise start invoked carrier=UUID_PAIR payloadPsm=218
+06-18 11:44:30.215 15326 15359 I MeshLinkReferenceAutomation: advertise requested carrier=UUID_PAIR payloadPsm=218
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peers role=SENDER count=0 suffixes=
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.waiting role=sender reason=no-peers
+06-18 11:44:30.262 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=1 delayMs=5000
+06-18 11:44:30.430 15326 15326 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true
+06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: GATT benchmark discovered device=7D:21:98:F3:63:4C rssi=-33
+06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Connecting(GATT benchmark)
+06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge
+06-18 11:44:30.720 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark connection status=0 state=CONNECTED
+06-18 11:44:30.720 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Configuring(GATT benchmark)
+06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge
+06-18 11:44:31.223 15326 15326 I MeshLinkReferenceAutomation: GATT benchmark service discovery retry attempt=1
+06-18 11:44:31.521 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark services discovered status=0
+06-18 11:44:31.521 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark characteristics ready write=4d455348-1002-1000-8000-000000000000 ack=4d455348-1003-1000-8000-000000000000
+06-18 11:44:31.545 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark notifications enabled
+06-18 11:44:31.545 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Running(GATT benchmark)
+06-18 11:44:31.545 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark start token=54487b8274844eff bytes=51 chunks=5
+06-18 11:44:31.585 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark data token=54487b8274844eff chunk=1/5 bytes=11
+06-18 11:44:31.610 15326 15375 I MeshLinkReferenceAutomation: GATT benchmark data token=54487b8274844eff chunk=2/5 bytes=11
+06-18 11:44:31.667 15326 15339 I MeshLinkReferenceAutomation: GATT benchmark data token=54487b8274844eff chunk=3/5 bytes=11
+06-18 11:44:31.731 15326 15339 I MeshLinkReferenceAutomation: GATT benchmark data token=54487b8274844eff chunk=4/5 bytes=11
+06-18 11:44:31.789 15326 15339 I MeshLinkReferenceAutomation: GATT benchmark data token=54487b8274844eff chunk=5/5 bytes=7
+06-18 11:44:31.855 15326 15339 I MeshLinkReferenceAutomation: BENCHMARK receipt send(844eff) -> Sent token=54487b8274844eff bytes=51 attempt=1
+06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: GATT benchmark completed token=54487b8274844eff bytes=51
+06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Completed(GATT benchmark)
+06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender
+06-18 11:44:35.268 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:44:35.268 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:44:35.269 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:35.269 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:35.270 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=2 delayMs=5000
+06-18 11:44:40.275 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:44:40.275 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:44:40.276 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:40.276 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:40.276 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=3 delayMs=5000
+06-18 11:44:45.282 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:44:45.282 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:44:45.283 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:45.284 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:44:45.284 15326 15357 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=4 delayMs=5000

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_nam_lx9</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge pass">passed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_nam_lx9 · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>passed</td></tr><tr><th>Failure stage</th><td>—</td></tr><tr><th>Failure reason</th><td>—</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>2ASVB21B09005117</td></tr><tr><th>Route stage</th><td>route-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>18.000s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive transport wait</th><td>0.000s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.435s</td></tr><tr><th>Sender trust connection</th><td>0.243s</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>1.813s</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>0.001s</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;install&quot;: {
+    &quot;passiveReused&quot;: true,
+    &quot;passiveSeconds&quot;: null,
+    &quot;senderReused&quot;: true,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;launch&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: null,
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.0,
+    &quot;line&quot;: &quot;06-18 11:44:28.891 17954 17985 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;permissions&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 0.2,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 0.1
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 18.0
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:44:31.515 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: 1.111,
+    &quot;sendRequestMarker&quot;: &quot;06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:44:30.405 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.001
+  },
+  &quot;passiveInstallReused&quot;: true,
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.435,
+    &quot;sendCompletionSeconds&quot;: 1.813,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.243
+  },
+  &quot;senderInstallReused&quot;: true,
+  &quot;totalSeconds&quot;: 18.0,
+  &quot;transportEvidence&quot;: &quot;06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.json
@@ -1,0 +1,119 @@
+{
+  "status": "passed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "storageSubdirectory": "01_a065_nam_lx9_final",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "2ASVB21B09005117",
+  "senderCompletion": "06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+  "passiveCompletion": null,
+  "senderPowerState": "06-18 11:44:30.074 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "route-discovered",
+  "routeEvidence": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "route-discovered",
+  "senderRouteEvidence": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": "route-discovered",
+  "passiveRouteEvidence": "06-18 11:44:31.228 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.0,
+      "line": "06-18 11:44:28.891 17954 17985 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": false,
+      "passiveReused": false,
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 18.0,
+    "install": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": true,
+      "passiveReused": true
+    },
+    "permissions": {
+      "senderSeconds": 0.1,
+      "passiveSeconds": 0.2,
+      "senderReused": false,
+      "passiveReused": false
+    }
+  },
+  "timings": {
+    "totalSeconds": 18.0,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+      "peerDiscoverySeconds": 0.435,
+      "peerDiscoveryMarker": "06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": 0.243,
+      "trustConnectionMarker": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": 1.813,
+      "sendRequestMarker": null,
+      "completionMarker": "06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "trustConnectionSeconds": 0.001,
+      "trustConnectionMarker": "06-18 11:44:30.405 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "sendLatencySeconds": 1.111,
+      "receiptSeconds": null,
+      "sendRequestMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "completionMarker": "06-18 11:44:31.515 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "senderInstallReused": true,
+    "passiveInstallReused": true
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": true,
+    "androidExport": true
+  },
+  "discoveredPeerId": null
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/.android-install-cache-1f1dad34.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/.android-install-cache-1f1dad34.json
@@ -1,0 +1,5 @@
+{
+  "sourceFingerprint": "7b2aa2a08ddd4137521e0d8101d19e997abf714f:dirty",
+  "apkPath": "/home/phil/Projects/MeshLink/meshlink-reference/android/build/outputs/apk/debug/android-debug.apk",
+  "apkHash": "92a6071f28b7eba5da955a6b86b8c82e851d46ef80f937abfe811d0dee5e770e"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/android_export.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/android_export.json
@@ -1,0 +1,7 @@
+{
+  "defaultMode": "redacted-preview",
+  "fullPayloadIncluded": false,
+  "operatorOptInRecorded": false,
+  "transport": "gatt",
+  "note": "proof-app passive export not available"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/android_history.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/android_history.json
@@ -1,0 +1,5 @@
+{
+  "transport": "gatt",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "note": "proof-app passive retained evidence is log-only"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/passive_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/passive_logcat.log
@@ -1,0 +1,16 @@
+--------- beginning of main
+06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype
+06-18 11:43:06.098 17667 17730 I MeshLinkProof: GATT benchmark server opening
+06-18 11:43:06.100 17667 17730 I MeshLinkProof: gatt.benchmark.start() -> Started
+06-18 11:43:06.272 17667 17667 I MeshLinkProof: GATT benchmark advertising started service=4d455348-1001-1000-8000-000000000000
+06-18 11:43:07.809 17667 17711 I MeshLinkProof: GATT benchmark connection addr=52:15:AC:2B:DF:78 status=0 state=CONNECTED
+06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION HOP_SESSION_ESTABLISHED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:43:09.384 17667 17689 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:43:09.434 17667 17689 I MeshLinkProof: GATT benchmark start addr=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51
+06-18 11:43:09.698 17667 17711 I MeshLinkProof: MSG from gatt bytes=51 benchmarkToken=df870458685d420d
+06-18 11:43:09.700 17667 17711 I MeshLinkProof: GATT benchmark receipt notify addr=52:15:AC:2B:DF:78 token=df870458685d420d status=true
+06-18 11:43:09.701 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51
+06-18 11:43:09.703 17667 17711 I MeshLinkProof: GATT benchmark notification sent addr=52:15:AC:2B:DF:78 status=0
+06-18 11:43:10.782 17667 17711 I MeshLinkProof: GATT benchmark connection addr=52:15:AC:2B:DF:78 status=0 state=DISCONNECTED

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/sender_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/sender_logcat.log
@@ -1,0 +1,74 @@
+--------- beginning of main
+06-18 11:43:07.200 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION readAutomationConfig enabled=true mode=live-proof role=sender benchmarkTransport=gatt-notify
+06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial
+06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onCreate interactive=true powerSaveMode=false directProof=true
+06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=SENDER benchmarkTransport=gatt-notify
+06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION gatt.server.evaluate role=SENDER benchmarkTransport=gatt-notify passiveGattRequested=false
+06-18 11:43:07.218 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 transport=gatt-benchmark
+06-18 11:43:07.218 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION send.requested role=sender
+06-18 11:43:07.220 15129 15129 I MeshLinkReferenceAutomation: GATT benchmark scanning appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:43:07.220 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Scanning(GATT benchmark)
+06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -> Started
+06-18 11:43:07.229 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:43:07.230 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup.coordinator.skipped mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify appId=demo.meshlink.reference.android-direct.a065_nam_lx9 controller=LiveReferenceMeshLinkController reason=non-meshlink-benchmark-transport
+06-18 11:43:07.246 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true
+06-18 11:43:07.340 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:43:07.340 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.created surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:43:07.345 15129 15168 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION session.controller.start kind=SUPPORTED_LIVE platform=Android
+06-18 11:43:07.345 15129 15168 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.dispatch surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:43:07.345 15129 15168 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.start surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_nam_lx9
+06-18 11:43:07.381 15129 15168 I MeshLinkReferenceAutomation: startTransport hardware scanner=true advertiser=true carrier=UUID_PAIR
+06-18 11:43:07.388 15129 15168 I MeshLinkReferenceAutomation: start() with l2capPsm=217
+06-18 11:43:07.389 15129 15168 I MeshLinkReferenceAutomation: refreshDiscoveryState started=true suspended=false scanner=true advertiser=true psm=217 carrier=UUID_PAIR
+06-18 11:43:07.389 15129 15168 I MeshLinkReferenceAutomation: scan requested mode=2 carrier=UUID_PAIR
+06-18 11:43:07.392 15129 15168 I MeshLinkReferenceAutomation: scan start invoked carrier=UUID_PAIR
+06-18 11:43:07.392 15129 15168 I MeshLinkReferenceAutomation: scan started
+06-18 11:43:07.392 15129 15168 I MeshLinkReferenceAutomation: advertise requested mode=2 carrier=UUID_PAIR payloadPsm=217
+06-18 11:43:07.393 15129 15168 I MeshLinkReferenceAutomation: advertise start invoked carrier=UUID_PAIR payloadPsm=217
+06-18 11:43:07.393 15129 15168 I MeshLinkReferenceAutomation: advertise requested carrier=UUID_PAIR payloadPsm=217
+06-18 11:43:07.395 15129 15168 I MeshLinkReferenceAutomation: REFERENCE_RUNTIME diagnostic code=MESH_STARTED stage=lifecycle.start peer=none detail=MESH_STARTED @ lifecycle.start
+06-18 11:43:07.438 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:43:07.438 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial
+06-18 11:43:07.438 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:43:07.438 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peers role=SENDER count=0 suffixes=
+06-18 11:43:07.438 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:07.438 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:07.439 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.waiting role=sender reason=no-peers
+06-18 11:43:07.439 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=1 delayMs=5000
+06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: GATT benchmark discovered device=59:E2:3C:73:CB:2F rssi=-34
+06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Connecting(GATT benchmark)
+06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge
+06-18 11:43:07.610 15129 15129 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true
+06-18 11:43:08.126 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark connection status=0 state=CONNECTED
+06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Configuring(GATT benchmark)
+06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge
+06-18 11:43:08.632 15129 15129 I MeshLinkReferenceAutomation: GATT benchmark service discovery retry attempt=1
+06-18 11:43:09.675 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark services discovered status=0
+06-18 11:43:09.675 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark characteristics ready write=4d455348-1002-1000-8000-000000000000 ack=4d455348-1003-1000-8000-000000000000
+06-18 11:43:09.701 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark notifications enabled
+06-18 11:43:09.702 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Running(GATT benchmark)
+06-18 11:43:09.702 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark start token=df870458685d420d bytes=51 chunks=5
+06-18 11:43:09.757 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark data token=df870458685d420d chunk=1/5 bytes=11
+06-18 11:43:09.797 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark data token=df870458685d420d chunk=2/5 bytes=11
+06-18 11:43:09.859 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark data token=df870458685d420d chunk=3/5 bytes=11
+06-18 11:43:09.919 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark data token=df870458685d420d chunk=4/5 bytes=11
+06-18 11:43:09.977 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark data token=df870458685d420d chunk=5/5 bytes=7
+06-18 11:43:10.040 15129 15148 I MeshLinkReferenceAutomation: BENCHMARK receipt send(5d420d) -> Sent token=df870458685d420d bytes=51 attempt=1
+06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: GATT benchmark completed token=df870458685d420d bytes=51
+06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Completed(GATT benchmark)
+06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender
+06-18 11:43:12.443 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:43:12.444 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:43:12.444 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:12.444 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:12.444 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=2 delayMs=5000
+06-18 11:43:17.447 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:43:17.447 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:43:17.447 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:17.448 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:17.448 15129 15180 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=3 delayMs=5000
+06-18 11:43:22.452 15129 15174 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:43:22.452 15129 15174 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:43:22.453 15129 15174 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:22.453 15129 15174 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:43:22.453 15129 15174 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=4 delayMs=5000

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_nam_lx9</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge pass">passed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_nam_lx9 · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>passed</td></tr><tr><th>Failure stage</th><td>—</td></tr><tr><th>Failure reason</th><td>—</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>2ASVB21B09005117</td></tr><tr><th>Route stage</th><td>route-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>27.400s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive transport wait</th><td>0.000s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.388s</td></tr><tr><th>Sender trust connection</th><td>0.523s</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>2.825s</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>0.001s</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;install&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 6.7,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 8.5
+  },
+  &quot;launch&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: null,
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.0,
+    &quot;line&quot;: &quot;06-18 11:43:06.100 17667 17730 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;permissions&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 0.1,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 0.1
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 27.4
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:43:09.701 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: 1.891,
+    &quot;sendRequestMarker&quot;: &quot;06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.001
+  },
+  &quot;passiveInstallReused&quot;: false,
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.388,
+    &quot;sendCompletionSeconds&quot;: 2.825,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.523
+  },
+  &quot;senderInstallReused&quot;: false,
+  &quot;totalSeconds&quot;: 27.4,
+  &quot;transportEvidence&quot;: &quot;06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.json
@@ -1,0 +1,119 @@
+{
+  "status": "passed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "storageSubdirectory": "01_a065_nam_lx9_initial",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "2ASVB21B09005117",
+  "senderCompletion": "06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+  "passiveCompletion": null,
+  "senderPowerState": "06-18 11:43:07.246 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "route-discovered",
+  "routeEvidence": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "route-discovered",
+  "senderRouteEvidence": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": "route-discovered",
+  "passiveRouteEvidence": "06-18 11:43:09.384 17667 17689 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.0,
+      "line": "06-18 11:43:06.100 17667 17730 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": false,
+      "passiveReused": false,
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 27.4,
+    "install": {
+      "senderSeconds": 8.5,
+      "passiveSeconds": 6.7,
+      "senderReused": false,
+      "passiveReused": false
+    },
+    "permissions": {
+      "senderSeconds": 0.1,
+      "passiveSeconds": 0.1,
+      "senderReused": false,
+      "passiveReused": false
+    }
+  },
+  "timings": {
+    "totalSeconds": 27.4,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+      "peerDiscoverySeconds": 0.388,
+      "peerDiscoveryMarker": "06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": 0.523,
+      "trustConnectionMarker": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": 2.825,
+      "sendRequestMarker": null,
+      "completionMarker": "06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "trustConnectionSeconds": 0.001,
+      "trustConnectionMarker": "06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "sendLatencySeconds": 1.891,
+      "receiptSeconds": null,
+      "sendRequestMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "completionMarker": "06-18 11:43:09.701 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "senderInstallReused": false,
+    "passiveInstallReused": false
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": true,
+    "androidExport": true
+  },
+  "discoveredPeerId": null
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_report.md
@@ -1,0 +1,277 @@
+# Pair 01 — a065_nam_lx9
+
+## Setup
+
+- Sender: A065 (1f1dad34)
+- Passive: NAM-LX9 (2ASVB21B09005117)
+- Sender API level: 36
+- Passive API level: 31
+- Transport: GATT
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md`
+- Pair report path: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_report.md`
+- Peer lookup time: 63.7s
+- Initial run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial`
+- Final run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final`
+
+## Result
+
+- Initial status: passed (no failure stage) in 27.5s
+- Final status: passed (no failure stage) in 18.1s
+- Target peer id: not resolved
+- Initial HTML report: `summary.html`
+- Final HTML report: `summary.html`
+- Initial summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.json`
+- Final summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.json`
+
+## Troubleshooting references
+
+| Initial artifact | Path | Captured |
+|---|---|---|
+| Initial senderLogcat | `sender_logcat.log` | yes |
+| Initial passiveLogcat | `passive_logcat.log` | yes |
+| Initial senderStart | `sender_start.txt` | yes |
+| Initial passiveStart | `passive_start.txt` | yes |
+| Initial androidHistory | `android_history.json` | yes |
+| Initial androidExport | `android_export.json` | yes |
+| Final artifact | Path | Captured |
+|---|---|---|
+| Final senderLogcat | `sender_logcat.log` | yes |
+| Final passiveLogcat | `passive_logcat.log` | yes |
+| Final senderStart | `sender_start.txt` | yes |
+| Final passiveStart | `passive_start.txt` | yes |
+| Final androidHistory | `android_history.json` | yes |
+| Final androidExport | `android_export.json` | yes |
+
+## Device quirks and issues
+
+- Transport used for the pair: GATT
+- Fallback reason: android API below 33; using GATT fallback (senderApiLevel=36 passiveApiLevel=31)
+- Passive API level 31 is below the floor 33.
+
+## Startup timing
+
+Initial startupTiming
+
+```json
+{
+  "install": {
+    "passiveReused": false,
+    "passiveSeconds": 6.7,
+    "senderReused": false,
+    "senderSeconds": 8.5
+  },
+  "launch": {
+    "passiveReused": false,
+    "passiveSeconds": null,
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0,
+    "senderReused": false,
+    "senderSeconds": null
+  },
+  "passive": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.0,
+    "line": "06-18 11:43:06.100 17667 17730 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "permissions": {
+    "passiveReused": false,
+    "passiveSeconds": 0.1,
+    "senderReused": false,
+    "senderSeconds": 0.1
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+    "observed": true
+  },
+  "totalSeconds": 27.4
+}
+```
+
+Initial timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": "06-18 11:43:09.701 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51",
+    "peerDiscoveryMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": 1.891,
+    "sendRequestMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "trustConnectionSeconds": 0.001
+  },
+  "passiveInstallReused": false,
+  "sender": {
+    "completionMarker": "06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+    "peerDiscoveryMarker": "06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.388,
+    "sendCompletionSeconds": 2.825,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+    "trustConnectionSeconds": 0.523
+  },
+  "senderInstallReused": false,
+  "totalSeconds": 27.4,
+  "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Final startupTiming
+
+```json
+{
+  "install": {
+    "passiveReused": true,
+    "passiveSeconds": null,
+    "senderReused": true,
+    "senderSeconds": null
+  },
+  "launch": {
+    "passiveReused": false,
+    "passiveSeconds": null,
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0,
+    "senderReused": false,
+    "senderSeconds": null
+  },
+  "passive": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.0,
+    "line": "06-18 11:44:28.891 17954 17985 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "permissions": {
+    "passiveReused": false,
+    "passiveSeconds": 0.2,
+    "senderReused": false,
+    "senderSeconds": 0.1
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+    "observed": true
+  },
+  "totalSeconds": 18.0
+}
+```
+
+Final timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": "06-18 11:44:31.515 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51",
+    "peerDiscoveryMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": 1.111,
+    "sendRequestMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:44:30.405 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "trustConnectionSeconds": 0.001
+  },
+  "passiveInstallReused": true,
+  "sender": {
+    "completionMarker": "06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+    "peerDiscoveryMarker": "06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.435,
+    "sendCompletionSeconds": 1.813,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+    "trustConnectionSeconds": 0.243
+  },
+  "senderInstallReused": true,
+  "totalSeconds": 18.0,
+  "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Captured evidence map
+
+```json
+{
+  "final": {
+    "androidExport": true,
+    "androidHistory": true,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  },
+  "initial": {
+    "androidExport": true,
+    "androidHistory": true,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  }
+}
+```
+
+## Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Matrix
+    participant Sender as A065
+    participant Passive as NAM-LX9
+    note over Matrix: transport GATT
+    note over Matrix: fleet inventory fleet.md
+    note over Matrix: pair report 01_a065_nam_lx9_report.md
+    Matrix->>Sender: initial run (27.5s)
+    note over Sender: passed (no failure stage)
+    alt initial passed
+        Matrix->>Passive: read passive peer id (63.7s)
+        note over Matrix: target peer not resolved
+        Matrix->>Sender: final run (18.1s)
+        note over Sender: passed (no failure stage)
+        alt final passed
+            note over Matrix: pair completed successfully
+        else final failed
+            note over Matrix: fail-fast stop after final failure
+        end
+    else initial failed
+        note over Matrix: fail-fast stop after initial failure
+    end
+```

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/android_export.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/android_export.json
@@ -1,0 +1,7 @@
+{
+  "defaultMode": "redacted-preview",
+  "fullPayloadIncluded": false,
+  "operatorOptInRecorded": false,
+  "transport": "gatt",
+  "note": "proof-app passive export not available"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/android_history.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/android_history.json
@@ -1,0 +1,5 @@
+{
+  "transport": "gatt",
+  "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+  "note": "proof-app passive retained evidence is log-only"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/passive_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/passive_logcat.log
@@ -1,0 +1,17 @@
+--------- beginning of system
+--------- beginning of main
+06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype
+06-18 11:46:24.353 18355 18375 I MeshLinkProof: GATT benchmark server opening
+06-18 11:46:24.359 18355 18375 I MeshLinkProof: gatt.benchmark.start() -> Started
+06-18 11:46:24.576 18355 18355 I MeshLinkProof: GATT benchmark advertising started service=4d455348-1001-1000-8000-000000000000
+06-18 11:46:25.887 18355 18368 I MeshLinkProof: GATT benchmark connection addr=7C:9B:EE:F8:58:1D status=0 state=CONNECTED
+06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D
+06-18 11:46:25.911 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D
+06-18 11:46:25.919 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION HOP_SESSION_ESTABLISHED role=PASSIVE peer=7C:9B:EE:F8:58:1D
+06-18 11:46:26.448 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D
+06-18 11:46:26.613 18355 18368 I MeshLinkProof: GATT benchmark start addr=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50
+06-18 11:46:26.955 18355 18368 I MeshLinkProof: MSG from gatt bytes=50 benchmarkToken=1c01054e65ee4bb3
+06-18 11:46:26.968 18355 18368 I MeshLinkProof: GATT benchmark receipt notify addr=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 status=true
+06-18 11:46:26.977 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50
+06-18 11:46:26.987 18355 18368 I MeshLinkProof: GATT benchmark notification sent addr=7C:9B:EE:F8:58:1D status=0
+06-18 11:46:28.005 18355 18368 I MeshLinkProof: GATT benchmark connection addr=7C:9B:EE:F8:58:1D status=0 state=DISCONNECTED

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/sender_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/sender_logcat.log
@@ -1,0 +1,74 @@
+--------- beginning of main
+06-18 11:46:26.048 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION readAutomationConfig enabled=true mode=live-proof role=sender benchmarkTransport=gatt-notify
+06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final
+06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onCreate interactive=true powerSaveMode=false directProof=true
+06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=SENDER benchmarkTransport=gatt-notify
+06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION gatt.server.evaluate role=SENDER benchmarkTransport=gatt-notify passiveGattRequested=false
+06-18 11:46:26.066 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover transport=gatt-benchmark
+06-18 11:46:26.066 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION send.requested role=sender
+06-18 11:46:26.068 15875 15875 I MeshLinkReferenceAutomation: GATT benchmark scanning appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:46:26.068 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Scanning(GATT benchmark)
+06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -> Started
+06-18 11:46:26.077 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:46:26.078 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup.coordinator.skipped mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify appId=demo.meshlink.reference.android-direct.a065_xcover controller=LiveReferenceMeshLinkController reason=non-meshlink-benchmark-transport
+06-18 11:46:26.094 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true
+06-18 11:46:26.188 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:46:26.188 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.created surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:46:26.193 15875 15902 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION session.controller.start kind=SUPPORTED_LIVE platform=Android
+06-18 11:46:26.193 15875 15902 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.dispatch surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:46:26.193 15875 15902 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.start surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:46:26.236 15875 15902 I MeshLinkReferenceAutomation: startTransport hardware scanner=true advertiser=true carrier=UUID_PAIR
+06-18 11:46:26.239 15875 15902 I MeshLinkReferenceAutomation: start() with l2capPsm=220
+06-18 11:46:26.240 15875 15902 I MeshLinkReferenceAutomation: refreshDiscoveryState started=true suspended=false scanner=true advertiser=true psm=220 carrier=UUID_PAIR
+06-18 11:46:26.241 15875 15902 I MeshLinkReferenceAutomation: scan requested mode=2 carrier=UUID_PAIR
+06-18 11:46:26.244 15875 15902 I MeshLinkReferenceAutomation: scan start invoked carrier=UUID_PAIR
+06-18 11:46:26.244 15875 15902 I MeshLinkReferenceAutomation: scan started
+06-18 11:46:26.244 15875 15902 I MeshLinkReferenceAutomation: advertise requested mode=2 carrier=UUID_PAIR payloadPsm=220
+06-18 11:46:26.245 15875 15902 I MeshLinkReferenceAutomation: advertise start invoked carrier=UUID_PAIR payloadPsm=220
+06-18 11:46:26.245 15875 15902 I MeshLinkReferenceAutomation: advertise requested carrier=UUID_PAIR payloadPsm=220
+06-18 11:46:26.246 15875 15906 I MeshLinkReferenceAutomation: REFERENCE_RUNTIME diagnostic code=MESH_STARTED stage=lifecycle.start peer=none detail=MESH_STARTED @ lifecycle.start
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peers role=SENDER count=0 suffixes=
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.waiting role=sender reason=no-peers
+06-18 11:46:26.286 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=1 delayMs=5000
+06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: GATT benchmark discovered device=7B:FB:9F:BF:4E:34 rssi=-65
+06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Connecting(GATT benchmark)
+06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge
+06-18 11:46:26.451 15875 15875 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true
+06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark connection status=0 state=CONNECTED
+06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Configuring(GATT benchmark)
+06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge
+06-18 11:46:27.320 15875 15875 I MeshLinkReferenceAutomation: GATT benchmark service discovery retry attempt=1
+06-18 11:46:27.360 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark services discovered status=0
+06-18 11:46:27.361 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark characteristics ready write=4d455348-1002-1000-8000-000000000000 ack=4d455348-1003-1000-8000-000000000000
+06-18 11:46:27.392 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark notifications enabled
+06-18 11:46:27.392 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Running(GATT benchmark)
+06-18 11:46:27.392 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark start token=1c01054e65ee4bb3 bytes=50 chunks=5
+06-18 11:46:27.584 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark data token=1c01054e65ee4bb3 chunk=1/5 bytes=11
+06-18 11:46:27.640 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark data token=1c01054e65ee4bb3 chunk=2/5 bytes=11
+06-18 11:46:27.701 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark data token=1c01054e65ee4bb3 chunk=3/5 bytes=11
+06-18 11:46:27.792 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark data token=1c01054e65ee4bb3 chunk=4/5 bytes=11
+06-18 11:46:27.851 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark data token=1c01054e65ee4bb3 chunk=5/5 bytes=6
+06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: BENCHMARK receipt send(ee4bb3) -> Sent token=1c01054e65ee4bb3 bytes=50 attempt=1
+06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: GATT benchmark completed token=1c01054e65ee4bb3 bytes=50
+06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Completed(GATT benchmark)
+06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender
+06-18 11:46:31.290 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:46:31.290 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:46:31.291 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:31.291 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:31.291 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=2 delayMs=5000
+06-18 11:46:36.296 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:46:36.296 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:46:36.296 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:36.296 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:36.297 15875 15900 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=3 delayMs=5000
+06-18 11:46:41.300 15875 15904 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:46:41.301 15875 15904 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:46:41.301 15875 15904 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:41.301 15875 15904 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:41.301 15875 15904 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=4 delayMs=5000

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_xcover</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge pass">passed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_xcover · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>passed</td></tr><tr><th>Failure stage</th><td>—</td></tr><tr><th>Failure reason</th><td>—</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>42004386e43c8589</td></tr><tr><th>Route stage</th><td>route-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>18.800s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>1.300s</td></tr>
+<tr><th>Passive transport wait</th><td>0.000s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.351s</td></tr><tr><th>Sender trust connection</th><td>0.403s</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>1.847s</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>1.300s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>0.013s</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;install&quot;: {
+    &quot;passiveReused&quot;: true,
+    &quot;passiveSeconds&quot;: null,
+    &quot;senderReused&quot;: true,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;launch&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: null,
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 1.3,
+    &quot;line&quot;: &quot;06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.0,
+    &quot;line&quot;: &quot;06-18 11:46:24.359 18355 18375 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;permissions&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 0.2,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 0.1
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 18.8
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:46:26.977 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D&quot;,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: 1.079,
+    &quot;sendRequestMarker&quot;: &quot;06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D&quot;,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 1.3,
+    &quot;transportEvidence&quot;: &quot;06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:46:25.911 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.013
+  },
+  &quot;passiveInstallReused&quot;: true,
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.351,
+    &quot;sendCompletionSeconds&quot;: 1.847,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.403
+  },
+  &quot;senderInstallReused&quot;: true,
+  &quot;totalSeconds&quot;: 18.8,
+  &quot;transportEvidence&quot;: &quot;06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.json
@@ -1,0 +1,119 @@
+{
+  "status": "passed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+  "storageSubdirectory": "02_a065_xcover_final",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "42004386e43c8589",
+  "senderCompletion": "06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+  "passiveCompletion": null,
+  "senderPowerState": "06-18 11:46:26.094 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "route-discovered",
+  "routeEvidence": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "route-discovered",
+  "senderRouteEvidence": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": "route-discovered",
+  "passiveRouteEvidence": "06-18 11:46:26.448 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 1.3,
+      "line": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.0,
+      "line": "06-18 11:46:24.359 18355 18375 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": false,
+      "passiveReused": false,
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 18.8,
+    "install": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": true,
+      "passiveReused": true
+    },
+    "permissions": {
+      "senderSeconds": 0.1,
+      "passiveSeconds": 0.2,
+      "senderReused": false,
+      "passiveReused": false
+    }
+  },
+  "timings": {
+    "totalSeconds": 18.8,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final",
+      "peerDiscoverySeconds": 0.351,
+      "peerDiscoveryMarker": "06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": 0.403,
+      "trustConnectionMarker": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": 1.847,
+      "sendRequestMarker": null,
+      "completionMarker": "06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 1.3,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+      "trustConnectionSeconds": 0.013,
+      "trustConnectionMarker": "06-18 11:46:25.911 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+      "sendLatencySeconds": 1.079,
+      "receiptSeconds": null,
+      "sendRequestMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+      "completionMarker": "06-18 11:46:26.977 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "senderInstallReused": true,
+    "passiveInstallReused": true
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": true,
+    "androidExport": true
+  },
+  "discoveredPeerId": null
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/.android-install-cache-1f1dad34.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/.android-install-cache-1f1dad34.json
@@ -1,0 +1,5 @@
+{
+  "sourceFingerprint": "7b2aa2a08ddd4137521e0d8101d19e997abf714f:dirty",
+  "apkPath": "/home/phil/Projects/MeshLink/meshlink-reference/android/build/outputs/apk/debug/android-debug.apk",
+  "apkHash": "92a6071f28b7eba5da955a6b86b8c82e851d46ef80f937abfe811d0dee5e770e"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/android_export.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/android_export.json
@@ -1,0 +1,7 @@
+{
+  "defaultMode": "redacted-preview",
+  "fullPayloadIncluded": false,
+  "operatorOptInRecorded": false,
+  "transport": "gatt",
+  "note": "proof-app passive export not available"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/android_history.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/android_history.json
@@ -1,0 +1,5 @@
+{
+  "transport": "gatt",
+  "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+  "note": "proof-app passive retained evidence is log-only"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/passive_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/passive_logcat.log
@@ -1,0 +1,17 @@
+--------- beginning of main
+--------- beginning of system
+06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype
+06-18 11:45:00.529 17927 18032 I MeshLinkProof: GATT benchmark server opening
+06-18 11:45:00.551 17927 18032 I MeshLinkProof: gatt.benchmark.start() -> Started
+06-18 11:45:00.977 17927 17927 I MeshLinkProof: GATT benchmark advertising started service=4d455348-1001-1000-8000-000000000000
+06-18 11:45:01.926 17927 17946 I MeshLinkProof: GATT benchmark connection addr=52:15:AC:2B:DF:78 status=0 state=CONNECTED
+06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:45:01.935 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:45:01.938 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION HOP_SESSION_ESTABLISHED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:45:02.478 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78
+06-18 11:45:02.658 17927 17946 I MeshLinkProof: GATT benchmark start addr=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50
+06-18 11:45:02.945 17927 17946 I MeshLinkProof: MSG from gatt bytes=50 benchmarkToken=10f093f0885a42e4
+06-18 11:45:02.959 17927 17946 I MeshLinkProof: GATT benchmark receipt notify addr=52:15:AC:2B:DF:78 token=10f093f0885a42e4 status=true
+06-18 11:45:02.967 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50
+06-18 11:45:02.974 17927 17946 I MeshLinkProof: GATT benchmark notification sent addr=52:15:AC:2B:DF:78 status=0
+06-18 11:45:04.027 17927 17946 I MeshLinkProof: GATT benchmark connection addr=52:15:AC:2B:DF:78 status=0 state=DISCONNECTED

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/sender_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/sender_logcat.log
@@ -1,0 +1,74 @@
+--------- beginning of main
+06-18 11:45:02.291 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION readAutomationConfig enabled=true mode=live-proof role=sender benchmarkTransport=gatt-notify
+06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial
+06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onCreate interactive=true powerSaveMode=false directProof=true
+06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=SENDER benchmarkTransport=gatt-notify
+06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION gatt.server.evaluate role=SENDER benchmarkTransport=gatt-notify passiveGattRequested=false
+06-18 11:45:02.309 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover transport=gatt-benchmark
+06-18 11:45:02.309 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION send.requested role=sender
+06-18 11:45:02.310 15576 15576 I MeshLinkReferenceAutomation: GATT benchmark scanning appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:45:02.310 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Scanning(GATT benchmark)
+06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -> Started
+06-18 11:45:02.320 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:45:02.321 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup.coordinator.skipped mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify appId=demo.meshlink.reference.android-direct.a065_xcover controller=LiveReferenceMeshLinkController reason=non-meshlink-benchmark-transport
+06-18 11:45:02.337 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true
+06-18 11:45:02.430 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:45:02.430 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.created surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:45:02.435 15576 15605 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION session.controller.start kind=SUPPORTED_LIVE platform=Android
+06-18 11:45:02.435 15576 15605 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.dispatch surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:45:02.435 15576 15605 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.start surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_xcover
+06-18 11:45:02.472 15576 15605 I MeshLinkReferenceAutomation: startTransport hardware scanner=true advertiser=true carrier=UUID_PAIR
+06-18 11:45:02.476 15576 15605 I MeshLinkReferenceAutomation: start() with l2capPsm=219
+06-18 11:45:02.477 15576 15605 I MeshLinkReferenceAutomation: refreshDiscoveryState started=true suspended=false scanner=true advertiser=true psm=219 carrier=UUID_PAIR
+06-18 11:45:02.477 15576 15605 I MeshLinkReferenceAutomation: scan requested mode=2 carrier=UUID_PAIR
+06-18 11:45:02.481 15576 15605 I MeshLinkReferenceAutomation: scan start invoked carrier=UUID_PAIR
+06-18 11:45:02.481 15576 15605 I MeshLinkReferenceAutomation: scan started
+06-18 11:45:02.481 15576 15605 I MeshLinkReferenceAutomation: advertise requested mode=2 carrier=UUID_PAIR payloadPsm=219
+06-18 11:45:02.482 15576 15605 I MeshLinkReferenceAutomation: advertise start invoked carrier=UUID_PAIR payloadPsm=219
+06-18 11:45:02.483 15576 15605 I MeshLinkReferenceAutomation: advertise requested carrier=UUID_PAIR payloadPsm=219
+06-18 11:45:02.485 15576 15604 I MeshLinkReferenceAutomation: REFERENCE_RUNTIME diagnostic code=MESH_STARTED stage=lifecycle.start peer=none detail=MESH_STARTED @ lifecycle.start
+06-18 11:45:02.527 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:45:02.527 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial
+06-18 11:45:02.527 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:45:02.527 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peers role=SENDER count=0 suffixes=
+06-18 11:45:02.527 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:02.527 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:02.528 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.waiting role=sender reason=no-peers
+06-18 11:45:02.528 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=1 delayMs=5000
+06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: GATT benchmark discovered device=4E:48:75:FC:F6:D7 rssi=-57
+06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Connecting(GATT benchmark)
+06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge
+06-18 11:45:02.693 15576 15576 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true
+06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark connection status=0 state=CONNECTED
+06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Configuring(GATT benchmark)
+06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge
+06-18 11:45:03.348 15576 15576 I MeshLinkReferenceAutomation: GATT benchmark service discovery retry attempt=1
+06-18 11:45:03.395 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark services discovered status=0
+06-18 11:45:03.395 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark characteristics ready write=4d455348-1002-1000-8000-000000000000 ack=4d455348-1003-1000-8000-000000000000
+06-18 11:45:03.432 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark notifications enabled
+06-18 11:45:03.433 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Running(GATT benchmark)
+06-18 11:45:03.433 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark start token=10f093f0885a42e4 bytes=50 chunks=5
+06-18 11:45:03.601 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark data token=10f093f0885a42e4 chunk=1/5 bytes=11
+06-18 11:45:03.663 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark data token=10f093f0885a42e4 chunk=2/5 bytes=11
+06-18 11:45:03.721 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark data token=10f093f0885a42e4 chunk=3/5 bytes=11
+06-18 11:45:03.780 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark data token=10f093f0885a42e4 chunk=4/5 bytes=11
+06-18 11:45:03.842 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark data token=10f093f0885a42e4 chunk=5/5 bytes=6
+06-18 11:45:03.903 15576 15615 I MeshLinkReferenceAutomation: BENCHMARK receipt send(5a42e4) -> Sent token=10f093f0885a42e4 bytes=50 attempt=1
+06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: GATT benchmark completed token=10f093f0885a42e4 bytes=50
+06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Completed(GATT benchmark)
+06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender
+06-18 11:45:07.532 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:45:07.532 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:45:07.532 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:07.532 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:07.532 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=2 delayMs=5000
+06-18 11:45:12.537 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:45:12.537 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:45:12.537 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:12.538 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:12.538 15576 15602 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=3 delayMs=5000
+06-18 11:45:17.544 15576 15603 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:45:17.545 15576 15603 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:45:17.546 15576 15603 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:17.546 15576 15603 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:45:17.547 15576 15603 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=4 delayMs=5000

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_xcover</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge pass">passed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_xcover · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>passed</td></tr><tr><th>Failure stage</th><td>—</td></tr><tr><th>Failure reason</th><td>—</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>42004386e43c8589</td></tr><tr><th>Route stage</th><td>route-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>32.200s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>1.800s</td></tr>
+<tr><th>Passive transport wait</th><td>0.300s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.380s</td></tr><tr><th>Sender trust connection</th><td>0.157s</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>1.597s</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>1.800s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>0.004s</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;install&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 11.7,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 8.6
+  },
+  &quot;launch&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: null,
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 1.8,
+    &quot;line&quot;: &quot;06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.3,
+    &quot;line&quot;: &quot;06-18 11:45:00.551 17927 18032 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;permissions&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 0.2,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 0.1
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 32.2
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:45:02.967 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: 1.036,
+    &quot;sendRequestMarker&quot;: &quot;06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 1.8,
+    &quot;transportEvidence&quot;: &quot;06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:45:01.935 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.004
+  },
+  &quot;passiveInstallReused&quot;: false,
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.38,
+    &quot;sendCompletionSeconds&quot;: 1.597,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.157
+  },
+  &quot;senderInstallReused&quot;: false,
+  &quot;totalSeconds&quot;: 32.2,
+  &quot;transportEvidence&quot;: &quot;06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.json
@@ -1,0 +1,119 @@
+{
+  "status": "passed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+  "storageSubdirectory": "02_a065_xcover_initial",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "42004386e43c8589",
+  "senderCompletion": "06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+  "passiveCompletion": null,
+  "senderPowerState": "06-18 11:45:02.337 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "route-discovered",
+  "routeEvidence": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "route-discovered",
+  "senderRouteEvidence": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": "route-discovered",
+  "passiveRouteEvidence": "06-18 11:45:02.478 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 1.8,
+      "line": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.3,
+      "line": "06-18 11:45:00.551 17927 18032 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": false,
+      "passiveReused": false,
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 32.2,
+    "install": {
+      "senderSeconds": 8.6,
+      "passiveSeconds": 11.7,
+      "senderReused": false,
+      "passiveReused": false
+    },
+    "permissions": {
+      "senderSeconds": 0.1,
+      "passiveSeconds": 0.2,
+      "senderReused": false,
+      "passiveReused": false
+    }
+  },
+  "timings": {
+    "totalSeconds": 32.2,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+      "peerDiscoverySeconds": 0.38,
+      "peerDiscoveryMarker": "06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": 0.157,
+      "trustConnectionMarker": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": 1.597,
+      "sendRequestMarker": null,
+      "completionMarker": "06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 1.8,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "trustConnectionSeconds": 0.004,
+      "trustConnectionMarker": "06-18 11:45:01.935 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "sendLatencySeconds": 1.036,
+      "receiptSeconds": null,
+      "sendRequestMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+      "completionMarker": "06-18 11:45:02.967 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "senderInstallReused": false,
+    "passiveInstallReused": false
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": true,
+    "androidExport": true
+  },
+  "discoveredPeerId": null
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_report.md
@@ -1,0 +1,277 @@
+# Pair 02 — a065_xcover
+
+## Setup
+
+- Sender: A065 (1f1dad34)
+- Passive: SM-G390F (42004386e43c8589)
+- Sender API level: 36
+- Passive API level: 28
+- Transport: GATT
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md`
+- Pair report path: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_report.md`
+- Peer lookup time: 64.9s
+- Initial run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial`
+- Final run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final`
+
+## Result
+
+- Initial status: passed (no failure stage) in 32.3s
+- Final status: passed (no failure stage) in 18.8s
+- Target peer id: not resolved
+- Initial HTML report: `summary.html`
+- Final HTML report: `summary.html`
+- Initial summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.json`
+- Final summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.json`
+
+## Troubleshooting references
+
+| Initial artifact | Path | Captured |
+|---|---|---|
+| Initial senderLogcat | `sender_logcat.log` | yes |
+| Initial passiveLogcat | `passive_logcat.log` | yes |
+| Initial senderStart | `sender_start.txt` | yes |
+| Initial passiveStart | `passive_start.txt` | yes |
+| Initial androidHistory | `android_history.json` | yes |
+| Initial androidExport | `android_export.json` | yes |
+| Final artifact | Path | Captured |
+|---|---|---|
+| Final senderLogcat | `sender_logcat.log` | yes |
+| Final passiveLogcat | `passive_logcat.log` | yes |
+| Final senderStart | `sender_start.txt` | yes |
+| Final passiveStart | `passive_start.txt` | yes |
+| Final androidHistory | `android_history.json` | yes |
+| Final androidExport | `android_export.json` | yes |
+
+## Device quirks and issues
+
+- Transport used for the pair: GATT
+- Fallback reason: android API below 33; using GATT fallback (senderApiLevel=36 passiveApiLevel=28)
+- Passive API level 28 is below the floor 33.
+
+## Startup timing
+
+Initial startupTiming
+
+```json
+{
+  "install": {
+    "passiveReused": false,
+    "passiveSeconds": 11.7,
+    "senderReused": false,
+    "senderSeconds": 8.6
+  },
+  "launch": {
+    "passiveReused": false,
+    "passiveSeconds": null,
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0,
+    "senderReused": false,
+    "senderSeconds": null
+  },
+  "passive": {
+    "elapsedSeconds": 1.8,
+    "line": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.3,
+    "line": "06-18 11:45:00.551 17927 18032 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "permissions": {
+    "passiveReused": false,
+    "passiveSeconds": 0.2,
+    "senderReused": false,
+    "senderSeconds": 0.1
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+    "observed": true
+  },
+  "totalSeconds": 32.2
+}
+```
+
+Initial timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": "06-18 11:45:02.967 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50",
+    "peerDiscoveryMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": 1.036,
+    "sendRequestMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 1.8,
+    "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:45:01.935 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+    "trustConnectionSeconds": 0.004
+  },
+  "passiveInstallReused": false,
+  "sender": {
+    "completionMarker": "06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+    "peerDiscoveryMarker": "06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.38,
+    "sendCompletionSeconds": 1.597,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+    "trustConnectionSeconds": 0.157
+  },
+  "senderInstallReused": false,
+  "totalSeconds": 32.2,
+  "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Final startupTiming
+
+```json
+{
+  "install": {
+    "passiveReused": true,
+    "passiveSeconds": null,
+    "senderReused": true,
+    "senderSeconds": null
+  },
+  "launch": {
+    "passiveReused": false,
+    "passiveSeconds": null,
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0,
+    "senderReused": false,
+    "senderSeconds": null
+  },
+  "passive": {
+    "elapsedSeconds": 1.3,
+    "line": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.0,
+    "line": "06-18 11:46:24.359 18355 18375 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "permissions": {
+    "passiveReused": false,
+    "passiveSeconds": 0.2,
+    "senderReused": false,
+    "senderSeconds": 0.1
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final",
+    "observed": true
+  },
+  "totalSeconds": 18.8
+}
+```
+
+Final timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": "06-18 11:46:26.977 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50",
+    "peerDiscoveryMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": 1.079,
+    "sendRequestMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 1.3,
+    "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:46:25.911 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+    "trustConnectionSeconds": 0.013
+  },
+  "passiveInstallReused": true,
+  "sender": {
+    "completionMarker": "06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+    "peerDiscoveryMarker": "06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.351,
+    "sendCompletionSeconds": 1.847,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+    "trustConnectionSeconds": 0.403
+  },
+  "senderInstallReused": true,
+  "totalSeconds": 18.8,
+  "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Captured evidence map
+
+```json
+{
+  "final": {
+    "androidExport": true,
+    "androidHistory": true,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  },
+  "initial": {
+    "androidExport": true,
+    "androidHistory": true,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  }
+}
+```
+
+## Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Matrix
+    participant Sender as A065
+    participant Passive as SM-G390F
+    note over Matrix: transport GATT
+    note over Matrix: fleet inventory fleet.md
+    note over Matrix: pair report 02_a065_xcover_report.md
+    Matrix->>Sender: initial run (32.3s)
+    note over Sender: passed (no failure stage)
+    alt initial passed
+        Matrix->>Passive: read passive peer id (64.9s)
+        note over Matrix: target peer not resolved
+        Matrix->>Sender: final run (18.8s)
+        note over Sender: passed (no failure stage)
+        alt final passed
+            note over Matrix: pair completed successfully
+        else final failed
+            note over Matrix: fail-fast stop after final failure
+        end
+    else initial failed
+        note over Matrix: fail-fast stop after initial failure
+    end
+```

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/.android-install-cache-1f1dad34.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/.android-install-cache-1f1dad34.json
@@ -1,0 +1,5 @@
+{
+  "sourceFingerprint": "7b2aa2a08ddd4137521e0d8101d19e997abf714f:dirty",
+  "apkPath": "/home/phil/Projects/MeshLink/meshlink-reference/android/build/outputs/apk/debug/android-debug.apk",
+  "apkHash": "92a6071f28b7eba5da955a6b86b8c82e851d46ef80f937abfe811d0dee5e770e"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/passive_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/passive_logcat.log
@@ -1,0 +1,6 @@
+--------- beginning of main
+--------- beginning of system
+06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype
+06-18 05:46:57.056 10554 10633 I MeshLinkProof: GATT benchmark server opening
+06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -> Started
+06-18 05:46:57.232 10554 10554 I MeshLinkProof: GATT benchmark advertising started service=4d455348-1001-1000-8000-000000000000

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/sender_logcat.log
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/sender_logcat.log
@@ -1,0 +1,45 @@
+--------- beginning of main
+06-18 11:46:53.036 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION readAutomationConfig enabled=true mode=live-proof role=sender benchmarkTransport=gatt-notify
+06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial
+06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onCreate interactive=true powerSaveMode=false directProof=true
+06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=SENDER benchmarkTransport=gatt-notify
+06-18 11:46:53.053 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION gatt.server.evaluate role=SENDER benchmarkTransport=gatt-notify passiveGattRequested=false
+06-18 11:46:53.055 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 transport=gatt-benchmark
+06-18 11:46:53.055 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION send.requested role=sender
+06-18 11:46:53.056 16105 16105 I MeshLinkReferenceAutomation: GATT benchmark scanning appId=demo.meshlink.reference.android-direct.a065_mi_note3
+06-18 11:46:53.056 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Scanning(GATT benchmark)
+06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started
+06-18 11:46:53.066 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_mi_note3
+06-18 11:46:53.067 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup.coordinator.skipped mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify appId=demo.meshlink.reference.android-direct.a065_mi_note3 controller=LiveReferenceMeshLinkController reason=non-meshlink-benchmark-transport
+06-18 11:46:53.083 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true
+06-18 11:46:53.179 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.created surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_mi_note3
+06-18 11:46:53.179 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.created surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:46:53.184 16105 16133 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION session.controller.start kind=SUPPORTED_LIVE platform=Android
+06-18 11:46:53.184 16105 16133 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION supported.controller.dispatch surface=main-guided type=LiveReferenceMeshLinkController
+06-18 11:46:53.184 16105 16133 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION live.controller.start surface=main-guided platform=Android appId=demo.meshlink.reference.android-direct.a065_mi_note3
+06-18 11:46:53.227 16105 16133 I MeshLinkReferenceAutomation: startTransport hardware scanner=true advertiser=true carrier=UUID_PAIR
+06-18 11:46:53.232 16105 16133 I MeshLinkReferenceAutomation: start() with l2capPsm=221
+06-18 11:46:53.233 16105 16133 I MeshLinkReferenceAutomation: refreshDiscoveryState started=true suspended=false scanner=true advertiser=true psm=221 carrier=UUID_PAIR
+06-18 11:46:53.234 16105 16133 I MeshLinkReferenceAutomation: scan requested mode=2 carrier=UUID_PAIR
+06-18 11:46:53.237 16105 16133 I MeshLinkReferenceAutomation: scan start invoked carrier=UUID_PAIR
+06-18 11:46:53.237 16105 16133 I MeshLinkReferenceAutomation: scan started
+06-18 11:46:53.237 16105 16133 I MeshLinkReferenceAutomation: advertise requested mode=2 carrier=UUID_PAIR payloadPsm=221
+06-18 11:46:53.238 16105 16133 I MeshLinkReferenceAutomation: advertise start invoked carrier=UUID_PAIR payloadPsm=221
+06-18 11:46:53.238 16105 16133 I MeshLinkReferenceAutomation: advertise requested carrier=UUID_PAIR payloadPsm=221
+06-18 11:46:53.242 16105 16131 I MeshLinkReferenceAutomation: REFERENCE_RUNTIME diagnostic code=MESH_STARTED stage=lifecycle.start peer=none detail=MESH_STARTED @ lifecycle.start
+06-18 11:46:53.277 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION driver.handle role=SENDER mode=LIVE_PROOF snapshotPeers=0 timelineEntries=4
+06-18 11:46:53.277 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER benchmarkTransport=gatt-notify scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial
+06-18 11:46:53.277 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION snapshot role=SENDER peers=0 hasPeers=false meshStartRequested=false peerAnnounced=false announced=true
+06-18 11:46:53.277 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peers role=SENDER count=0 suffixes=
+06-18 11:46:53.277 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.evaluate role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:53.278 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION mesh.start.skipped role=SENDER meshStartRequested=false meshState=Running readinessBlockers=
+06-18 11:46:53.278 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.waiting role=sender reason=no-peers
+06-18 11:46:53.278 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION sender.wait.retry role=sender reason=no-peers attempt=1 delayMs=5000
+06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: GATT benchmark discovered device=77:A5:E4:04:3F:46 rssi=-57
+06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Connecting(GATT benchmark)
+06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge
+06-18 11:46:53.444 16105 16105 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true
+06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: GATT benchmark connection status=133 state=DISCONNECTED
+06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: GATT benchmark failed reason=GATT_DISCONNECTED elapsedMs=915
+06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION bridge.state Error(GATT benchmark)
+06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_mi_note3</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge fail">failed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_mi_note3 · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>failed</td></tr><tr><th>Failure stage</th><td>capture</td></tr><tr><th>Failure reason</th><td>Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>42c2cf</td></tr><tr><th>Route stage</th><td>peer-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>11.800s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>0.800s</td></tr>
+<tr><th>Passive transport wait</th><td>0.000s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.386s</td></tr><tr><th>Sender trust connection</th><td>—</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>0.800s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>—</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>—</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;launch&quot;: {
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 0.8,
+    &quot;line&quot;: &quot;06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.0,
+    &quot;line&quot;: &quot;06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 11.8
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: null,
+    &quot;peerDiscoveryMarker&quot;: null,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.8,
+    &quot;transportEvidence&quot;: &quot;06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: null,
+    &quot;trustConnectionSeconds&quot;: null
+  },
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: null,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.386,
+    &quot;sendCompletionSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: null,
+    &quot;trustConnectionSeconds&quot;: null
+  },
+  &quot;totalSeconds&quot;: 11.8,
+  &quot;transportEvidence&quot;: &quot;06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.json
@@ -1,0 +1,104 @@
+{
+  "status": "failed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_mi_note3",
+  "storageSubdirectory": "03_a065_mi_note3_initial",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "42c2cf",
+  "senderCompletion": null,
+  "passiveCompletion": null,
+  "senderFailure": "06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+  "senderPowerState": "06-18 11:46:53.083 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "peer-discovered",
+  "routeEvidence": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "peer-discovered",
+  "senderRouteEvidence": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": null,
+  "passiveRouteEvidence": null,
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 0.8,
+      "line": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.0,
+      "line": "06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 11.8
+  },
+  "timings": {
+    "totalSeconds": 11.8,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+      "peerDiscoverySeconds": 0.386,
+      "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": null,
+      "trustConnectionMarker": null,
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": null,
+      "sendRequestMarker": null,
+      "completionMarker": null,
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 0.8,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": null,
+      "trustConnectionSeconds": null,
+      "trustConnectionMarker": null,
+      "sendLatencySeconds": null,
+      "receiptSeconds": null,
+      "sendRequestMarker": null,
+      "completionMarker": null,
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    }
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "failureStage": "capture",
+  "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": false,
+    "androidExport": false
+  },
+  "partialEvidenceAvailable": true
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_report.md
@@ -1,0 +1,204 @@
+# Pair 03 — a065_mi_note3
+
+## Setup
+
+- Sender: A065 (1f1dad34)
+- Passive: Mi Note 3 (42c2cf)
+- Sender API level: 36
+- Passive API level: 28
+- Transport: GATT
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md`
+- Pair report path: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_report.md`
+- Peer lookup time: —
+- Initial run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial`
+- Final run dir: `—`
+
+## Result
+
+- Initial status: failed (capture) in 11.9s
+- Final status: skipped (capture) in 11.9s
+- Target peer id: not resolved
+- Initial HTML report: `summary.html`
+- Final HTML report: `summary.html`
+- Initial summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.json`
+- Final summary JSON: `—`
+
+## Troubleshooting references
+
+| Initial artifact | Path | Captured |
+|---|---|---|
+| Initial senderLogcat | `sender_logcat.log` | yes |
+| Initial passiveLogcat | `passive_logcat.log` | yes |
+| Initial senderStart | `sender_start.txt` | yes |
+| Initial passiveStart | `passive_start.txt` | yes |
+| Initial androidHistory | `android_history.json` | no |
+| Initial androidExport | `android_export.json` | no |
+| Final artifact | Path | Captured |
+|---|---|---|
+| Final senderLogcat | `—` | no |
+| Final passiveLogcat | `—` | no |
+| Final senderStart | `—` | no |
+| Final passiveStart | `—` | no |
+| Final androidHistory | `—` | no |
+| Final androidExport | `—` | no |
+
+## Device quirks and issues
+
+- Transport used for the pair: GATT
+- Fallback reason: android API below 33; using GATT fallback (senderApiLevel=36 passiveApiLevel=28)
+- Passive API level 28 is below the floor 33.
+- Initial run failure: Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)
+- Final run failure: Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)
+
+## Startup timing
+
+Initial startupTiming
+
+```json
+{
+  "launch": {
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0
+  },
+  "passive": {
+    "elapsedSeconds": 0.8,
+    "line": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.0,
+    "line": "06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+    "observed": true
+  },
+  "totalSeconds": 11.8
+}
+```
+
+Initial timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": null,
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 0.8,
+    "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "sender": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.386,
+    "sendCompletionSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "totalSeconds": 11.8,
+  "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Final startupTiming
+
+```json
+{}
+```
+
+Final timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": null,
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 0.8,
+    "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "sender": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.386,
+    "sendCompletionSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "totalSeconds": 11.8,
+  "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Captured evidence map
+
+```json
+{
+  "final": {},
+  "initial": {
+    "androidExport": false,
+    "androidHistory": false,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  }
+}
+```
+
+## Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Matrix
+    participant Sender as A065
+    participant Passive as Mi Note 3
+    note over Matrix: transport GATT
+    note over Matrix: fleet inventory fleet.md
+    note over Matrix: pair report 03_a065_mi_note3_report.md
+    Matrix->>Sender: initial run (11.9s)
+    note over Sender: failed (capture)
+    alt initial failed
+        note over Matrix: fail-fast stop after initial failure
+    end
+```

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md
@@ -1,0 +1,35 @@
+# Android direct-proof fleet run 20260618T114257
+
+This is the first tracked fleet sweep bundle under `reports/android-direct-proof-fleet/runs/`.
+
+## Result summary
+
+- Fail-fast sweep: yes
+- Completed pairs: 3
+- Stopped early: yes
+- Stop reason: `pair a065_mi_note3 failed during capture`
+
+## Pair reports
+
+- [01_a065_nam_lx9_report.md](01_a065_nam_lx9_report.md)
+- [02_a065_xcover_report.md](02_a065_xcover_report.md)
+- [03_a065_mi_note3_report.md](03_a065_mi_note3_report.md)
+
+## Bundle contents
+
+- `fleet.json`
+- `fleet.md`
+- `matrix-results.json`
+- `matrix-report.md`
+- `progress.json`
+- `state.json`
+- `01_a065_nam_lx9_initial/`
+- `01_a065_nam_lx9_final/`
+- `02_a065_xcover_initial/`
+- `02_a065_xcover_final/`
+- `03_a065_mi_note3_initial/`
+- `03_a065_mi_note3_final/`
+
+## Notes
+
+This bundle is intentionally kept in the repository root `reports/` tree so it can be reviewed, diffed, and referenced alongside the code that produced it.

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md
@@ -8,6 +8,7 @@ This is the first tracked fleet sweep bundle under `reports/android-direct-proof
 - Completed pairs: 3
 - Stopped early: yes
 - Stop reason: `pair a065_mi_note3 failed during capture`
+- Run summary: [SUMMARY.md](SUMMARY.md)
 
 ## Pair reports
 
@@ -23,6 +24,7 @@ This is the first tracked fleet sweep bundle under `reports/android-direct-proof
 - `matrix-report.md`
 - `progress.json`
 - `state.json`
+- `SUMMARY.md`
 - `01_a065_nam_lx9_initial/`
 - `01_a065_nam_lx9_final/`
 - `02_a065_xcover_initial/`
@@ -32,4 +34,5 @@ This is the first tracked fleet sweep bundle under `reports/android-direct-proof
 
 ## Notes
 
-This bundle is intentionally kept in the repository root `reports/` tree so it can be reviewed, diffed, and referenced alongside the code that produced it.
+This bundle is in the repository root `reports/` tree so it can be reviewed, diffed, and referenced alongside the code that produced it.
+The summary above is the first place to look before opening the per-pair report files.

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md
@@ -1,0 +1,46 @@
+# Android direct-proof fleet run summary
+
+## Outcome
+
+- Sweep mode: fail-fast
+- Total directed pairs discovered: 30
+- Completed pairs: 3
+- Stopped early: yes
+- Stop reason: `pair a065_mi_note3 failed during capture`
+
+## What happened
+
+1. `a065_nam_lx9` passed end-to-end on GATT fallback.
+2. `a065_xcover` passed end-to-end on GATT fallback.
+3. `a065_mi_note3` failed during the capture phase and the sweep stopped immediately.
+
+## Key evidence
+
+- Fleet inventory: `fleet.md` and `fleet.json`
+- Matrix summary: `matrix-report.md`
+- Per-pair reports:
+  - `01_a065_nam_lx9_report.md`
+  - `02_a065_xcover_report.md`
+  - `03_a065_mi_note3_report.md`
+- Mi Note 3 failure report:
+  - initial summary: `03_a065_mi_note3_initial/summary.json`
+  - initial HTML report: `03_a065_mi_note3_initial/summary.html`
+  - initial sender logcat: `03_a065_mi_note3_initial/sender_logcat.log`
+  - initial passive logcat: `03_a065_mi_note3_initial/passive_logcat.log`
+
+## Observed failure mode
+
+The Mi Note 3 pair did not produce a retained completion during capture.
+The run report shows the passive proof app started and emitted `gatt.benchmark.start() -> Started`, but the sender did not complete the capture path before the fail-fast stop.
+
+## Next fix to try
+
+- Inspect the Mi Note 3 sender and passive logcats for the missing completion marker.
+- Check whether the GATT fallback path on SDK 28 needs a tighter startup/transport wait or a device-specific workaround.
+- If the failure reproduces, add a dedicated Mi Note 3 regression note and keep the fail-fast sweep behavior unchanged.
+
+## Related paths
+
+- Run index: `INDEX.md`
+- Run bundle root: `.`
+- Top-level reports index: `../../../../INDEX.md`

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json
@@ -1,0 +1,280 @@
+{
+  "capturedAt": "20260618T114257",
+  "failFast": true,
+  "deviceCount": 12,
+  "pairCount": 30,
+  "devices": [
+    {
+      "serial": "1f1dad34",
+      "model": "A065",
+      "apiLevel": 36
+    },
+    {
+      "serial": "2ASVB21B09005117",
+      "model": "NAM-LX9",
+      "apiLevel": 31
+    },
+    {
+      "serial": "42004386e43c8589",
+      "model": "SM-G390F",
+      "apiLevel": 28
+    },
+    {
+      "serial": "42c2cf",
+      "model": "Mi Note 3",
+      "apiLevel": 28
+    },
+    {
+      "serial": "7XHEIBPBLRJJSKFU",
+      "model": "7XHEIBPBLRJJSKFU",
+      "apiLevel": 35
+    },
+    {
+      "serial": "EQUGS85LJNEIO7Z5",
+      "model": "CPH2359",
+      "apiLevel": 34
+    },
+    {
+      "serial": "GX6CTR500184",
+      "model": "E940-2849-00",
+      "apiLevel": 33
+    },
+    {
+      "serial": "ZY22GCD9ST",
+      "model": "ZY22GCD9ST",
+      "apiLevel": 34
+    },
+    {
+      "serial": "e9097611",
+      "model": "e9097611",
+      "apiLevel": 29
+    },
+    {
+      "serial": "adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp",
+      "model": "adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp",
+      "apiLevel": 34
+    },
+    {
+      "serial": "adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp",
+      "model": "adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp",
+      "apiLevel": 33
+    },
+    {
+      "serial": "adb-bb722dcd-7SjtpI._adb-tls-connect._tcp",
+      "model": "adb-bb722dcd-7SjtpI._adb-tls-connect._tcp",
+      "apiLevel": 31
+    }
+  ],
+  "availablePairs": [
+    {
+      "label": "a065_nam_lx9",
+      "sender": "1f1dad34",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "A065",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "a065_xcover",
+      "sender": "1f1dad34",
+      "passive": "42004386e43c8589",
+      "senderModel": "A065",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "a065_mi_note3",
+      "sender": "1f1dad34",
+      "passive": "42c2cf",
+      "senderModel": "A065",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "a065_cph2359",
+      "sender": "1f1dad34",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "A065",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "a065_e940",
+      "sender": "1f1dad34",
+      "passive": "GX6CTR500184",
+      "senderModel": "A065",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "nam_lx9_a065",
+      "sender": "2ASVB21B09005117",
+      "passive": "1f1dad34",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "nam_lx9_xcover",
+      "sender": "2ASVB21B09005117",
+      "passive": "42004386e43c8589",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "nam_lx9_mi_note3",
+      "sender": "2ASVB21B09005117",
+      "passive": "42c2cf",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "nam_lx9_cph2359",
+      "sender": "2ASVB21B09005117",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "nam_lx9_e940",
+      "sender": "2ASVB21B09005117",
+      "passive": "GX6CTR500184",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "xcover_a065",
+      "sender": "42004386e43c8589",
+      "passive": "1f1dad34",
+      "senderModel": "SM-G390F",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "xcover_nam_lx9",
+      "sender": "42004386e43c8589",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "SM-G390F",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "xcover_mi_note3",
+      "sender": "42004386e43c8589",
+      "passive": "42c2cf",
+      "senderModel": "SM-G390F",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "xcover_cph2359",
+      "sender": "42004386e43c8589",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "SM-G390F",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "xcover_e940",
+      "sender": "42004386e43c8589",
+      "passive": "GX6CTR500184",
+      "senderModel": "SM-G390F",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "mi_note3_a065",
+      "sender": "42c2cf",
+      "passive": "1f1dad34",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "mi_note3_nam_lx9",
+      "sender": "42c2cf",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "mi_note3_xcover",
+      "sender": "42c2cf",
+      "passive": "42004386e43c8589",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "mi_note3_cph2359",
+      "sender": "42c2cf",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "mi_note3_e940",
+      "sender": "42c2cf",
+      "passive": "GX6CTR500184",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "cph2359_a065",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "1f1dad34",
+      "senderModel": "CPH2359",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "cph2359_nam_lx9",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "CPH2359",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "cph2359_xcover",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "42004386e43c8589",
+      "senderModel": "CPH2359",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "cph2359_mi_note3",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "42c2cf",
+      "senderModel": "CPH2359",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "cph2359_e940",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "GX6CTR500184",
+      "senderModel": "CPH2359",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "e940_a065",
+      "sender": "GX6CTR500184",
+      "passive": "1f1dad34",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "e940_nam_lx9",
+      "sender": "GX6CTR500184",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "e940_xcover",
+      "sender": "GX6CTR500184",
+      "passive": "42004386e43c8589",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "e940_mi_note3",
+      "sender": "GX6CTR500184",
+      "passive": "42c2cf",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "e940_cph2359",
+      "sender": "GX6CTR500184",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "CPH2359"
+    }
+  ]
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md
@@ -1,0 +1,58 @@
+# Android fleet inventory
+
+- Captured: 20260618T114257
+- Fail-fast: enabled
+- Device count: 12
+- Pair count: 30
+
+## Devices
+
+| Serial | Model | API level |
+|---|---|---|
+| 1f1dad34 | A065 | 36 |
+| 2ASVB21B09005117 | NAM-LX9 | 31 |
+| 42004386e43c8589 | SM-G390F | 28 |
+| 42c2cf | Mi Note 3 | 28 |
+| 7XHEIBPBLRJJSKFU | 7XHEIBPBLRJJSKFU | 35 |
+| EQUGS85LJNEIO7Z5 | CPH2359 | 34 |
+| GX6CTR500184 | E940-2849-00 | 33 |
+| ZY22GCD9ST | ZY22GCD9ST | 34 |
+| e9097611 | e9097611 | 29 |
+| adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp | adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp | 34 |
+| adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp | adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp | 33 |
+| adb-bb722dcd-7SjtpI._adb-tls-connect._tcp | adb-bb722dcd-7SjtpI._adb-tls-connect._tcp | 31 |
+
+## Available directed pairs
+
+| Label | Sender | Passive |
+|---|---|---|
+| a065_nam_lx9 | A065 (1f1dad34) | NAM-LX9 (2ASVB21B09005117) |
+| a065_xcover | A065 (1f1dad34) | SM-G390F (42004386e43c8589) |
+| a065_mi_note3 | A065 (1f1dad34) | Mi Note 3 (42c2cf) |
+| a065_cph2359 | A065 (1f1dad34) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| a065_e940 | A065 (1f1dad34) | E940-2849-00 (GX6CTR500184) |
+| nam_lx9_a065 | NAM-LX9 (2ASVB21B09005117) | A065 (1f1dad34) |
+| nam_lx9_xcover | NAM-LX9 (2ASVB21B09005117) | SM-G390F (42004386e43c8589) |
+| nam_lx9_mi_note3 | NAM-LX9 (2ASVB21B09005117) | Mi Note 3 (42c2cf) |
+| nam_lx9_cph2359 | NAM-LX9 (2ASVB21B09005117) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| nam_lx9_e940 | NAM-LX9 (2ASVB21B09005117) | E940-2849-00 (GX6CTR500184) |
+| xcover_a065 | SM-G390F (42004386e43c8589) | A065 (1f1dad34) |
+| xcover_nam_lx9 | SM-G390F (42004386e43c8589) | NAM-LX9 (2ASVB21B09005117) |
+| xcover_mi_note3 | SM-G390F (42004386e43c8589) | Mi Note 3 (42c2cf) |
+| xcover_cph2359 | SM-G390F (42004386e43c8589) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| xcover_e940 | SM-G390F (42004386e43c8589) | E940-2849-00 (GX6CTR500184) |
+| mi_note3_a065 | Mi Note 3 (42c2cf) | A065 (1f1dad34) |
+| mi_note3_nam_lx9 | Mi Note 3 (42c2cf) | NAM-LX9 (2ASVB21B09005117) |
+| mi_note3_xcover | Mi Note 3 (42c2cf) | SM-G390F (42004386e43c8589) |
+| mi_note3_cph2359 | Mi Note 3 (42c2cf) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| mi_note3_e940 | Mi Note 3 (42c2cf) | E940-2849-00 (GX6CTR500184) |
+| cph2359_a065 | CPH2359 (EQUGS85LJNEIO7Z5) | A065 (1f1dad34) |
+| cph2359_nam_lx9 | CPH2359 (EQUGS85LJNEIO7Z5) | NAM-LX9 (2ASVB21B09005117) |
+| cph2359_xcover | CPH2359 (EQUGS85LJNEIO7Z5) | SM-G390F (42004386e43c8589) |
+| cph2359_mi_note3 | CPH2359 (EQUGS85LJNEIO7Z5) | Mi Note 3 (42c2cf) |
+| cph2359_e940 | CPH2359 (EQUGS85LJNEIO7Z5) | E940-2849-00 (GX6CTR500184) |
+| e940_a065 | E940-2849-00 (GX6CTR500184) | A065 (1f1dad34) |
+| e940_nam_lx9 | E940-2849-00 (GX6CTR500184) | NAM-LX9 (2ASVB21B09005117) |
+| e940_xcover | E940-2849-00 (GX6CTR500184) | SM-G390F (42004386e43c8589) |
+| e940_mi_note3 | E940-2849-00 (GX6CTR500184) | Mi Note 3 (42c2cf) |
+| e940_cph2359 | E940-2849-00 (GX6CTR500184) | CPH2359 (EQUGS85LJNEIO7Z5) |

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/matrix-report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/matrix-report.md
@@ -1,0 +1,23 @@
+# Android direct-proof matrix report
+
+## Passing pairs
+
+| Sender | Passive | Result |
+|---|---|---|
+| A065 | NAM-LX9 | passed |
+| A065 | SM-G390F | passed |
+
+## Most common failure reason per device
+
+| Device | Most common failure reason | Count |
+|---|---|---|
+| A065 | passed | 2 |
+
+
+## Run setup
+
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md`
+- Fleet JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json`
+- Fail-fast: enabled
+- Stopped early: yes
+- Stop reason: pair a065_mi_note3 failed during capture

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/matrix-results.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/matrix-results.json
@@ -1,0 +1,662 @@
+[
+  {
+    "label": "a065_nam_lx9",
+    "sender": "1f1dad34",
+    "passive": "2ASVB21B09005117",
+    "senderModel": "A065",
+    "passiveModel": "NAM-LX9",
+    "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+    "targetPeerId": null,
+    "initial": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 11:43:06.100 17667 17730 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 27.4,
+        "install": {
+          "senderSeconds": 8.5,
+          "passiveSeconds": 6.7,
+          "senderReused": false,
+          "passiveReused": false
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.1,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 27.4,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+          "peerDiscoverySeconds": 0.388,
+          "peerDiscoveryMarker": "06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.523,
+          "trustConnectionMarker": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 2.825,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "sendLatencySeconds": 1.891,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "completionMarker": "06-18 11:43:09.701 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": false,
+        "passiveInstallReused": false
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial"
+    },
+    "final": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 11:44:28.891 17954 17985 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 18.0,
+        "install": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": true,
+          "passiveReused": true
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 18.0,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+          "peerDiscoverySeconds": 0.435,
+          "peerDiscoveryMarker": "06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.243,
+          "trustConnectionMarker": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.813,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 11:44:30.405 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "sendLatencySeconds": 1.111,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "completionMarker": "06-18 11:44:31.515 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": true,
+        "passiveInstallReused": true
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final"
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": 63.7,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 31,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  {
+    "label": "a065_xcover",
+    "sender": "1f1dad34",
+    "passive": "42004386e43c8589",
+    "senderModel": "A065",
+    "passiveModel": "SM-G390F",
+    "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+    "targetPeerId": null,
+    "initial": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.8,
+          "line": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.3,
+          "line": "06-18 11:45:00.551 17927 18032 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 32.2,
+        "install": {
+          "senderSeconds": 8.6,
+          "passiveSeconds": 11.7,
+          "senderReused": false,
+          "passiveReused": false
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 32.2,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.38,
+          "peerDiscoveryMarker": "06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.157,
+          "trustConnectionMarker": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.597,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "trustConnectionSeconds": 0.004,
+          "trustConnectionMarker": "06-18 11:45:01.935 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "sendLatencySeconds": 1.036,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "completionMarker": "06-18 11:45:02.967 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": false,
+        "passiveInstallReused": false
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial"
+    },
+    "final": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.3,
+          "line": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 11:46:24.359 18355 18375 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 18.8,
+        "install": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": true,
+          "passiveReused": true
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 18.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final",
+          "peerDiscoverySeconds": 0.351,
+          "peerDiscoveryMarker": "06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.403,
+          "trustConnectionMarker": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.847,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.3,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+          "trustConnectionSeconds": 0.013,
+          "trustConnectionMarker": "06-18 11:46:25.911 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+          "sendLatencySeconds": 1.079,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+          "completionMarker": "06-18 11:46:26.977 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": true,
+        "passiveInstallReused": true
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final"
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": 64.9,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  {
+    "label": "a065_mi_note3",
+    "sender": "1f1dad34",
+    "passive": "42c2cf",
+    "senderModel": "A065",
+    "passiveModel": "Mi Note 3",
+    "appId": "demo.meshlink.reference.android-direct.a065_mi_note3",
+    "targetPeerId": null,
+    "initial": {
+      "status": "failed",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "peer-discovered",
+      "routeEvidence": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "peer-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.8,
+          "line": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 11.8
+      },
+      "timings": {
+        "totalSeconds": 11.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+          "peerDiscoverySeconds": 0.386,
+          "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": false,
+        "androidExport": false
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial"
+    },
+    "final": {
+      "status": "skipped",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": null,
+      "routeEvidence": null,
+      "senderRouteStage": null,
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": null,
+      "timings": {
+        "totalSeconds": 11.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+          "peerDiscoverySeconds": 0.386,
+          "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": null,
+      "captured": null,
+      "summaryPath": null,
+      "runDir": null
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": null,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  }
+]

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/progress.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/progress.json
@@ -1,0 +1,662 @@
+[
+  {
+    "label": "a065_nam_lx9",
+    "sender": "1f1dad34",
+    "passive": "2ASVB21B09005117",
+    "senderModel": "A065",
+    "passiveModel": "NAM-LX9",
+    "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+    "targetPeerId": null,
+    "initial": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 11:43:06.100 17667 17730 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 27.4,
+        "install": {
+          "senderSeconds": 8.5,
+          "passiveSeconds": 6.7,
+          "senderReused": false,
+          "passiveReused": false
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.1,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 27.4,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:43:07.216 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+          "peerDiscoverySeconds": 0.388,
+          "peerDiscoveryMarker": "06-18 11:43:07.604 15129 15129 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.523,
+          "trustConnectionMarker": "06-18 11:43:08.127 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 2.825,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:43:10.041 15129 15148 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:43:07.225 15129 15129 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 11:43:07.811 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "sendLatencySeconds": 1.891,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:43:07.810 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "completionMarker": "06-18 11:43:09.701 17667 17711 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=df870458685d420d bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:43:06.054 17667 17667 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": false,
+        "passiveInstallReused": false
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial"
+    },
+    "final": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 11:44:28.891 17954 17985 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 18.0,
+        "install": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": true,
+          "passiveReused": true
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 18.0,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:44:30.043 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+          "peerDiscoverySeconds": 0.435,
+          "peerDiscoveryMarker": "06-18 11:44:30.478 15326 15326 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.243,
+          "trustConnectionMarker": "06-18 11:44:30.721 15326 15375 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.813,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:44:31.856 15326 15339 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:44:30.052 15326 15326 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 11:44:30.405 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "sendLatencySeconds": 1.111,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:44:30.404 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "completionMarker": "06-18 11:44:31.515 17954 17974 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=54487b8274844eff bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:44:28.853 17954 17954 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": true,
+        "passiveInstallReused": true
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final"
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/01_a065_nam_lx9_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": 63.7,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 31,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  {
+    "label": "a065_xcover",
+    "sender": "1f1dad34",
+    "passive": "42004386e43c8589",
+    "senderModel": "A065",
+    "passiveModel": "SM-G390F",
+    "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+    "targetPeerId": null,
+    "initial": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.8,
+          "line": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.3,
+          "line": "06-18 11:45:00.551 17927 18032 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 32.2,
+        "install": {
+          "senderSeconds": 8.6,
+          "passiveSeconds": 11.7,
+          "senderReused": false,
+          "passiveReused": false
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 32.2,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:45:02.307 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.38,
+          "peerDiscoveryMarker": "06-18 11:45:02.687 15576 15576 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.157,
+          "trustConnectionMarker": "06-18 11:45:02.844 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.597,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:45:03.904 15576 15615 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:45:02.316 15576 15576 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "trustConnectionSeconds": 0.004,
+          "trustConnectionMarker": "06-18 11:45:01.935 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "sendLatencySeconds": 1.036,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:45:01.931 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=52:15:AC:2B:DF:78",
+          "completionMarker": "06-18 11:45:02.967 17927 17946 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=52:15:AC:2B:DF:78 token=10f093f0885a42e4 bytes=50",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:45:00.318 17927 17927 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": false,
+        "passiveInstallReused": false
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial"
+    },
+    "final": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.3,
+          "line": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 11:46:24.359 18355 18375 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 18.8,
+        "install": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": true,
+          "passiveReused": true
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 18.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:26.064 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_final",
+          "peerDiscoverySeconds": 0.351,
+          "peerDiscoveryMarker": "06-18 11:46:26.415 15875 15875 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.403,
+          "trustConnectionMarker": "06-18 11:46:26.818 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.847,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 11:46:27.911 15875 15891 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:26.072 15875 15875 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.3,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+          "trustConnectionSeconds": 0.013,
+          "trustConnectionMarker": "06-18 11:46:25.911 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+          "sendLatencySeconds": 1.079,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 11:46:25.898 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=7C:9B:EE:F8:58:1D",
+          "completionMarker": "06-18 11:46:26.977 18355 18368 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=7C:9B:EE:F8:58:1D token=1c01054e65ee4bb3 bytes=50",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:24.234 18355 18355 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": true,
+        "passiveInstallReused": true
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final"
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/02_a065_xcover_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": 64.9,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  {
+    "label": "a065_mi_note3",
+    "sender": "1f1dad34",
+    "passive": "42c2cf",
+    "senderModel": "A065",
+    "passiveModel": "Mi Note 3",
+    "appId": "demo.meshlink.reference.android-direct.a065_mi_note3",
+    "targetPeerId": null,
+    "initial": {
+      "status": "failed",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "peer-discovered",
+      "routeEvidence": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "peer-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.8,
+          "line": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 11.8
+      },
+      "timings": {
+        "totalSeconds": 11.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+          "peerDiscoverySeconds": 0.386,
+          "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": false,
+        "androidExport": false
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial"
+    },
+    "final": {
+      "status": "skipped",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": null,
+      "routeEvidence": null,
+      "senderRouteStage": null,
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": null,
+      "timings": {
+        "totalSeconds": 11.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+          "peerDiscoverySeconds": 0.386,
+          "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": null,
+      "captured": null,
+      "summaryPath": null,
+      "runDir": null
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": null,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  }
+]

--- a/reports/android-direct-proof-fleet/runs/20260618T114257/state.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T114257/state.json
@@ -1,0 +1,182 @@
+{
+  "runRoot": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257",
+  "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+  "totalPairs": 30,
+  "completedPairs": 3,
+  "pendingPairs": 27,
+  "lastPair": {
+    "label": "a065_mi_note3",
+    "sender": "1f1dad34",
+    "passive": "42c2cf",
+    "senderModel": "A065",
+    "passiveModel": "Mi Note 3",
+    "appId": "demo.meshlink.reference.android-direct.a065_mi_note3",
+    "targetPeerId": null,
+    "initial": {
+      "status": "failed",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "peer-discovered",
+      "routeEvidence": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "peer-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.8,
+          "line": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 05:46:57.062 10554 10633 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 11.8
+      },
+      "timings": {
+        "totalSeconds": 11.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+          "peerDiscoverySeconds": 0.386,
+          "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": false,
+        "androidExport": false
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial"
+    },
+    "final": {
+      "status": "skipped",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 11:46:53.971 16105 16118 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": null,
+      "routeEvidence": null,
+      "senderRouteStage": null,
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": null,
+      "timings": {
+        "totalSeconds": 11.8,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 11:46:53.052 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_mi_note3 storage=03_a065_mi_note3_initial",
+          "peerDiscoverySeconds": 0.386,
+          "peerDiscoveryMarker": "06-18 11:46:53.438 16105 16105 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 11:46:53.061 16105 16105 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 05:46:56.995 10554 10554 I MeshLinkProof: MeshLink proof app ready on Xiaomi Mi Note 3 (SDK 28) appId=demo.meshlink.reference.android-direct.a065_mi_note3 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": null,
+      "captured": null,
+      "summaryPath": null,
+      "runDir": null
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/03_a065_mi_note3_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T114257/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": null,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  "failFast": true,
+  "stoppedEarly": true,
+  "stopReason": "pair a065_mi_note3 failed during capture"
+}


### PR DESCRIPTION
## Summary

This PR roots the Android direct-proof fleet reports under `reports/` and commits a tracked sample run bundle so the generated evidence is easy to find, diff, and review.

### What changed
- moved the default fleet sweep output root to `reports/android-direct-proof-fleet/runs/<timestamp>/`
- added repository-tracked report navigation pages under `reports/`
- added a run-local `SUMMARY.md` for the tracked sweep
- enriched per-pair reports with timing, transport, and raw evidence references
- kept the docs index and report guides aligned with the new report root

### Evidence
- the tracked sweep completed 3 pairs and stopped early on `a065_mi_note3`
- the Mi Note 3 report records the capture failure and points to the relevant logs and summaries

### Verification
- `python -m unittest meshlink-reference/scripts/tests/test_docs_index_links.py -v`
- `cd meshlink-reference/scripts && python -m unittest discover -s tests -p 'test_reference_android_direct_matrix.py' -v`

