### PR TITLE
fix(ci): disable dependabot swift updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "swift"
-    directory: "/"
-    schedule:
-      interval: "daily"
+
+# Dependabot Swift updates are disabled because the repository uses a local
+# binaryTarget package layout. Dependabot attempts to parse the local xcframework
+# path before the release artifact exists in its checkout, which causes the
+# Swift updater to fail. The SwiftPM manifests remain in the repo for Xcode and
+# local checkout consumers, but version updates are intentionally limited to Gradle.


### PR DESCRIPTION
## Summary

Disable Dependabot's Swift updater because this repository uses a local-binary SwiftPM layout and Dependabot fails when it tries to parse the local `binaryTarget` path.

### Root cause

Dependabot's Swift version job attempts to resolve the root `Package.swift` manifest. The manifest points at `meshlink/build/swiftpm/MeshLink.xcframework`, but that binary artifact is not present in Dependabot's checkout, so the updater aborts before it can process updates.

### Fix

- remove the `swift` ecosystem from `.github/dependabot.yml`
- keep the Gradle updater enabled
- document the reason inline in the Dependabot config

### Verification

- YAML parses successfully
- push hook verification passed

