### PR TITLE
fix: make gatt a real transport bearer

### DIFF
--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt
@@ -96,11 +96,10 @@ internal class LiveProofAutomationCoordinator(
                 meshStartRequested = progress.meshStartRequested,
                 snapshot = snapshot,
                 readinessBlockers = readinessBlockers,
-                benchmarkTransport = automationConfig.benchmarkTransport,
             )
         if (!shouldRequest) {
             actions.emitAutomationLog(
-                "REFERENCE_AUTOMATION mesh.start.skipped role=${automationConfig.role} meshStartRequested=${progress.meshStartRequested} meshState=${snapshot.session.meshStateLabel} benchmarkTransport=${automationConfig.benchmarkTransport} readinessBlockers=${readinessBlockers.joinToString(separator = "|")}"
+                "REFERENCE_AUTOMATION mesh.start.skipped role=${automationConfig.role} meshStartRequested=${progress.meshStartRequested} meshState=${snapshot.session.meshStateLabel} readinessBlockers=${readinessBlockers.joinToString(separator = "|")}"
             )
             return
         }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt
@@ -49,11 +49,7 @@ internal class LiveProofAutomationDriver(
                 "snapshotPeers=${timelineUiState.liveSnapshot.peers.size} " +
                 "timelineEntries=${timelineUiState.liveSnapshot.timeline.size}"
         )
-        if (
-            config.role == ReferenceAutomationRole.SENDER &&
-                !progress.meshStartRequested &&
-                config.benchmarkTransport.equals("meshlink", ignoreCase = true)
-        ) {
+        if (config.role == ReferenceAutomationRole.SENDER && !progress.meshStartRequested) {
             actions.emitAutomationLog(
                 "REFERENCE_AUTOMATION mesh.start.requested role=${config.role} meshState=${timelineUiState.liveSnapshot.session.meshStateLabel} readinessBlockers=${actions.readinessBlockers.joinToString(separator = "|")}"
             )

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationSenderStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationSenderStepRunner.kt
@@ -8,10 +8,7 @@ internal fun runSenderAutomationStep(
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
 ): Unit {
-    if (
-        !progress.meshStartRequested &&
-            automationConfig.benchmarkTransport.equals("meshlink", ignoreCase = true)
-    ) {
+    if (!progress.meshStartRequested) {
         actions.emitAutomationLog(
             "REFERENCE_AUTOMATION mesh.start.requested role=${automationConfig.role} meshState=${snapshot.session.meshStateLabel} readinessBlockers=${actions.readinessBlockers.joinToString(separator = "|")}"
         )

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationStatePredicates.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationStatePredicates.kt
@@ -6,12 +6,10 @@ internal fun shouldRequestLiveProofMeshStart(
     meshStartRequested: Boolean,
     snapshot: ReferenceControllerSnapshot,
     readinessBlockers: List<String>,
-    benchmarkTransport: String = "meshlink",
 ): Boolean {
     return !meshStartRequested &&
         !hasMeshEnteredLifecycle(snapshot.session.meshStateLabel) &&
-        readinessBlockers.isEmpty() &&
-        benchmarkTransport.equals("meshlink", ignoreCase = true)
+        readinessBlockers.isEmpty()
 }
 
 internal fun shouldRequestPauseForPauseResume(

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceAutomationConfig.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceAutomationConfig.kt
@@ -6,7 +6,6 @@ public data class ReferenceAutomationConfig(
     public val role: ReferenceAutomationRole,
     public val appId: String,
     public val storageSubdirectory: String,
-    public val benchmarkTransport: String = "meshlink",
     public val requiredPeerCount: Int = 1,
     public val targetPeerIndex: Int = 0,
     public val targetPeerId: String? = null,

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceStartupCoordinator.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceStartupCoordinator.kt
@@ -22,12 +22,6 @@ public class ReferenceStartupCoordinator(
         if (config.mode != ReferenceAutomationMode.LIVE_PROOF) {
             return
         }
-        if (!config.benchmarkTransport.equals("meshlink", ignoreCase = true)) {
-            platformServices.emitAutomationLog(
-                "REFERENCE_AUTOMATION startup.coordinator.skipped mode=${config.mode} role=${config.role} appId=${config.appId} benchmarkTransport=${config.benchmarkTransport} reason=non-meshlink-benchmark-transport"
-            )
-            return
-        }
         if (liveProofStartupRequested) {
             return
         }

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupportTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupportTest.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.runBlocking
 
 class PreferredGattSendSupportTest {
     @Test
-    fun sendViaPreferredGattSideLinkOrNullSkipsHandshakeFrames(): Unit = runBlocking {
+    fun sendViaPreferredGattSideLinkOrNullHandlesHandshakeFrames(): Unit = runBlocking {
         // Arrange
         val fixture = PreferredGattSendFixture()
         val frame =
@@ -30,8 +30,8 @@ class PreferredGattSendSupportTest {
             )
 
         // Assert
-        assertNull(result)
-        assertEquals(0, fixture.ensureSideLinkCalls)
+        assertEquals(TransportSendResult.Delivered, result)
+        assertEquals(1, fixture.ensureSideLinkCalls)
         assertEquals(0, fixture.restartReasons.size)
     }
 

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinator.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinator.kt
@@ -2,6 +2,7 @@ package ch.trancee.meshlink.platform.android
 
 import ch.trancee.meshlink.api.PeerId
 import ch.trancee.meshlink.transport.BleDiscoveryPlatformFamily
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.shouldUseMixedPlatformGattNotifyBearer
 
 internal interface GattSideLinkClient : PreferredGattSendClient {
@@ -37,10 +38,11 @@ internal class GattSideLinkCoordinator(
         localPlatformFamily: BleDiscoveryPlatformFamily,
     ): Unit {
         if (
-            !shouldUseMixedPlatformGattNotifyBearer(
-                localPlatformFamily = localPlatformFamily,
-                remotePlatformFamily = peer.platformFamily,
-            )
+            peer.transportMode != TransportMode.GATT &&
+                !shouldUseMixedPlatformGattNotifyBearer(
+                    localPlatformFamily = localPlatformFamily,
+                    remotePlatformFamily = peer.platformFamily,
+                )
         ) {
             return
         }

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupport.kt
@@ -35,7 +35,7 @@ internal suspend fun sendViaPreferredGattSideLinkOrNull(
     dependencies: PreferredGattSendDependencies,
 ): TransportSendResult? {
     val directFrame = runCatching { DirectWireFrame.decode(frame.payload) }.getOrNull()
-    if (directFrame !is DirectWireFrame.Data) {
+    if (directFrame == null) {
         return null
     }
 

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineHandshakeSupport.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineHandshakeSupport.kt
@@ -3,6 +3,7 @@ package ch.trancee.meshlink.engine
 import ch.trancee.meshlink.api.PeerId
 import ch.trancee.meshlink.diagnostics.DiagnosticReason
 import ch.trancee.meshlink.routing.RouteCoordinator
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 
 internal data class MeshEngineHandshakeState(val sessionRegistry: MeshEngineSessionRegistry)
@@ -13,7 +14,8 @@ internal data class MeshEngineHandshakeRoutingContext(
 )
 
 internal data class MeshEngineHandshakeCallbacks(
-    val sendDirectWireFrame: suspend (PeerId, DirectWireFrame, String) -> TransportSendResult,
+    val sendDirectWireFrame:
+        suspend (PeerId, DirectWireFrame, String, TransportMode?) -> TransportSendResult,
     val emitHopSessionEstablished: (PeerId, String) -> Unit,
     val emitHopSessionFailed: (PeerId, String, DiagnosticReason, Map<String, String>) -> Unit,
     val promoteTemporaryPeer: suspend (PeerId, PeerId) -> Unit,
@@ -27,7 +29,8 @@ internal data class PendingInitiatorHandshakeFailure(
 )
 
 internal fun buildMeshEngineRuntimeHandshakeCallbacks(
-    sendDirectWireFrame: suspend (PeerId, DirectWireFrame, String) -> TransportSendResult,
+    sendDirectWireFrame:
+        suspend (PeerId, DirectWireFrame, String, TransportMode?) -> TransportSendResult,
     emitHopSessionEstablished: (PeerId, String) -> Unit,
     emitHopSessionFailed: (PeerId, String, DiagnosticReason, Map<String, String>) -> Unit,
     promoteTemporaryPeer: suspend (PeerId, PeerId) -> Unit,

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineInitiatorHandshakeSupport.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineInitiatorHandshakeSupport.kt
@@ -4,6 +4,7 @@ import ch.trancee.meshlink.api.PeerId
 import ch.trancee.meshlink.crypto.NoiseXXHandshakeResult
 import ch.trancee.meshlink.diagnostics.DiagnosticReason
 import ch.trancee.meshlink.identity.LocalIdentity
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 import ch.trancee.meshlink.trust.TrustRecord
 
@@ -118,6 +119,7 @@ internal class MeshEngineInitiatorHandshakeSupport(
                 peerId,
                 DirectWireFrame.HandshakeMessage3(result.message3),
                 "handshake.message3",
+                TransportMode.GATT,
             )
         ) {
             TransportSendResult.Delivered ->

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineResponderHandshakeSupport.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineResponderHandshakeSupport.kt
@@ -5,6 +5,7 @@ import ch.trancee.meshlink.crypto.NoiseXXHandshakeManager
 import ch.trancee.meshlink.crypto.NoiseXXResponderResult
 import ch.trancee.meshlink.diagnostics.DiagnosticReason
 import ch.trancee.meshlink.identity.LocalIdentity
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 import ch.trancee.meshlink.trust.TrustRecord
 
@@ -37,6 +38,7 @@ internal class MeshEngineResponderHandshakeSupport(
                 peerId,
                 DirectWireFrame.HandshakeMessage2(message2),
                 "handshake.message2",
+                TransportMode.GATT,
             )
         ) {
             TransportSendResult.Delivered -> Unit

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineRuntimeSessionAssembly.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineRuntimeSessionAssembly.kt
@@ -85,8 +85,8 @@ internal fun buildMeshEngineRuntimeSessionAssembly(
         )
     val handshakeCallbacks =
         buildMeshEngineRuntimeHandshakeCallbacks(
-            sendDirectWireFrame = { peerId, frame, action ->
-                support.sendDirectWireFrame(peerId, frame, action, null)
+            sendDirectWireFrame = { peerId, frame, action, preferredMode ->
+                support.sendDirectWireFrame(peerId, frame, action, preferredMode)
             },
             emitHopSessionEstablished = hopTransportSupport::emitHopSessionEstablished,
             emitHopSessionFailed = hopTransportSupport::emitHopSessionFailed,

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineSessionSupport.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineSessionSupport.kt
@@ -6,6 +6,7 @@ import ch.trancee.meshlink.diagnostics.DiagnosticCode
 import ch.trancee.meshlink.diagnostics.DiagnosticReason
 import ch.trancee.meshlink.diagnostics.DiagnosticSeverity
 import ch.trancee.meshlink.identity.LocalIdentity
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -108,7 +109,7 @@ internal class MeshEngineSessionSupport(
                     peerId,
                     DirectWireFrame.HandshakeMessage1(message1),
                     "handshake.message1",
-                    null,
+                    TransportMode.GATT,
                 )
             if (result !is TransportSendResult.Dropped || !result.isTransientLinkNotReady()) {
                 return result

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineTransportSupport.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineTransportSupport.kt
@@ -62,7 +62,9 @@ internal class MeshEngineTransportSupport(
     }
 
     private suspend fun handleDiscoveredPeer(event: TransportEvent.PeerDiscovered): Unit {
-        if (event.transportMode != TransportMode.L2CAP) {
+        if (
+            event.transportMode != TransportMode.L2CAP && event.transportMode != TransportMode.GATT
+        ) {
             emitTransportModeDiagnostic(
                 peerId = event.peerId,
                 transportMode = event.transportMode,
@@ -81,7 +83,8 @@ internal class MeshEngineTransportSupport(
     private suspend fun handleTransportModeChanged(
         event: TransportEvent.TransportModeChanged
     ): Unit {
-        val accepted = event.transportMode == TransportMode.L2CAP
+        val accepted =
+            event.transportMode == TransportMode.L2CAP || event.transportMode == TransportMode.GATT
         emitTransportModeDiagnostic(
             peerId = event.peerId,
             transportMode = event.transportMode,
@@ -177,7 +180,8 @@ internal class MeshEngineTransportSupport(
             DiagnosticReason.TRANSPORT_CHANGE,
             mapOf(
                 "accepted" to accepted.toString(),
-                "supportedTransportMode" to TransportMode.L2CAP.name,
+                "supportedTransportMode" to
+                    "${TransportMode.L2CAP.name},${TransportMode.GATT.name}",
                 "transportMode" to transportMode.name,
             ),
         )

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineHandshakeSupportTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineHandshakeSupportTest.kt
@@ -19,7 +19,7 @@ class MeshEngineHandshakeSupportTest {
         var promotedCall: Pair<String, String>? = null
         val callbacks =
             buildMeshEngineRuntimeHandshakeCallbacks(
-                sendDirectWireFrame = { peerId, _, action ->
+                sendDirectWireFrame = { peerId, _, action, _ ->
                     sendCall = Triple(peerId.value, "HandshakeMessage1", action)
                     TransportSendResult.Delivered
                 },
@@ -45,7 +45,7 @@ class MeshEngineHandshakeSupportTest {
         val frame = DirectWireFrame.HandshakeMessage1(byteArrayOf(0x01))
 
         // Act
-        val sendResult = callbacks.sendDirectWireFrame(peerId, frame, "handshake.message1")
+        val sendResult = callbacks.sendDirectWireFrame(peerId, frame, "handshake.message1", null)
         callbacks.emitHopSessionEstablished(peerId, "handshake.established")
         callbacks.emitHopSessionFailed(
             peerId,

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineInitiatorHandshakeSupportTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineInitiatorHandshakeSupportTest.kt
@@ -8,6 +8,7 @@ import ch.trancee.meshlink.diagnostics.DiagnosticSeverity
 import ch.trancee.meshlink.identity.LocalIdentity
 import ch.trancee.meshlink.routing.RouteCoordinator
 import ch.trancee.meshlink.test.InMemorySecureStorage
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 import ch.trancee.meshlink.trust.TofuTrustStore
 import ch.trancee.meshlink.trust.TrustPublicKeys
@@ -85,7 +86,7 @@ class MeshEngineInitiatorHandshakeSupportTest {
             val responderIdentity = LocalIdentity.fromAppId("initiator-handshake-responder")
             val peerId = responderIdentity.peerId
             val fixture =
-                initiatorHandshakeFixture(localIdentity = localIdentity) { _, _, _ ->
+                initiatorHandshakeFixture(localIdentity = localIdentity) { _, _, _, _ ->
                     TransportSendResult.Dropped("link not ready")
                 }
             val initiatorManager = NoiseXXHandshakeManager(localIdentity.cryptoProvider)
@@ -217,8 +218,9 @@ private data class SeededPendingInitiatorHandshake(
 
 private fun initiatorHandshakeFixture(
     localIdentity: LocalIdentity,
-    sendDirectWireFrame: suspend (PeerId, DirectWireFrame, String) -> TransportSendResult =
-        { _, _, _ ->
+    sendDirectWireFrame:
+        suspend (PeerId, DirectWireFrame, String, TransportMode?) -> TransportSendResult =
+        { _, _, _, _ ->
             TransportSendResult.Delivered
         },
 ): InitiatorHandshakeFixture {
@@ -275,14 +277,14 @@ private fun initiatorHandshakeFixture(
                 ),
             callbacks =
                 MeshEngineHandshakeCallbacks(
-                    sendDirectWireFrame = { peerId, frame, action ->
+                    sendDirectWireFrame = { peerId, frame, action, preferredMode ->
                         sentFrames +=
                             RecordedInitiatorHandshakeSend(
                                 peerIdValue = peerId.value,
                                 frame = frame,
                                 action = action,
                             )
-                        sendDirectWireFrame(peerId, frame, action)
+                        sendDirectWireFrame(peerId, frame, action, preferredMode)
                     },
                     emitHopSessionEstablished = { peerId, stage ->
                         established +=

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineResponderHandshakeSupportTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineResponderHandshakeSupportTest.kt
@@ -8,6 +8,7 @@ import ch.trancee.meshlink.diagnostics.DiagnosticSeverity
 import ch.trancee.meshlink.identity.LocalIdentity
 import ch.trancee.meshlink.routing.RouteCoordinator
 import ch.trancee.meshlink.test.InMemorySecureStorage
+import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 import ch.trancee.meshlink.trust.TofuTrustStore
 import kotlin.test.Test
@@ -117,7 +118,7 @@ class MeshEngineResponderHandshakeSupportTest {
             val initiatorManager = NoiseXXHandshakeManager(localIdentity.cryptoProvider)
             val message1 = initiatorManager.createMessage1()
             val fixture =
-                responderHandshakeFixture(localIdentity = localIdentity) { _, _, _ ->
+                responderHandshakeFixture(localIdentity = localIdentity) { _, _, _, _ ->
                     TransportSendResult.Dropped("link not ready")
                 }
 
@@ -182,8 +183,9 @@ private data class ResponderHandshakeFixture(
 
 private fun responderHandshakeFixture(
     localIdentity: LocalIdentity,
-    sendDirectWireFrame: suspend (PeerId, DirectWireFrame, String) -> TransportSendResult =
-        { _, _, _ ->
+    sendDirectWireFrame:
+        suspend (PeerId, DirectWireFrame, String, TransportMode?) -> TransportSendResult =
+        { _, _, _, _ ->
             TransportSendResult.Delivered
         },
 ): ResponderHandshakeFixture {
@@ -241,14 +243,14 @@ private fun responderHandshakeFixture(
                 ),
             callbacks =
                 MeshEngineHandshakeCallbacks(
-                    sendDirectWireFrame = { peerId, frame, action ->
+                    sendDirectWireFrame = { peerId, frame, action, preferredMode ->
                         sentFrames +=
                             RecordedResponderHandshakeSend(
                                 peerIdValue = peerId.value,
                                 frame = frame,
                                 action = action,
                             )
-                        sendDirectWireFrame(peerId, frame, action)
+                        sendDirectWireFrame(peerId, frame, action, preferredMode)
                     },
                     emitHopSessionEstablished = { peerId, stage ->
                         established +=

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineTransportSupportTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/engine/MeshEngineTransportSupportTest.kt
@@ -44,46 +44,40 @@ class MeshEngineTransportSupportTest {
     }
 
     @Test
-    fun `transport mode changed to gatt retracts routes and emits a lost peer event`() =
-        runBlocking {
-            // Arrange
-            val harness = transportSupportHarness()
-            val peerId = PeerId("peer-abcdef")
-            harness.presenceTracker.onPeerConnected(peerId)
-            harness.routeCoordinator.onPeerConnected(
-                peerId = peerId,
-                trustRecord = trustRecord(peerId = peerId, seed = 1),
-            )
+    fun `transport mode changed to gatt keeps the peer connected`() = runBlocking {
+        // Arrange
+        val harness = transportSupportHarness()
+        val peerId = PeerId("peer-abcdef")
+        harness.presenceTracker.onPeerConnected(peerId)
+        harness.routeCoordinator.onPeerConnected(
+            peerId = peerId,
+            trustRecord = trustRecord(peerId = peerId, seed = 1),
+        )
 
-            // Act
-            harness.support.handleTransportEvent(
-                TransportEvent.TransportModeChanged(
-                    peerId = peerId,
-                    transportMode = TransportMode.GATT,
-                )
-            )
+        // Act
+        harness.support.handleTransportEvent(
+            TransportEvent.TransportModeChanged(peerId = peerId, transportMode = TransportMode.GATT)
+        )
 
-            // Assert
-            val lost = assertIs<PeerEvent.Lost>(harness.mutablePeerEvents.replayCache.single())
-            assertEquals(peerId.value, lost.peerId.value)
-            assertNull(harness.routeCoordinator.routeFor(peerId))
-            val modeChanged =
-                harness.diagnostics.firstOrNull { diagnostic ->
-                    diagnostic.code == DiagnosticCode.TRANSPORT_MODE_CHANGED &&
-                        diagnostic.stage == "transport.modeChanged" &&
-                        diagnostic.metadata["accepted"] == "false" &&
-                        diagnostic.metadata["transportMode"] == TransportMode.GATT.name
-                }
-            val routeRetracted =
-                harness.diagnostics.firstOrNull { diagnostic ->
-                    diagnostic.code == DiagnosticCode.ROUTE_RETRACTED &&
-                        diagnostic.stage == "transport.modeChanged.rejected.routeRetracted" &&
-                        diagnostic.metadata["removedByPeerId"] == peerId.value
-                }
-            assertNotNull(modeChanged)
-            assertNotNull(routeRetracted)
-            Unit
-        }
+        // Assert
+        assertTrue(harness.mutablePeerEvents.replayCache.isEmpty())
+        assertNotNull(harness.routeCoordinator.routeFor(peerId))
+        val modeChanged =
+            harness.diagnostics.firstOrNull { diagnostic ->
+                diagnostic.code == DiagnosticCode.TRANSPORT_MODE_CHANGED &&
+                    diagnostic.stage == "transport.modeChanged" &&
+                    diagnostic.metadata["accepted"] == "true" &&
+                    diagnostic.metadata["transportMode"] == TransportMode.GATT.name
+            }
+        val routeRetracted =
+            harness.diagnostics.firstOrNull { diagnostic ->
+                diagnostic.code == DiagnosticCode.ROUTE_RETRACTED &&
+                    diagnostic.stage == "transport.modeChanged.rejected.routeRetracted"
+            }
+        assertNotNull(modeChanged)
+        assertNull(routeRetracted)
+        Unit
+    }
 
     @Test
     fun `clearRuntimeView clears connected peers and routes and emits lost events`() = runBlocking {
@@ -127,7 +121,7 @@ class MeshEngineTransportSupportTest {
     }
 
     @Test
-    fun `peer discovered on gatt is rejected without peer events or prewarm`() = runBlocking {
+    fun `peer discovered on gatt is accepted and prewarms`() = runBlocking {
         // Arrange
         val harness = transportSupportHarness()
         val peerId = PeerId("peer-gatt")
@@ -138,14 +132,15 @@ class MeshEngineTransportSupportTest {
         )
 
         // Assert
-        assertTrue(harness.mutablePeerEvents.replayCache.isEmpty())
-        assertTrue(harness.prewarmedPeerIds.isEmpty())
-        assertNotNull(
-            harness.diagnostics.firstOrNull { diagnostic ->
+        val found = assertIs<PeerEvent.Found>(harness.mutablePeerEvents.replayCache.single())
+        assertEquals(peerId.value, found.peerId.value)
+        assertEquals(PeerConnectionState.CONNECTED, found.state)
+        assertEquals(listOf(peerId.value), harness.prewarmedPeerIds)
+        assertTrue(
+            harness.diagnostics.none { diagnostic ->
                 diagnostic.code == DiagnosticCode.TRANSPORT_MODE_CHANGED &&
                     diagnostic.stage == "transport.peerDiscovered.rejected" &&
-                    diagnostic.metadata["accepted"] == "false" &&
-                    diagnostic.metadata["transportMode"] == TransportMode.GATT.name
+                    diagnostic.metadata["accepted"] == "false"
             }
         )
         Unit

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/MeshRoutingIntegrationTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/integration/MeshRoutingIntegrationTest.kt
@@ -338,7 +338,7 @@ class MeshRoutingIntegrationTest {
         }
 
     @Test
-    fun `gatt-only peers are rejected and remain unreachable`() = runBlocking {
+    fun `gatt-only peers can complete a send after discovery`() = runBlocking {
         // Arrange
         val harness = harness()
         val sender =
@@ -346,7 +346,7 @@ class MeshRoutingIntegrationTest {
                 peerIdValue = "peer-a",
                 configOverride =
                     meshLinkConfig {
-                        appId = "peer-a-gatt-reject"
+                        appId = "peer-a-gatt-accept"
                         deliveryRetryDeadline = 500.milliseconds
                     },
             )
@@ -358,21 +358,33 @@ class MeshRoutingIntegrationTest {
         sender.meshLink.start()
         recipient.meshLink.start()
         testDelay(250)
+        awaitDiagnosticForPeer(
+            diagnostics = sender.diagnosticSink::events,
+            code = DiagnosticCode.ROUTE_DISCOVERED,
+            peerIdValue = recipient.peerId.value,
+            routeAvailable = true,
+            timeoutMillis = 5_000,
+        )
+
+        val receivedMessageDeferred =
+            async(start = CoroutineStart.UNDISPATCHED) {
+                testWithTimeout(5_000) { recipient.meshLink.messages.first() }
+            }
 
         // Act
-        val sendResult = sender.meshLink.send(recipient.peerId, payload)
-        val receivedMessage = testWithTimeoutOrNull(250) { recipient.meshLink.messages.first() }
+        val sendResult = testWithTimeout(5_000) { sender.meshLink.send(recipient.peerId, payload) }
+        val receivedMessage = receivedMessageDeferred.await()
 
         // Assert
-        val notSent = assertIs<SendResult.NotSent>(sendResult)
-        assertEquals(SendFailureReason.UNREACHABLE, notSent.reason)
-        assertNull(receivedMessage)
+        assertIs<SendResult.Sent>(sendResult)
+        assertNotNull(receivedMessage)
+        assertContentEquals(payload, receivedMessage.payload)
         assertTrue(
-            sender.diagnosticSink.events().any { diagnostic ->
+            sender.diagnosticSink.events().none { diagnostic ->
                 diagnostic.code == DiagnosticCode.TRANSPORT_MODE_CHANGED &&
                     diagnostic.stage == "transport.peerDiscovered.rejected"
             },
-            "Expected GATT-only discovery to emit an explicit transport rejection diagnostic",
+            "Expected GATT discovery to remain accepted in the transport path",
         )
     }
 

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/test/VirtualMeshTransport.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/test/VirtualMeshTransport.kt
@@ -83,7 +83,7 @@ internal class VirtualMeshTransport(
             return TransportSendResult.Dropped("virtual transport is not started")
         }
         val mode = snapshot.discoveredPeerModes[frame.peerId.value]
-        if (mode != TransportMode.L2CAP) {
+        if (mode != TransportMode.L2CAP && mode != TransportMode.GATT) {
             return TransportSendResult.Dropped("recipient transport is unavailable")
         }
         mutableState.update { state ->

--- a/meshlink/src/iosMain/kotlin/ch/trancee/meshlink/platform/ios/PreferredGattSendSupport.kt
+++ b/meshlink/src/iosMain/kotlin/ch/trancee/meshlink/platform/ios/PreferredGattSendSupport.kt
@@ -31,7 +31,7 @@ internal suspend fun sendViaPreferredGattNotifyLinkOrNull(
     dependencies: PreferredGattSendDependencies,
 ): TransportSendResult? {
     val directFrame = runCatching { DirectWireFrame.decode(frame.payload) }.getOrNull()
-    if (directFrame !is DirectWireFrame.Data) {
+    if (directFrame == null) {
         return null
     }
 

--- a/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/PreferredGattSendSupportTest.kt
+++ b/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/PreferredGattSendSupportTest.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.runBlocking
 
 class PreferredGattSendSupportTest {
     @Test
-    fun sendViaPreferredGattNotifyLinkOrNullSkipsHandshakeFrames(): Unit = runBlocking {
+    fun sendViaPreferredGattNotifyLinkOrNullHandlesHandshakeFrames(): Unit = runBlocking {
         // Arrange
         val fixture = PreferredGattSendFixture()
         val frame =
@@ -27,8 +27,8 @@ class PreferredGattSendSupportTest {
             fixture.run(frame = frame, link = FakePreferredGattSendLink(enqueueResult = true))
 
         // Assert
-        assertNull(result)
-        assertEquals(0, fixture.currentLinkCalls)
+        assertEquals(TransportSendResult.Delivered, result)
+        assertEquals(1, fixture.currentLinkCalls)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove the proof-app benchmark side channel from live-proof startup
- allow GATT as a real bearer in the core transport path
- update the preferred-GATT tests and route/discovery expectations

## Verification
- ./gradlew :meshlink:jvmTest --tests ch.trancee.meshlink.engine.MeshEngineTransportSupportTest --tests ch.trancee.meshlink.integration.MeshRoutingIntegrationTest
- ./gradlew :meshlink-reference:android:compileDebugKotlin