### PR TITLE
docs(android): track latest fleet run

### DIFF
--- a/reports/INDEX.md
+++ b/reports/INDEX.md
@@ -13,7 +13,7 @@ reports/android-direct-proof-fleet/runs/<timestamp>/
 
 Latest tracked run:
 
-- [20260618T114257](android-direct-proof-fleet/runs/20260618T114257/INDEX.md) — [summary](android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md)
+- [20260618T133249](android-direct-proof-fleet/runs/20260618T133249/INDEX.md) — [summary](android-direct-proof-fleet/runs/20260618T133249/SUMMARY.md)
 
 Contents of each run:
 

--- a/reports/README.md
+++ b/reports/README.md
@@ -3,7 +3,7 @@
 Repository-tracked generated reports live here so fleet runs are easy to find, diff, and review.
 
 Start with [INDEX.md](INDEX.md) for the canonical report locations and links into the docs.
-The currently tracked example run lives at [reports/android-direct-proof-fleet/runs/20260618T114257/INDEX.md](android-direct-proof-fleet/runs/20260618T114257/INDEX.md), and its concise summary is [SUMMARY.md](android-direct-proof-fleet/runs/20260618T114257/SUMMARY.md).
+The currently tracked example run lives at [reports/android-direct-proof-fleet/runs/20260618T133249/INDEX.md](android-direct-proof-fleet/runs/20260618T133249/INDEX.md), and its concise summary is [SUMMARY.md](android-direct-proof-fleet/runs/20260618T133249/SUMMARY.md).
 
 ## Android direct-proof fleet reports
 

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/android_export.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/android_export.json
@@ -1,0 +1,7 @@
+{
+  "defaultMode": "redacted-preview",
+  "fullPayloadIncluded": false,
+  "operatorOptInRecorded": false,
+  "transport": "gatt",
+  "note": "proof-app passive export not available"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/android_history.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/android_history.json
@@ -1,0 +1,5 @@
+{
+  "transport": "gatt",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "note": "proof-app passive retained evidence is log-only"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_nam_lx9</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge pass">passed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_nam_lx9 · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>passed</td></tr><tr><th>Failure stage</th><td>—</td></tr><tr><th>Failure reason</th><td>—</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>2ASVB21B09005117</td></tr><tr><th>Route stage</th><td>route-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>18.100s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive transport wait</th><td>0.000s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.383s</td></tr><tr><th>Sender trust connection</th><td>0.383s</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>1.871s</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>0.001s</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 13:34:22.194 20449 20449 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;install&quot;: {
+    &quot;passiveReused&quot;: true,
+    &quot;passiveSeconds&quot;: null,
+    &quot;senderReused&quot;: true,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;launch&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: null,
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.0,
+    &quot;line&quot;: &quot;06-18 13:34:21.013 20333 20366 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;permissions&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 0.2,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 0.1
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 18.1
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 13:34:23.726 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=f6740680cf304274 bytes=51&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6&quot;,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: 1.086,
+    &quot;sendRequestMarker&quot;: &quot;06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6&quot;,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 13:34:22.641 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.001
+  },
+  &quot;passiveInstallReused&quot;: true,
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 13:34:22.568 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.383,
+    &quot;sendCompletionSeconds&quot;: 1.871,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 13:34:22.194 20449 20449 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.383
+  },
+  &quot;senderInstallReused&quot;: true,
+  &quot;totalSeconds&quot;: 18.1,
+  &quot;transportEvidence&quot;: &quot;06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.json
@@ -1,0 +1,119 @@
+{
+  "status": "passed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "storageSubdirectory": "01_a065_nam_lx9_final",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "2ASVB21B09005117",
+  "senderCompletion": "06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+  "passiveCompletion": null,
+  "senderPowerState": "06-18 13:34:22.216 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "route-discovered",
+  "routeEvidence": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "route-discovered",
+  "senderRouteEvidence": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": "route-discovered",
+  "passiveRouteEvidence": "06-18 13:34:23.441 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.0,
+      "line": "06-18 13:34:21.013 20333 20366 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": false,
+      "passiveReused": false,
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 18.1,
+    "install": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": true,
+      "passiveReused": true
+    },
+    "permissions": {
+      "senderSeconds": 0.1,
+      "passiveSeconds": 0.2,
+      "senderReused": false,
+      "passiveReused": false
+    }
+  },
+  "timings": {
+    "totalSeconds": 18.1,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+      "peerDiscoverySeconds": 0.383,
+      "peerDiscoveryMarker": "06-18 13:34:22.568 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": 0.383,
+      "trustConnectionMarker": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": 1.871,
+      "sendRequestMarker": null,
+      "completionMarker": "06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 13:34:22.194 20449 20449 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+      "trustConnectionSeconds": 0.001,
+      "trustConnectionMarker": "06-18 13:34:22.641 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+      "sendLatencySeconds": 1.086,
+      "receiptSeconds": null,
+      "sendRequestMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+      "completionMarker": "06-18 13:34:23.726 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=f6740680cf304274 bytes=51",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "senderInstallReused": true,
+    "passiveInstallReused": true
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": true,
+    "androidExport": true
+  },
+  "discoveredPeerId": null
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/.android-install-cache-1f1dad34.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/.android-install-cache-1f1dad34.json
@@ -1,0 +1,5 @@
+{
+  "sourceFingerprint": "ec7adf9220f6211d140559e37b8a4f7d9e193b50:dirty",
+  "apkPath": "/home/phil/Projects/MeshLink/meshlink-reference/android/build/outputs/apk/debug/android-debug.apk",
+  "apkHash": "92a6071f28b7eba5da955a6b86b8c82e851d46ef80f937abfe811d0dee5e770e"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/android_export.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/android_export.json
@@ -1,0 +1,7 @@
+{
+  "defaultMode": "redacted-preview",
+  "fullPayloadIncluded": false,
+  "operatorOptInRecorded": false,
+  "transport": "gatt",
+  "note": "proof-app passive export not available"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/android_history.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/android_history.json
@@ -1,0 +1,5 @@
+{
+  "transport": "gatt",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "note": "proof-app passive retained evidence is log-only"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_nam_lx9</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge pass">passed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_nam_lx9 · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>passed</td></tr><tr><th>Failure stage</th><td>—</td></tr><tr><th>Failure reason</th><td>—</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>2ASVB21B09005117</td></tr><tr><th>Route stage</th><td>route-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>27.500s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive transport wait</th><td>0.000s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.383s</td></tr><tr><th>Sender trust connection</th><td>0.554s</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>2.102s</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>0.500s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>0.001s</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 13:32:59.855 19996 19996 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;install&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 7.4,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 9.0
+  },
+  &quot;launch&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: null,
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: null
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.0,
+    &quot;line&quot;: &quot;06-18 13:32:58.705 20014 20042 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;permissions&quot;: {
+    &quot;passiveReused&quot;: false,
+    &quot;passiveSeconds&quot;: 0.1,
+    &quot;senderReused&quot;: false,
+    &quot;senderSeconds&quot;: 0.1
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 27.5
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 13:33:01.613 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=7a8c16ffe10c4a17 bytes=51&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6&quot;,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: 1.145,
+    &quot;sendRequestMarker&quot;: &quot;06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6&quot;,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 13:33:00.469 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.001
+  },
+  &quot;passiveInstallReused&quot;: false,
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: &quot;06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender&quot;,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 13:33:00.228 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.383,
+    &quot;sendCompletionSeconds&quot;: 2.102,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 13:32:59.855 19996 19996 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: &quot;06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;trustConnectionSeconds&quot;: 0.554
+  },
+  &quot;senderInstallReused&quot;: false,
+  &quot;totalSeconds&quot;: 27.5,
+  &quot;transportEvidence&quot;: &quot;06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.json
@@ -1,0 +1,119 @@
+{
+  "status": "passed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+  "storageSubdirectory": "01_a065_nam_lx9_initial",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "2ASVB21B09005117",
+  "senderCompletion": "06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+  "passiveCompletion": null,
+  "senderPowerState": "06-18 13:32:59.876 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "route-discovered",
+  "routeEvidence": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "route-discovered",
+  "senderRouteEvidence": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": "route-discovered",
+  "passiveRouteEvidence": "06-18 13:33:01.277 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.0,
+      "line": "06-18 13:32:58.705 20014 20042 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "senderSeconds": null,
+      "passiveSeconds": null,
+      "senderReused": false,
+      "passiveReused": false,
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 27.5,
+    "install": {
+      "senderSeconds": 9.0,
+      "passiveSeconds": 7.4,
+      "senderReused": false,
+      "passiveReused": false
+    },
+    "permissions": {
+      "senderSeconds": 0.1,
+      "passiveSeconds": 0.1,
+      "senderReused": false,
+      "passiveReused": false
+    }
+  },
+  "timings": {
+    "totalSeconds": 27.5,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+      "peerDiscoverySeconds": 0.383,
+      "peerDiscoveryMarker": "06-18 13:33:00.228 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": 0.554,
+      "trustConnectionMarker": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": 2.102,
+      "sendRequestMarker": null,
+      "completionMarker": "06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 13:32:59.855 19996 19996 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+      "trustConnectionSeconds": 0.001,
+      "trustConnectionMarker": "06-18 13:33:00.469 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+      "sendLatencySeconds": 1.145,
+      "receiptSeconds": null,
+      "sendRequestMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+      "completionMarker": "06-18 13:33:01.613 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=7a8c16ffe10c4a17 bytes=51",
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "senderInstallReused": false,
+    "passiveInstallReused": false
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": true,
+    "androidExport": true
+  },
+  "discoveredPeerId": null
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_report.md
@@ -1,0 +1,277 @@
+# Pair 01 — a065_nam_lx9
+
+## Setup
+
+- Sender: A065 (1f1dad34)
+- Passive: NAM-LX9 (2ASVB21B09005117)
+- Sender API level: 36
+- Passive API level: 31
+- Transport: GATT
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md`
+- Pair report path: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_report.md`
+- Peer lookup time: 63.8s
+- Initial run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial`
+- Final run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final`
+
+## Result
+
+- Initial status: passed (no failure stage) in 27.5s
+- Final status: passed (no failure stage) in 18.1s
+- Target peer id: not resolved
+- Initial HTML report: `summary.html`
+- Final HTML report: `summary.html`
+- Initial summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.json`
+- Final summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.json`
+
+## Troubleshooting references
+
+| Initial artifact | Path | Captured |
+|---|---|---|
+| Initial senderLogcat | `sender_logcat.log` | yes |
+| Initial passiveLogcat | `passive_logcat.log` | yes |
+| Initial senderStart | `sender_start.txt` | yes |
+| Initial passiveStart | `passive_start.txt` | yes |
+| Initial androidHistory | `android_history.json` | yes |
+| Initial androidExport | `android_export.json` | yes |
+| Final artifact | Path | Captured |
+|---|---|---|
+| Final senderLogcat | `sender_logcat.log` | yes |
+| Final passiveLogcat | `passive_logcat.log` | yes |
+| Final senderStart | `sender_start.txt` | yes |
+| Final passiveStart | `passive_start.txt` | yes |
+| Final androidHistory | `android_history.json` | yes |
+| Final androidExport | `android_export.json` | yes |
+
+## Device quirks and issues
+
+- Transport used for the pair: GATT
+- Fallback reason: android API below 33; using GATT fallback (senderApiLevel=36 passiveApiLevel=31)
+- Passive API level 31 is below the floor 33.
+
+## Startup timing
+
+Initial startupTiming
+
+```json
+{
+  "install": {
+    "passiveReused": false,
+    "passiveSeconds": 7.4,
+    "senderReused": false,
+    "senderSeconds": 9.0
+  },
+  "launch": {
+    "passiveReused": false,
+    "passiveSeconds": null,
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0,
+    "senderReused": false,
+    "senderSeconds": null
+  },
+  "passive": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.0,
+    "line": "06-18 13:32:58.705 20014 20042 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "permissions": {
+    "passiveReused": false,
+    "passiveSeconds": 0.1,
+    "senderReused": false,
+    "senderSeconds": 0.1
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+    "observed": true
+  },
+  "totalSeconds": 27.5
+}
+```
+
+Initial timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": "06-18 13:33:01.613 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=7a8c16ffe10c4a17 bytes=51",
+    "peerDiscoveryMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": 1.145,
+    "sendRequestMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 13:33:00.469 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+    "trustConnectionSeconds": 0.001
+  },
+  "passiveInstallReused": false,
+  "sender": {
+    "completionMarker": "06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+    "peerDiscoveryMarker": "06-18 13:33:00.228 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.383,
+    "sendCompletionSeconds": 2.102,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 13:32:59.855 19996 19996 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+    "trustConnectionSeconds": 0.554
+  },
+  "senderInstallReused": false,
+  "totalSeconds": 27.5,
+  "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Final startupTiming
+
+```json
+{
+  "install": {
+    "passiveReused": true,
+    "passiveSeconds": null,
+    "senderReused": true,
+    "senderSeconds": null
+  },
+  "launch": {
+    "passiveReused": false,
+    "passiveSeconds": null,
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0,
+    "senderReused": false,
+    "senderSeconds": null
+  },
+  "passive": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.0,
+    "line": "06-18 13:34:21.013 20333 20366 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "permissions": {
+    "passiveReused": false,
+    "passiveSeconds": 0.2,
+    "senderReused": false,
+    "senderSeconds": 0.1
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+    "observed": true
+  },
+  "totalSeconds": 18.1
+}
+```
+
+Final timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": "06-18 13:34:23.726 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=f6740680cf304274 bytes=51",
+    "peerDiscoveryMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": 1.086,
+    "sendRequestMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 13:34:22.641 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+    "trustConnectionSeconds": 0.001
+  },
+  "passiveInstallReused": true,
+  "sender": {
+    "completionMarker": "06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+    "peerDiscoveryMarker": "06-18 13:34:22.568 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.383,
+    "sendCompletionSeconds": 1.871,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 13:34:22.194 20449 20449 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+    "trustConnectionSeconds": 0.383
+  },
+  "senderInstallReused": true,
+  "totalSeconds": 18.1,
+  "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Captured evidence map
+
+```json
+{
+  "final": {
+    "androidExport": true,
+    "androidHistory": true,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  },
+  "initial": {
+    "androidExport": true,
+    "androidHistory": true,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  }
+}
+```
+
+## Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Matrix
+    participant Sender as A065
+    participant Passive as NAM-LX9
+    note over Matrix: transport GATT
+    note over Matrix: fleet inventory fleet.md
+    note over Matrix: pair report 01_a065_nam_lx9_report.md
+    Matrix->>Sender: initial run (27.5s)
+    note over Sender: passed (no failure stage)
+    alt initial passed
+        Matrix->>Passive: read passive peer id (63.8s)
+        note over Matrix: target peer not resolved
+        Matrix->>Sender: final run (18.1s)
+        note over Sender: passed (no failure stage)
+        alt final passed
+            note over Matrix: pair completed successfully
+        else final failed
+            note over Matrix: fail-fast stop after final failure
+        end
+    else initial failed
+        note over Matrix: fail-fast stop after initial failure
+    end
+```

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/.android-install-cache-1f1dad34.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/.android-install-cache-1f1dad34.json
@@ -1,0 +1,5 @@
+{
+  "sourceFingerprint": "ec7adf9220f6211d140559e37b8a4f7d9e193b50:dirty",
+  "apkPath": "/home/phil/Projects/MeshLink/meshlink-reference/android/build/outputs/apk/debug/android-debug.apk",
+  "apkHash": "92a6071f28b7eba5da955a6b86b8c82e851d46ef80f937abfe811d0dee5e770e"
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/passive_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/passive_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.proof.android/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/sender_start.txt
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/sender_start.txt
@@ -1,0 +1,1 @@
+Starting: Intent { cmp=ch.trancee.meshlink.reference/.MainActivity (has extras) }

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.html
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Android direct-proof summary — demo.meshlink.reference.android-direct.a065_xcover</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:24px;line-height:1.45;color:#111}
+h1,h2{margin:0 0 12px}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.pass{background:#d1fae5;color:#065f46}.fail{background:#fee2e2;color:#991b1b}
+table{border-collapse:collapse;width:100%;margin:12px 0 24px}
+th,td{border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;text-align:left}
+th{background:#f9fafb;width:280px}
+code,pre{background:#f3f4f6;border-radius:8px;padding:12px;overflow:auto}
+pre{white-space:pre-wrap;word-break:break-word}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>Android direct-proof summary <span class="badge fail">failed</span></h1>
+<p class="muted">App ID: demo.meshlink.reference.android-direct.a065_xcover · Scenario: direct-guided · Report: summary.html</p>
+<section><h2>Overview</h2><table><tr><th>Status</th><td>failed</td></tr><tr><th>Failure stage</th><td>capture</td></tr><tr><th>Failure reason</th><td>Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)</td></tr><tr><th>Startup state</th><td>—</td></tr><tr><th>Startup evidence</th><td>—</td></tr><tr><th>Sender</th><td>1f1dad34</td></tr><tr><th>Passive</th><td>42004386e43c8589</td></tr><tr><th>Route stage</th><td>peer-discovered</td></tr><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Total time</th><td>15.300s</td></tr><tr><th>Capture timeout</th><td>30.000s</td></tr></table></section>
+<section><h2>Startup timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr>
+<tr><th>Passive startup wait</th><td>1.800s</td></tr>
+<tr><th>Passive transport wait</th><td>0.300s</td></tr>
+<tr><th>Configured passive wait</th><td>20.000s</td></tr>
+<tr><th>Configured transport wait</th><td>20.000s</td></tr>
+<tr><th>Configured idle wait</th><td>2.000s</td></tr>
+</table></section>
+<section><h2>Interaction timing</h2><table>
+<tr><th>Sender startup wait</th><td>0.500s</td></tr><tr><th>Sender peer discovery</th><td>0.497s</td></tr><tr><th>Sender trust connection</th><td>—</td></tr><tr><th>Sender message latency</th><td>—</td></tr><tr><th>Sender completion</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr>
+<tr><th>Passive startup wait</th><td>1.800s</td></tr><tr><th>Passive peer discovery</th><td>—</td></tr><tr><th>Passive trust connection</th><td>—</td></tr><tr><th>Passive message latency</th><td>—</td></tr><tr><th>Passive completion</th><td>—</td></tr><tr><th>Passive transport</th><td>GATT</td></tr>
+</table></section>
+<section><h2>Transport</h2><table><tr><th>Transport mode</th><td>GATT</td></tr><tr><th>Transport evidence</th><td>—</td></tr><tr><th>Sender transport</th><td>GATT</td></tr><tr><th>Passive transport</th><td>GATT</td></tr><tr><th>Sender transport evidence</th><td>06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started</td></tr><tr><th>Passive transport evidence</th><td>06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype</td></tr></table></section>
+<section><h2>Evidence</h2><table><tr><th>Sender logcat</th><td>sender_logcat.log</td></tr><tr><th>Passive logcat</th><td>passive_logcat.log</td></tr><tr><th>Sender start</th><td>sender_start.txt</td></tr><tr><th>Passive start</th><td>passive_start.txt</td></tr><tr><th>Android history</th><td>android_history.json</td></tr><tr><th>Android export</th><td>android_export.json</td></tr></table></section>
+<section><h2>Completion lines</h2>
+<h3>Sender</h3><pre>—</pre>
+<h3>Passive</h3><pre>—</pre>
+<h3>Route evidence</h3><pre>06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge</pre>
+</section>
+<details><summary>Raw startup timing JSON</summary><pre>{
+  &quot;launch&quot;: {
+    &quot;passiveStartupWaitSeconds&quot;: 20.0,
+    &quot;passiveTransportWaitSeconds&quot;: 20.0,
+    &quot;postResultIdleSeconds&quot;: 2.0
+  },
+  &quot;passive&quot;: {
+    &quot;elapsedSeconds&quot;: 1.8,
+    &quot;line&quot;: &quot;06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;passiveTransport&quot;: {
+    &quot;elapsedSeconds&quot;: 0.3,
+    &quot;line&quot;: &quot;06-18 13:34:50.805 21893 22025 I MeshLinkProof: gatt.benchmark.start() -&gt; Started&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;sender&quot;: {
+    &quot;elapsedSeconds&quot;: 0.5,
+    &quot;line&quot;: &quot;06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial&quot;,
+    &quot;observed&quot;: true
+  },
+  &quot;totalSeconds&quot;: 15.3
+}</pre></details>
+<details><summary>Raw timing JSON</summary><pre>{
+  &quot;androidReadySeconds&quot;: 20.0,
+  &quot;captureTimeoutSeconds&quot;: 30.0,
+  &quot;passive&quot;: {
+    &quot;completionMarker&quot;: null,
+    &quot;peerDiscoveryMarker&quot;: null,
+    &quot;peerDiscoverySeconds&quot;: null,
+    &quot;receiptSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: null,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 1.8,
+    &quot;transportEvidence&quot;: &quot;06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: null,
+    &quot;trustConnectionSeconds&quot;: null
+  },
+  &quot;sender&quot;: {
+    &quot;completionMarker&quot;: null,
+    &quot;peerDiscoveryMarker&quot;: &quot;06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge&quot;,
+    &quot;peerDiscoverySeconds&quot;: 0.497,
+    &quot;sendCompletionSeconds&quot;: null,
+    &quot;sendLatencySeconds&quot;: null,
+    &quot;sendRequestMarker&quot;: null,
+    &quot;startupMarker&quot;: &quot;06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial&quot;,
+    &quot;startupObserved&quot;: true,
+    &quot;startupWaitSeconds&quot;: 0.5,
+    &quot;transportEvidence&quot;: &quot;06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -&gt; Started&quot;,
+    &quot;transportMode&quot;: &quot;GATT&quot;,
+    &quot;trustConnectionMarker&quot;: null,
+    &quot;trustConnectionSeconds&quot;: null
+  },
+  &quot;totalSeconds&quot;: 15.3,
+  &quot;transportEvidence&quot;: &quot;06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype&quot;,
+  &quot;transportMode&quot;: &quot;GATT&quot;
+}</pre></details>
+</body></html>

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.json
@@ -1,0 +1,104 @@
+{
+  "status": "failed",
+  "scenario": "direct-guided",
+  "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+  "storageSubdirectory": "02_a065_xcover_initial",
+  "senderPlatform": "android",
+  "passivePlatform": "android",
+  "senderSerial": "1f1dad34",
+  "passiveSerial": "42004386e43c8589",
+  "senderCompletion": null,
+  "passiveCompletion": null,
+  "senderFailure": "06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+  "senderPowerState": "06-18 13:34:52.631 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION power.state stage=onResume interactive=true powerSaveMode=false directProof=true",
+  "passivePowerState": null,
+  "startupState": null,
+  "startupStateEvidence": null,
+  "routeStage": "peer-discovered",
+  "routeEvidence": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+  "senderRouteStage": "peer-discovered",
+  "senderRouteEvidence": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+  "passiveRouteStage": null,
+  "passiveRouteEvidence": null,
+  "startupTiming": {
+    "sender": {
+      "observed": true,
+      "elapsedSeconds": 0.5,
+      "line": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+    },
+    "passive": {
+      "observed": true,
+      "elapsedSeconds": 1.8,
+      "line": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    },
+    "passiveTransport": {
+      "observed": true,
+      "elapsedSeconds": 0.3,
+      "line": "06-18 13:34:50.805 21893 22025 I MeshLinkProof: gatt.benchmark.start() -> Started"
+    },
+    "launch": {
+      "passiveStartupWaitSeconds": 20.0,
+      "passiveTransportWaitSeconds": 20.0,
+      "postResultIdleSeconds": 2.0
+    },
+    "totalSeconds": 15.3
+  },
+  "timings": {
+    "totalSeconds": 15.3,
+    "androidReadySeconds": 20.0,
+    "captureTimeoutSeconds": 30.0,
+    "transportMode": "GATT",
+    "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "sender": {
+      "startupWaitSeconds": 0.5,
+      "startupObserved": true,
+      "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+      "peerDiscoverySeconds": 0.497,
+      "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "trustConnectionSeconds": null,
+      "trustConnectionMarker": null,
+      "sendLatencySeconds": null,
+      "sendCompletionSeconds": null,
+      "sendRequestMarker": null,
+      "completionMarker": null,
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+    },
+    "passive": {
+      "startupWaitSeconds": 1.8,
+      "startupObserved": true,
+      "startupMarker": null,
+      "peerDiscoverySeconds": null,
+      "peerDiscoveryMarker": null,
+      "trustConnectionSeconds": null,
+      "trustConnectionMarker": null,
+      "sendLatencySeconds": null,
+      "receiptSeconds": null,
+      "sendRequestMarker": null,
+      "completionMarker": null,
+      "transportMode": "GATT",
+      "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+    }
+  },
+  "htmlReportPath": "summary.html",
+  "exportRelativePath": null,
+  "failureStage": "capture",
+  "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+  "evidence": {
+    "senderLogcat": "sender_logcat.log",
+    "passiveLogcat": "passive_logcat.log",
+    "senderStart": "sender_start.txt",
+    "passiveStart": "passive_start.txt",
+    "androidHistory": "android_history.json",
+    "androidExport": "android_export.json"
+  },
+  "captured": {
+    "senderLogcat": true,
+    "passiveLogcat": true,
+    "senderStart": true,
+    "passiveStart": true,
+    "androidHistory": false,
+    "androidExport": false
+  },
+  "partialEvidenceAvailable": true
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_report.md
@@ -1,0 +1,204 @@
+# Pair 02 — a065_xcover
+
+## Setup
+
+- Sender: A065 (1f1dad34)
+- Passive: SM-G390F (42004386e43c8589)
+- Sender API level: 36
+- Passive API level: 28
+- Transport: GATT
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md`
+- Pair report path: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_report.md`
+- Peer lookup time: —
+- Initial run dir: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial`
+- Final run dir: `—`
+
+## Result
+
+- Initial status: failed (capture) in 15.4s
+- Final status: skipped (capture) in 15.4s
+- Target peer id: not resolved
+- Initial HTML report: `summary.html`
+- Final HTML report: `summary.html`
+- Initial summary JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.json`
+- Final summary JSON: `—`
+
+## Troubleshooting references
+
+| Initial artifact | Path | Captured |
+|---|---|---|
+| Initial senderLogcat | `sender_logcat.log` | yes |
+| Initial passiveLogcat | `passive_logcat.log` | yes |
+| Initial senderStart | `sender_start.txt` | yes |
+| Initial passiveStart | `passive_start.txt` | yes |
+| Initial androidHistory | `android_history.json` | no |
+| Initial androidExport | `android_export.json` | no |
+| Final artifact | Path | Captured |
+|---|---|---|
+| Final senderLogcat | `—` | no |
+| Final passiveLogcat | `—` | no |
+| Final senderStart | `—` | no |
+| Final passiveStart | `—` | no |
+| Final androidHistory | `—` | no |
+| Final androidExport | `—` | no |
+
+## Device quirks and issues
+
+- Transport used for the pair: GATT
+- Fallback reason: android API below 33; using GATT fallback (senderApiLevel=36 passiveApiLevel=28)
+- Passive API level 28 is below the floor 33.
+- Initial run failure: Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)
+- Final run failure: Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)
+
+## Startup timing
+
+Initial startupTiming
+
+```json
+{
+  "launch": {
+    "passiveStartupWaitSeconds": 20.0,
+    "passiveTransportWaitSeconds": 20.0,
+    "postResultIdleSeconds": 2.0
+  },
+  "passive": {
+    "elapsedSeconds": 1.8,
+    "line": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "observed": true
+  },
+  "passiveTransport": {
+    "elapsedSeconds": 0.3,
+    "line": "06-18 13:34:50.805 21893 22025 I MeshLinkProof: gatt.benchmark.start() -> Started",
+    "observed": true
+  },
+  "sender": {
+    "elapsedSeconds": 0.5,
+    "line": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+    "observed": true
+  },
+  "totalSeconds": 15.3
+}
+```
+
+Initial timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": null,
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 1.8,
+    "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "sender": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.497,
+    "sendCompletionSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "totalSeconds": 15.3,
+  "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Final startupTiming
+
+```json
+{}
+```
+
+Final timings
+
+```json
+{
+  "androidReadySeconds": 20.0,
+  "captureTimeoutSeconds": 30.0,
+  "passive": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": null,
+    "peerDiscoverySeconds": null,
+    "receiptSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": null,
+    "startupObserved": true,
+    "startupWaitSeconds": 1.8,
+    "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "sender": {
+    "completionMarker": null,
+    "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+    "peerDiscoverySeconds": 0.497,
+    "sendCompletionSeconds": null,
+    "sendLatencySeconds": null,
+    "sendRequestMarker": null,
+    "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+    "startupObserved": true,
+    "startupWaitSeconds": 0.5,
+    "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started",
+    "transportMode": "GATT",
+    "trustConnectionMarker": null,
+    "trustConnectionSeconds": null
+  },
+  "totalSeconds": 15.3,
+  "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+  "transportMode": "GATT"
+}
+```
+
+Captured evidence map
+
+```json
+{
+  "final": {},
+  "initial": {
+    "androidExport": false,
+    "androidHistory": false,
+    "passiveLogcat": true,
+    "passiveStart": true,
+    "senderLogcat": true,
+    "senderStart": true
+  }
+}
+```
+
+## Mermaid sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Matrix
+    participant Sender as A065
+    participant Passive as SM-G390F
+    note over Matrix: transport GATT
+    note over Matrix: fleet inventory fleet.md
+    note over Matrix: pair report 02_a065_xcover_report.md
+    Matrix->>Sender: initial run (15.4s)
+    note over Sender: failed (capture)
+    alt initial failed
+        note over Matrix: fail-fast stop after initial failure
+    end
+```

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/INDEX.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/INDEX.md
@@ -1,0 +1,35 @@
+# Android direct-proof fleet run 20260618T133249
+
+This tracked fleet sweep bundle lives under `reports/android-direct-proof-fleet/runs/`.
+
+## Result summary
+
+- Fail-fast sweep: yes
+- Completed pairs: 2
+- Stopped early: yes
+- Stop reason: `pair a065_xcover failed during capture`
+- Run summary: [SUMMARY.md](SUMMARY.md)
+
+## Pair reports
+
+- [01_a065_nam_lx9_report.md](01_a065_nam_lx9_report.md)
+- [02_a065_xcover_report.md](02_a065_xcover_report.md)
+
+## Bundle contents
+
+- `fleet.json`
+- `fleet.md`
+- `matrix-results.json`
+- `matrix-report.md`
+- `progress.json`
+- `state.json`
+- `SUMMARY.md`
+- `01_a065_nam_lx9_initial/`
+- `01_a065_nam_lx9_final/`
+- `02_a065_xcover_initial/`
+- `02_a065_xcover_final/`
+
+## Notes
+
+This bundle is in the repository-root `reports/` tree so it can be reviewed, diffed, and referenced alongside the code that produced it.
+The summary above is the first place to look before opening the per-pair report files.

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/SUMMARY.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/SUMMARY.md
@@ -1,0 +1,45 @@
+# Android direct-proof fleet run summary
+
+## Outcome
+
+- Sweep mode: fail-fast
+- Total directed pairs discovered: 30
+- Completed pairs: 2
+- Stopped early: yes
+- Stop reason: `pair a065_xcover failed during capture`
+
+## What happened
+
+1. `a065_nam_lx9` passed end-to-end on GATT fallback.
+2. `a065_xcover` failed during capture and the sweep stopped immediately.
+3. The sweep did not reach `a065_mi_note3` in this run.
+
+## Key evidence
+
+- Fleet inventory: `fleet.md` and `fleet.json`
+- Matrix summary: `matrix-report.md`
+- Per-pair reports:
+  - `01_a065_nam_lx9_report.md`
+  - `02_a065_xcover_report.md`
+- Xcover failure report:
+  - initial summary: `02_a065_xcover_initial/summary.json`
+  - initial HTML report: `02_a065_xcover_initial/summary.html`
+  - initial sender logcat: `02_a065_xcover_initial/sender_logcat.log`
+  - initial passive logcat: `02_a065_xcover_initial/passive_logcat.log`
+
+## Observed failure mode
+
+The xcover pair failed before retained completion.
+The report shows the sender emitted `proof.failed` with `Error(GATT benchmark)` during the capture phase.
+
+## Next fix to try
+
+- Inspect the xcover sender and passive logcats for the GATT benchmark failure path.
+- Check whether the passive SDK 28 GATT fallback is too brittle for this pair and needs a device-specific guard or a different transport selection.
+- Keep the fail-fast sweep behavior unchanged so later failures are not masked.
+
+## Related paths
+
+- Run index: `INDEX.md`
+- Run bundle root: `.`
+- Top-level reports index: `../../../../INDEX.md`

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json
@@ -1,0 +1,280 @@
+{
+  "capturedAt": "20260618T133250",
+  "failFast": true,
+  "deviceCount": 12,
+  "pairCount": 30,
+  "devices": [
+    {
+      "serial": "1f1dad34",
+      "model": "A065",
+      "apiLevel": 36
+    },
+    {
+      "serial": "2ASVB21B09005117",
+      "model": "NAM-LX9",
+      "apiLevel": 31
+    },
+    {
+      "serial": "42004386e43c8589",
+      "model": "SM-G390F",
+      "apiLevel": 28
+    },
+    {
+      "serial": "42c2cf",
+      "model": "Mi Note 3",
+      "apiLevel": 28
+    },
+    {
+      "serial": "7XHEIBPBLRJJSKFU",
+      "model": "7XHEIBPBLRJJSKFU",
+      "apiLevel": 35
+    },
+    {
+      "serial": "EQUGS85LJNEIO7Z5",
+      "model": "CPH2359",
+      "apiLevel": 34
+    },
+    {
+      "serial": "GX6CTR500184",
+      "model": "E940-2849-00",
+      "apiLevel": 33
+    },
+    {
+      "serial": "ZY22GCD9ST",
+      "model": "ZY22GCD9ST",
+      "apiLevel": 34
+    },
+    {
+      "serial": "e9097611",
+      "model": "e9097611",
+      "apiLevel": 29
+    },
+    {
+      "serial": "adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp",
+      "model": "adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp",
+      "apiLevel": 34
+    },
+    {
+      "serial": "adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp",
+      "model": "adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp",
+      "apiLevel": 33
+    },
+    {
+      "serial": "adb-bb722dcd-7SjtpI._adb-tls-connect._tcp",
+      "model": "adb-bb722dcd-7SjtpI._adb-tls-connect._tcp",
+      "apiLevel": 31
+    }
+  ],
+  "availablePairs": [
+    {
+      "label": "a065_nam_lx9",
+      "sender": "1f1dad34",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "A065",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "a065_xcover",
+      "sender": "1f1dad34",
+      "passive": "42004386e43c8589",
+      "senderModel": "A065",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "a065_mi_note3",
+      "sender": "1f1dad34",
+      "passive": "42c2cf",
+      "senderModel": "A065",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "a065_cph2359",
+      "sender": "1f1dad34",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "A065",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "a065_e940",
+      "sender": "1f1dad34",
+      "passive": "GX6CTR500184",
+      "senderModel": "A065",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "nam_lx9_a065",
+      "sender": "2ASVB21B09005117",
+      "passive": "1f1dad34",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "nam_lx9_xcover",
+      "sender": "2ASVB21B09005117",
+      "passive": "42004386e43c8589",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "nam_lx9_mi_note3",
+      "sender": "2ASVB21B09005117",
+      "passive": "42c2cf",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "nam_lx9_cph2359",
+      "sender": "2ASVB21B09005117",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "nam_lx9_e940",
+      "sender": "2ASVB21B09005117",
+      "passive": "GX6CTR500184",
+      "senderModel": "NAM-LX9",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "xcover_a065",
+      "sender": "42004386e43c8589",
+      "passive": "1f1dad34",
+      "senderModel": "SM-G390F",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "xcover_nam_lx9",
+      "sender": "42004386e43c8589",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "SM-G390F",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "xcover_mi_note3",
+      "sender": "42004386e43c8589",
+      "passive": "42c2cf",
+      "senderModel": "SM-G390F",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "xcover_cph2359",
+      "sender": "42004386e43c8589",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "SM-G390F",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "xcover_e940",
+      "sender": "42004386e43c8589",
+      "passive": "GX6CTR500184",
+      "senderModel": "SM-G390F",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "mi_note3_a065",
+      "sender": "42c2cf",
+      "passive": "1f1dad34",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "mi_note3_nam_lx9",
+      "sender": "42c2cf",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "mi_note3_xcover",
+      "sender": "42c2cf",
+      "passive": "42004386e43c8589",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "mi_note3_cph2359",
+      "sender": "42c2cf",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "CPH2359"
+    },
+    {
+      "label": "mi_note3_e940",
+      "sender": "42c2cf",
+      "passive": "GX6CTR500184",
+      "senderModel": "Mi Note 3",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "cph2359_a065",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "1f1dad34",
+      "senderModel": "CPH2359",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "cph2359_nam_lx9",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "CPH2359",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "cph2359_xcover",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "42004386e43c8589",
+      "senderModel": "CPH2359",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "cph2359_mi_note3",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "42c2cf",
+      "senderModel": "CPH2359",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "cph2359_e940",
+      "sender": "EQUGS85LJNEIO7Z5",
+      "passive": "GX6CTR500184",
+      "senderModel": "CPH2359",
+      "passiveModel": "E940-2849-00"
+    },
+    {
+      "label": "e940_a065",
+      "sender": "GX6CTR500184",
+      "passive": "1f1dad34",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "A065"
+    },
+    {
+      "label": "e940_nam_lx9",
+      "sender": "GX6CTR500184",
+      "passive": "2ASVB21B09005117",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "NAM-LX9"
+    },
+    {
+      "label": "e940_xcover",
+      "sender": "GX6CTR500184",
+      "passive": "42004386e43c8589",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "SM-G390F"
+    },
+    {
+      "label": "e940_mi_note3",
+      "sender": "GX6CTR500184",
+      "passive": "42c2cf",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "Mi Note 3"
+    },
+    {
+      "label": "e940_cph2359",
+      "sender": "GX6CTR500184",
+      "passive": "EQUGS85LJNEIO7Z5",
+      "senderModel": "E940-2849-00",
+      "passiveModel": "CPH2359"
+    }
+  ]
+}

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md
@@ -1,0 +1,58 @@
+# Android fleet inventory
+
+- Captured: 20260618T133250
+- Fail-fast: enabled
+- Device count: 12
+- Pair count: 30
+
+## Devices
+
+| Serial | Model | API level |
+|---|---|---|
+| 1f1dad34 | A065 | 36 |
+| 2ASVB21B09005117 | NAM-LX9 | 31 |
+| 42004386e43c8589 | SM-G390F | 28 |
+| 42c2cf | Mi Note 3 | 28 |
+| 7XHEIBPBLRJJSKFU | 7XHEIBPBLRJJSKFU | 35 |
+| EQUGS85LJNEIO7Z5 | CPH2359 | 34 |
+| GX6CTR500184 | E940-2849-00 | 33 |
+| ZY22GCD9ST | ZY22GCD9ST | 34 |
+| e9097611 | e9097611 | 29 |
+| adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp | adb-AQKSLVH004M52800029-gRaTr5._adb-tls-connect._tcp | 34 |
+| adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp | adb-MZLJMJAIO7SKS8BI-iOFt5D._adb-tls-connect._tcp | 33 |
+| adb-bb722dcd-7SjtpI._adb-tls-connect._tcp | adb-bb722dcd-7SjtpI._adb-tls-connect._tcp | 31 |
+
+## Available directed pairs
+
+| Label | Sender | Passive |
+|---|---|---|
+| a065_nam_lx9 | A065 (1f1dad34) | NAM-LX9 (2ASVB21B09005117) |
+| a065_xcover | A065 (1f1dad34) | SM-G390F (42004386e43c8589) |
+| a065_mi_note3 | A065 (1f1dad34) | Mi Note 3 (42c2cf) |
+| a065_cph2359 | A065 (1f1dad34) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| a065_e940 | A065 (1f1dad34) | E940-2849-00 (GX6CTR500184) |
+| nam_lx9_a065 | NAM-LX9 (2ASVB21B09005117) | A065 (1f1dad34) |
+| nam_lx9_xcover | NAM-LX9 (2ASVB21B09005117) | SM-G390F (42004386e43c8589) |
+| nam_lx9_mi_note3 | NAM-LX9 (2ASVB21B09005117) | Mi Note 3 (42c2cf) |
+| nam_lx9_cph2359 | NAM-LX9 (2ASVB21B09005117) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| nam_lx9_e940 | NAM-LX9 (2ASVB21B09005117) | E940-2849-00 (GX6CTR500184) |
+| xcover_a065 | SM-G390F (42004386e43c8589) | A065 (1f1dad34) |
+| xcover_nam_lx9 | SM-G390F (42004386e43c8589) | NAM-LX9 (2ASVB21B09005117) |
+| xcover_mi_note3 | SM-G390F (42004386e43c8589) | Mi Note 3 (42c2cf) |
+| xcover_cph2359 | SM-G390F (42004386e43c8589) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| xcover_e940 | SM-G390F (42004386e43c8589) | E940-2849-00 (GX6CTR500184) |
+| mi_note3_a065 | Mi Note 3 (42c2cf) | A065 (1f1dad34) |
+| mi_note3_nam_lx9 | Mi Note 3 (42c2cf) | NAM-LX9 (2ASVB21B09005117) |
+| mi_note3_xcover | Mi Note 3 (42c2cf) | SM-G390F (42004386e43c8589) |
+| mi_note3_cph2359 | Mi Note 3 (42c2cf) | CPH2359 (EQUGS85LJNEIO7Z5) |
+| mi_note3_e940 | Mi Note 3 (42c2cf) | E940-2849-00 (GX6CTR500184) |
+| cph2359_a065 | CPH2359 (EQUGS85LJNEIO7Z5) | A065 (1f1dad34) |
+| cph2359_nam_lx9 | CPH2359 (EQUGS85LJNEIO7Z5) | NAM-LX9 (2ASVB21B09005117) |
+| cph2359_xcover | CPH2359 (EQUGS85LJNEIO7Z5) | SM-G390F (42004386e43c8589) |
+| cph2359_mi_note3 | CPH2359 (EQUGS85LJNEIO7Z5) | Mi Note 3 (42c2cf) |
+| cph2359_e940 | CPH2359 (EQUGS85LJNEIO7Z5) | E940-2849-00 (GX6CTR500184) |
+| e940_a065 | E940-2849-00 (GX6CTR500184) | A065 (1f1dad34) |
+| e940_nam_lx9 | E940-2849-00 (GX6CTR500184) | NAM-LX9 (2ASVB21B09005117) |
+| e940_xcover | E940-2849-00 (GX6CTR500184) | SM-G390F (42004386e43c8589) |
+| e940_mi_note3 | E940-2849-00 (GX6CTR500184) | Mi Note 3 (42c2cf) |
+| e940_cph2359 | E940-2849-00 (GX6CTR500184) | CPH2359 (EQUGS85LJNEIO7Z5) |

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/matrix-report.md
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/matrix-report.md
@@ -1,0 +1,22 @@
+# Android direct-proof matrix report
+
+## Passing pairs
+
+| Sender | Passive | Result |
+|---|---|---|
+| A065 | NAM-LX9 | passed |
+
+## Most common failure reason per device
+
+| Device | Most common failure reason | Count |
+|---|---|---|
+| A065 | passed | 1 |
+
+
+## Run setup
+
+- Fleet inventory: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md`
+- Fleet JSON: `/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json`
+- Fail-fast: enabled
+- Stopped early: yes
+- Stop reason: pair a065_xcover failed during capture

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/matrix-results.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/matrix-results.json
@@ -1,0 +1,418 @@
+[
+  {
+    "label": "a065_nam_lx9",
+    "sender": "1f1dad34",
+    "passive": "2ASVB21B09005117",
+    "senderModel": "A065",
+    "passiveModel": "NAM-LX9",
+    "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+    "targetPeerId": null,
+    "initial": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 13:32:58.705 20014 20042 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 27.5,
+        "install": {
+          "senderSeconds": 9.0,
+          "passiveSeconds": 7.4,
+          "senderReused": false,
+          "passiveReused": false
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.1,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 27.5,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+          "peerDiscoverySeconds": 0.383,
+          "peerDiscoveryMarker": "06-18 13:33:00.228 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.554,
+          "trustConnectionMarker": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 2.102,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:32:59.855 19996 19996 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 13:33:00.469 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "sendLatencySeconds": 1.145,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "completionMarker": "06-18 13:33:01.613 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=7a8c16ffe10c4a17 bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": false,
+        "passiveInstallReused": false
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial"
+    },
+    "final": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 13:34:21.013 20333 20366 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 18.1,
+        "install": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": true,
+          "passiveReused": true
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 18.1,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+          "peerDiscoverySeconds": 0.383,
+          "peerDiscoveryMarker": "06-18 13:34:22.568 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.383,
+          "trustConnectionMarker": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.871,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:22.194 20449 20449 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 13:34:22.641 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "sendLatencySeconds": 1.086,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "completionMarker": "06-18 13:34:23.726 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=f6740680cf304274 bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": true,
+        "passiveInstallReused": true
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final"
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": 63.8,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 31,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  {
+    "label": "a065_xcover",
+    "sender": "1f1dad34",
+    "passive": "42004386e43c8589",
+    "senderModel": "A065",
+    "passiveModel": "SM-G390F",
+    "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+    "targetPeerId": null,
+    "initial": {
+      "status": "failed",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "peer-discovered",
+      "routeEvidence": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "peer-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.8,
+          "line": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.3,
+          "line": "06-18 13:34:50.805 21893 22025 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 15.3
+      },
+      "timings": {
+        "totalSeconds": 15.3,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.497,
+          "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": false,
+        "androidExport": false
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial"
+    },
+    "final": {
+      "status": "skipped",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": null,
+      "routeEvidence": null,
+      "senderRouteStage": null,
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": null,
+      "timings": {
+        "totalSeconds": 15.3,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.497,
+          "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": null,
+      "captured": null,
+      "summaryPath": null,
+      "runDir": null
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": null,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  }
+]

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/progress.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/progress.json
@@ -1,0 +1,418 @@
+[
+  {
+    "label": "a065_nam_lx9",
+    "sender": "1f1dad34",
+    "passive": "2ASVB21B09005117",
+    "senderModel": "A065",
+    "passiveModel": "NAM-LX9",
+    "appId": "demo.meshlink.reference.android-direct.a065_nam_lx9",
+    "targetPeerId": null,
+    "initial": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 13:32:58.705 20014 20042 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 27.5,
+        "install": {
+          "senderSeconds": 9.0,
+          "passiveSeconds": 7.4,
+          "senderReused": false,
+          "passiveReused": false
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.1,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 27.5,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:32:59.845 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_initial",
+          "peerDiscoverySeconds": 0.383,
+          "peerDiscoveryMarker": "06-18 13:33:00.228 19996 19996 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.554,
+          "trustConnectionMarker": "06-18 13:33:00.782 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 2.102,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 13:33:01.947 19996 20035 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:32:59.855 19996 19996 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 13:33:00.469 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "sendLatencySeconds": 1.145,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 13:33:00.468 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "completionMarker": "06-18 13:33:01.613 20014 20037 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=7a8c16ffe10c4a17 bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:32:58.667 20014 20014 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": false,
+        "passiveInstallReused": false
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial"
+    },
+    "final": {
+      "status": "passed",
+      "failureStage": null,
+      "failureReason": null,
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "route-discovered",
+      "routeEvidence": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "route-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": "route-discovered",
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.0,
+          "line": "06-18 13:34:21.013 20333 20366 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": false,
+          "passiveReused": false,
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 18.1,
+        "install": {
+          "senderSeconds": null,
+          "passiveSeconds": null,
+          "senderReused": true,
+          "passiveReused": true
+        },
+        "permissions": {
+          "senderSeconds": 0.1,
+          "passiveSeconds": 0.2,
+          "senderReused": false,
+          "passiveReused": false
+        }
+      },
+      "timings": {
+        "totalSeconds": 18.1,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:22.185 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_nam_lx9 storage=01_a065_nam_lx9_final",
+          "peerDiscoverySeconds": 0.383,
+          "peerDiscoveryMarker": "06-18 13:34:22.568 20449 20449 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": 0.383,
+          "trustConnectionMarker": "06-18 13:34:22.951 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=SENDER peer=gatt-notify-bridge",
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": 1.871,
+          "sendRequestMarker": null,
+          "completionMarker": "06-18 13:34:24.056 20449 20495 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.complete role=sender",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:22.194 20449 20449 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "trustConnectionSeconds": 0.001,
+          "trustConnectionMarker": "06-18 13:34:22.641 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION ROUTE_DISCOVERED role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "sendLatencySeconds": 1.086,
+          "receiptSeconds": null,
+          "sendRequestMarker": "06-18 13:34:22.640 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION peer.discovered role=PASSIVE peer=66:92:2E:1C:0C:D6",
+          "completionMarker": "06-18 13:34:23.726 20333 20354 I MeshLinkProof: REFERENCE_AUTOMATION proof.complete role=passive peer=66:92:2E:1C:0C:D6 token=f6740680cf304274 bytes=51",
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:20.976 20333 20333 I MeshLinkProof: MeshLink proof app ready on HUAWEI NAM-LX9 (SDK 31) appId=demo.meshlink.reference.android-direct.a065_nam_lx9 powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "senderInstallReused": true,
+        "passiveInstallReused": true
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": true,
+        "androidExport": true
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final"
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/01_a065_nam_lx9_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": 63.8,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 31,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  {
+    "label": "a065_xcover",
+    "sender": "1f1dad34",
+    "passive": "42004386e43c8589",
+    "senderModel": "A065",
+    "passiveModel": "SM-G390F",
+    "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+    "targetPeerId": null,
+    "initial": {
+      "status": "failed",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "peer-discovered",
+      "routeEvidence": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "peer-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.8,
+          "line": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.3,
+          "line": "06-18 13:34:50.805 21893 22025 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 15.3
+      },
+      "timings": {
+        "totalSeconds": 15.3,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.497,
+          "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": false,
+        "androidExport": false
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial"
+    },
+    "final": {
+      "status": "skipped",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": null,
+      "routeEvidence": null,
+      "senderRouteStage": null,
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": null,
+      "timings": {
+        "totalSeconds": 15.3,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.497,
+          "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": null,
+      "captured": null,
+      "summaryPath": null,
+      "runDir": null
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": null,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  }
+]

--- a/reports/android-direct-proof-fleet/runs/20260618T133249/state.json
+++ b/reports/android-direct-proof-fleet/runs/20260618T133249/state.json
@@ -1,0 +1,182 @@
+{
+  "runRoot": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249",
+  "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md",
+  "totalPairs": 30,
+  "completedPairs": 2,
+  "pendingPairs": 28,
+  "lastPair": {
+    "label": "a065_xcover",
+    "sender": "1f1dad34",
+    "passive": "42004386e43c8589",
+    "senderModel": "A065",
+    "passiveModel": "SM-G390F",
+    "appId": "demo.meshlink.reference.android-direct.a065_xcover",
+    "targetPeerId": null,
+    "initial": {
+      "status": "failed",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": "peer-discovered",
+      "routeEvidence": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+      "senderRouteStage": "peer-discovered",
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": {
+        "sender": {
+          "observed": true,
+          "elapsedSeconds": 0.5,
+          "line": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial"
+        },
+        "passive": {
+          "observed": true,
+          "elapsedSeconds": 1.8,
+          "line": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        },
+        "passiveTransport": {
+          "observed": true,
+          "elapsedSeconds": 0.3,
+          "line": "06-18 13:34:50.805 21893 22025 I MeshLinkProof: gatt.benchmark.start() -> Started"
+        },
+        "launch": {
+          "passiveStartupWaitSeconds": 20.0,
+          "passiveTransportWaitSeconds": 20.0,
+          "postResultIdleSeconds": 2.0
+        },
+        "totalSeconds": 15.3
+      },
+      "timings": {
+        "totalSeconds": 15.3,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.497,
+          "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": {
+        "senderLogcat": "sender_logcat.log",
+        "passiveLogcat": "passive_logcat.log",
+        "senderStart": "sender_start.txt",
+        "passiveStart": "passive_start.txt",
+        "androidHistory": "android_history.json",
+        "androidExport": "android_export.json"
+      },
+      "captured": {
+        "senderLogcat": true,
+        "passiveLogcat": true,
+        "senderStart": true,
+        "passiveStart": true,
+        "androidHistory": false,
+        "androidExport": false
+      },
+      "summaryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial/summary.json",
+      "runDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial"
+    },
+    "final": {
+      "status": "skipped",
+      "failureStage": "capture",
+      "failureReason": "Android sender reported proof.failed before retained completion: 06-18 13:34:53.405 20751 20765 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION proof.failed role=sender reason=Error(GATT benchmark)",
+      "senderCompletion": null,
+      "passiveCompletion": null,
+      "routeStage": null,
+      "routeEvidence": null,
+      "senderRouteStage": null,
+      "senderRouteEvidence": null,
+      "passiveRouteStage": null,
+      "passiveRouteEvidence": null,
+      "startupTiming": null,
+      "timings": {
+        "totalSeconds": 15.3,
+        "androidReadySeconds": 20.0,
+        "captureTimeoutSeconds": 30.0,
+        "transportMode": "GATT",
+        "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype",
+        "sender": {
+          "startupWaitSeconds": 0.5,
+          "startupObserved": true,
+          "startupMarker": "06-18 13:34:52.601 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink.reference.android-direct.a065_xcover storage=02_a065_xcover_initial",
+          "peerDiscoverySeconds": 0.497,
+          "peerDiscoveryMarker": "06-18 13:34:53.098 20751 20751 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION peer.discovered role=SENDER peer=gatt-notify-bridge",
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "sendCompletionSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:52.609 20751 20751 I MeshLinkReferenceAutomation: gatt.start() -> Started"
+        },
+        "passive": {
+          "startupWaitSeconds": 1.8,
+          "startupObserved": true,
+          "startupMarker": null,
+          "peerDiscoverySeconds": null,
+          "peerDiscoveryMarker": null,
+          "trustConnectionSeconds": null,
+          "trustConnectionMarker": null,
+          "sendLatencySeconds": null,
+          "receiptSeconds": null,
+          "sendRequestMarker": null,
+          "completionMarker": null,
+          "transportMode": "GATT",
+          "transportEvidence": "06-18 13:34:50.592 21893 21893 I MeshLinkProof: MeshLink proof app ready on samsung SM-G390F (SDK 28) appId=demo.meshlink.reference.android-direct.a065_xcover powerMode=Automatic primaryTransport=gattPrototype benchmarkTransport=gattPrototype"
+        }
+      },
+      "htmlReportPath": "summary.html",
+      "exportRelativePath": null,
+      "evidence": null,
+      "captured": null,
+      "summaryPath": null,
+      "runDir": null
+    },
+    "initialRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_initial",
+    "finalRunDir": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_final",
+    "pairReportPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/02_a065_xcover_report.md",
+    "fleetJsonPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.json",
+    "fleetInventoryPath": "/home/phil/Projects/MeshLink/reports/android-direct-proof-fleet/runs/20260618T133249/fleet.md",
+    "transportMode": "gatt",
+    "peerLookupSeconds": null,
+    "fallbackReason": {
+      "senderApiLevel": 36,
+      "passiveApiLevel": 28,
+      "reason": "android API below 33; using GATT fallback"
+    },
+    "failFast": true
+  },
+  "failFast": true,
+  "stoppedEarly": true,
+  "stopReason": "pair a065_xcover failed during capture"
+}


### PR DESCRIPTION
## Summary

Track the latest Android direct-proof fleet sweep under `reports/` and keep the repository-local bundle index, per-run summary, and artifact links in sync.

### What changed
- default fleet-report output now lands under `reports/android-direct-proof-fleet/runs/<timestamp>/`
- added repository-tracked report navigation at `reports/INDEX.md` and `reports/README.md`
- added a run-local `SUMMARY.md` and `INDEX.md` for the latest tracked sweep
- committed the latest tracked bundle so the repo contains a concrete fleet evidence set
- updated docs references to point at the repository-root reports tree

### Latest tracked run
- 12 devices discovered
- 30 directed pairs discovered
- 2 pairs completed before fail-fast stop
- stop reason: `pair a065_xcover failed during capture`

### Verification
- `python -m unittest meshlink-reference/scripts/tests/test_docs_index_links.py -v`
- `cd meshlink-reference/scripts && python -m unittest discover -s tests -p 'test_reference_android_direct_matrix.py' -v`
- `verifyDocs` passed in the push hook

