### PR TITLE
docs: expand reference app architecture guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,7 @@ guessing which page owns which model.
 
 - [About the repository architecture](explanation/about-the-repository-architecture.md) — why the repository is split between the SDK, the reference app, the proof apps, and the retained evidence surfaces.
 - [About proof validation surfaces](explanation/about-proof-validation-surfaces.md) — when to choose the reference app, the proof apps, or retained benchmarks.
+- [Reference app and test architecture](explanation/reference-app-and-test-architecture.md) — how the reference app, proof apps, and automated tests fit together.
 
 ### Integration and lifecycle
 

--- a/docs/explanation/about-proof-validation-surfaces.md
+++ b/docs/explanation/about-proof-validation-surfaces.md
@@ -17,6 +17,13 @@ It is an explanation page. Use the other docs when the job is different:
 - retained performance thresholds and latest evidence —
   [Benchmark and validation baselines](../../benchmarks/README.md)
 
+> Quick orientation:
+> - the reference app shows the supported evaluation path
+> - the proof apps show physical transport evidence
+> - the retained benchmarks show the current numeric posture
+>
+> If you need the full split and file map, open [Reference app and test architecture](reference-app-and-test-architecture.md).
+
 ## One repository, three different kinds of claim
 
 The repository supports several kinds of validation, but they are not all meant

--- a/docs/explanation/about-proof-validation-surfaces.md
+++ b/docs/explanation/about-proof-validation-surfaces.md
@@ -8,6 +8,8 @@ It is an explanation page. Use the other docs when the job is different:
 
 - product-like evaluation through the shared Android and iOS experience —
   [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
+- the internal architecture of the reference app, proof apps, and automated tests —
+  [Reference app and test architecture](reference-app-and-test-architecture.md)
 - Android proof-host setup and launch steps —
   [How to run the Android proof app](../../meshlink-proof/android/README.md)
 - iPhone proof-host setup and launch steps —

--- a/docs/explanation/about-proof-validation-surfaces.md
+++ b/docs/explanation/about-proof-validation-surfaces.md
@@ -10,9 +10,9 @@ It is an explanation page. Use the other docs when the job is different:
   [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
 - the internal architecture of the reference app, proof apps, and automated tests —
   [Reference app and test architecture](reference-app-and-test-architecture.md)
-- Android proof-host setup and launch steps —
+- Android proof-app setup and launch steps —
   [How to run the Android proof app](../../meshlink-proof/android/README.md)
-- iPhone proof-host setup and launch steps —
+- iPhone proof-app setup and launch steps —
   [How to build and run the iOS proof app](../../meshlink-proof/ios/README.md)
 - retained performance thresholds and latest evidence —
   [Benchmark and validation baselines](../../benchmarks/README.md)
@@ -66,8 +66,8 @@ host-level concerns are genuinely different:
 - iOS launch control is shaped around Xcode signing, environment variables,
   simulator or device destinations, and retained console capture
 
-That does not mean the hosts should become giant files.
-The current proof-host refactors keep the platform shell thin while pushing the
+That does not mean the apps should become giant files.
+The current proof-app refactors keep the platform shell thin while pushing the
 real moving parts behind narrower helpers such as launch-config parsing,
 permission policy, benchmark framing, runtime ownership, benchmark-mode
 switching, and transport-log capture.

--- a/docs/explanation/about-proof-validation-surfaces.md
+++ b/docs/explanation/about-proof-validation-surfaces.md
@@ -56,7 +56,7 @@ Keeping those behaviors separate means a reviewer can still say:
 
 without those statements stepping on each other.
 
-## Why the proof hosts still look platform-specific
+## Why the proof apps still look platform-specific
 
 The proof apps are intentionally separate on Android and iPhone because the
 host-level concerns are genuinely different:

--- a/docs/explanation/about-proof-validation-surfaces.md
+++ b/docs/explanation/about-proof-validation-surfaces.md
@@ -112,6 +112,7 @@ or move to the reference app.
 
 - [MeshLink documentation map](../README.md)
 - [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
+- [Reference app and test architecture](reference-app-and-test-architecture.md)
 - [How to run the Android proof app](../../meshlink-proof/android/README.md)
 - [How to build and run the iOS proof app](../../meshlink-proof/ios/README.md)
 - [Benchmark and validation baselines](../../benchmarks/README.md)

--- a/docs/explanation/about-the-repository-architecture.md
+++ b/docs/explanation/about-the-repository-architecture.md
@@ -16,6 +16,13 @@ It is an explanation page. Use the other docs when the job is different:
   [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
 - reference-app and test boundaries —
   [Reference app and test architecture](reference-app-and-test-architecture.md)
+
+> Quick orientation:
+> - the reference app is the human-facing surface for evaluation and review
+> - the proof apps are the transport-validation surfaces kept separate from it
+> - the repository split keeps SDK, app, and evidence concerns independently testable
+
+## How the repository is organized
 - proof-surface chooser and validation-boundary explanation —
   [About proof validation surfaces](about-proof-validation-surfaces.md)
 

--- a/docs/explanation/about-the-repository-architecture.md
+++ b/docs/explanation/about-the-repository-architecture.md
@@ -336,10 +336,10 @@ Keeping them separate preserves a clean boundary between:
 - evaluating the SDK as a coherent operator-facing experience
 - proving transport behavior on physical devices
 
-Inside those proof hosts, the code now follows the same architectural instinct.
-The Android proof activity stays a thin host surface while launch parsing,
+Inside those proof apps, the code now follows the same architectural instinct.
+The Android proof activity stays a thin app surface while launch parsing,
 permission rules, benchmark framing, and runtime ownership sit behind narrower
-helpers. The iPhone proof host still presents one view model to SwiftUI, but
+helpers. The iPhone proof app still presents one view model to SwiftUI, but
 benchmark-only mode switching, launch parsing, and transport-log capture no
 longer compete inside one undifferentiated file.
 

--- a/docs/explanation/about-the-repository-architecture.md
+++ b/docs/explanation/about-the-repository-architecture.md
@@ -14,6 +14,8 @@ It is an explanation page. Use the other docs when the job is different:
   [MeshLink runtime behavior reference](../reference/meshlink-runtime-behavior.md)
 - reference-app evaluation flow —
   [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
+- reference-app and test boundaries —
+  [Reference app and test architecture](reference-app-and-test-architecture.md)
 - proof-surface chooser and validation-boundary explanation —
   [About proof validation surfaces](about-proof-validation-surfaces.md)
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -1,0 +1,362 @@
+# Reference app and test architecture
+
+This page explains how the MeshLink reference app works and how the related
+automated tests execute.
+
+It is written for a reader landing cold. The goal is to show where the user
+experience lives, where the runtime state lives, and where the tests and proof
+runs attach.
+
+## The short version
+
+MeshLink has three related surfaces:
+
+1. **The reference app** — the product-like Android and iOS experience for
+   guided evaluation, runtime inspection, retained history, and exports.
+2. **The proof apps** — focused Android and iOS hosts used for transport
+   validation, retained evidence, and benchmark-oriented runs.
+3. **The automation/tests** — app-driven automation, Android instrumented
+   benchmarks, and retained physical campaigns that read the app’s own state
+   and logs.
+
+The reference app is what a human uses to understand MeshLink. The proof apps
+and benchmark runners are what we use to prove timing, throughput, and retained
+physical behavior.
+
+## System overview
+
+```mermaid
+graph TD
+    subgraph Human surfaces
+        RA[Reference app]
+        PA[Proof app]
+    end
+
+    subgraph Shared runtime
+        SDK[MeshLink SDK/runtime]
+        SNAP[Controller snapshot + timeline state]
+        HIST[Retained session history]
+        EX[Export / evidence files]
+    end
+
+    subgraph Automation and tests
+        AUTO[Live proof automation]
+        ANDROIDTEST[Android instrumented benchmarks]
+        IOSRUN[Launch-time iOS proof modes]
+        CAMPAIGN[Retained physical scenario campaign]
+    end
+
+    RA --> SDK
+    RA --> SNAP
+    RA --> HIST
+    RA --> EX
+
+    PA --> SDK
+    PA --> SNAP
+
+    SDK --> SNAP
+    SNAP --> HIST
+    SNAP --> EX
+
+    AUTO --> SNAP
+    AUTO --> SDK
+    AUTO --> RA
+
+    ANDROIDTEST --> PA
+    ANDROIDTEST --> LOGS[proof.log]
+    LOGS --> ANDROIDTEST
+
+    IOSRUN --> PA
+    IOSRUN --> SDK
+    IOSRUN --> LOGS2[stdout / proof log]
+    LOGS2 --> IOSRUN
+
+    CAMPAIGN --> RA
+    CAMPAIGN --> PA
+    CAMPAIGN --> EX
+```
+
+## What the reference app is doing
+
+The reference app is not a benchmark harness. It is the shared, product-like
+experience that an evaluator or integrator can open on Android and iOS.
+
+The app is organized into clearly separated surfaces:
+
+- **Guided first exchange** — the shortest path to a first successful proof
+- **Solo exploration** — a non-authoritative path when only one device is
+  available
+- **Advanced controls** — lifecycle, power, peer, trust, and send controls
+- **Technical timeline** — lifecycle, peer, diagnostic, message, and export
+  evidence in one place
+- **Recent history** — retained sessions separated from the live session
+- **Lab** — proof-only or benchmark-only behavior kept away from the normal
+  product path
+
+The shared runtime owns the important state:
+
+- session lifecycle
+- peer discovery and peer trust
+- message send / receive events
+- retained history
+- export actions
+- timeline entries
+
+The platform code mainly provides:
+
+- app launch and lifecycle hooks
+- platform permissions and device services
+- the native shell UI around the shared model
+
+## How the reference app automation works
+
+The reference app includes an in-app automation layer in shared code. That is a
+key design choice: the automation reads the same snapshot and timeline state the
+human sees.
+
+The automation path is roughly:
+
+1. the app emits a live controller snapshot and timeline state
+2. the automation driver watches for state changes
+3. the automation coordinator decides which step should happen next
+4. role-specific step runners request mesh actions, peer actions, or export
+   actions
+5. the timeline records explicit automation markers
+
+### Reference-app automation diagram
+
+```mermaid
+flowchart LR
+    SNAP[Live controller snapshot]
+    TIMELINE[Technical timeline state]
+    DRIVER[LiveProofAutomationDriver]
+    COORD[LiveProofAutomationCoordinator]
+    STEPS[Role-specific step runners]
+    ACTIONS[Mesh / peer / export requests]
+    LOG[Automation markers in timeline]
+
+    SNAP --> DRIVER
+    TIMELINE --> DRIVER
+    DRIVER --> COORD
+    COORD --> STEPS
+    STEPS --> ACTIONS
+    ACTIONS --> SNAP
+    ACTIONS --> LOG
+    LOG --> TIMELINE
+```
+
+### What this means in practice
+
+For a guided direct-proof run, the automation is looking for things like:
+
+- readiness blockers clearing
+- peer discovery
+- peer selection or peer targeting
+- mesh start or resume
+- send request
+- delivery / receipt evidence
+- completion markers
+
+For a passive role, the automation waits for the peer and timeline state to
+reach the expected phase, then records completion markers once the proof is
+observable.
+
+The important thing is that the reference app automation does not invent a
+parallel world. It drives the same live runtime state that the operator UI is
+showing.
+
+## How the Android proof app tests execute
+
+The Android proof app is a small activity-based host with a runtime object
+behind it.
+
+### App side
+
+`MainActivity` renders a simple operator UI:
+
+- current state
+- known peers
+- start / stop control
+- send hello control
+- live logs
+
+`MeshLinkProofRuntime` owns the behavior:
+
+- initializes the MeshLink runtime
+- checks Bluetooth readiness before starting
+- starts and stops MeshLink
+- tracks known peers and peer events
+- handles auto-send and benchmark paths
+- appends diagnostic and benchmark logs
+- persists a rolling `proof.log`
+
+That retained log matters because the tests assert against it.
+
+### Test side
+
+The benchmark tests live under `meshlink-proof/android/src/androidTest/...`
+and are standard instrumented JUnit tests.
+
+They use a shared support helper that does four jobs:
+
+1. **launches the activity** with intent extras such as app id, power mode,
+   payload size, and benchmark flags
+2. **ensures runtime permissions** are available before launch
+3. **waits for a log line** to appear in `proof.log`
+4. **parses the line** for elapsed time, throughput, or result status
+
+The tests themselves follow an Arrange → Act → Assert pattern:
+
+- clear the log
+- launch the proof app in the desired mode
+- wait for the benchmark line
+- assert the timing/result threshold
+- close the scenario and clear the log
+
+### Android benchmark test flow
+
+```mermaid
+sequenceDiagram
+    participant Test as Android instrumented test
+    participant Support as BenchmarkTestSupport
+    participant App as Proof app activity
+    participant Runtime as MeshLinkProofRuntime
+    participant Log as proof.log
+
+    Test->>Support: startProofApp(extras)
+    Support->>App: launch MainActivity via ActivityScenario
+    App->>Runtime: initialize / start MeshLink
+    Runtime->>Log: append benchmark and diagnostic lines
+    Test->>Support: waitForLogLine("BENCHMARK ...")
+    Support->>Log: poll retained log file
+    Log-->>Support: matching line
+    Support-->>Test: parsed line
+    Test->>Test: assert elapsedMs / throughput / result
+    Test->>Support: scenario.close()
+```
+
+### What gets asserted
+
+The tests are verifying the app’s own retained evidence, not a guessed UI state.
+
+Typical checks include:
+
+- startup under a time bound for cold start
+- transport latency under a threshold
+- throughput above a threshold
+- power mode diagnostics showing the expected scan / interval profile
+- benchmark result lines reporting `Sent`
+
+## How the iOS proof app executes benchmark-like runs
+
+The iOS proof app is a SwiftUI host with a view model that owns the runtime.
+
+### App side
+
+`ProofApp` installs the crypto and transport bridges at launch.
+
+`ContentView` is the visible shell:
+
+- state text
+- peer list
+- start / stop controls
+- send hello control
+- live logs
+
+`ProofViewModel` owns the app behavior:
+
+- reads launch configuration from environment variables
+- builds the MeshLink runtime
+- clears the retained log on startup
+- binds state and peer flows
+- handles start / stop / send
+- switches into benchmark mode when requested
+
+### Benchmark mode selection
+
+`ProofLaunchConfig` reads launch-time environment variables such as:
+
+- app id
+- power mode
+- benchmark payload size
+- battery / charging hints
+- cold-start flag
+- auto-send flag
+- transport telemetry flag
+- benchmark transport selection
+
+`ProofBenchmarkModeController` decides whether the app should run:
+
+- normal MeshLink mode
+- GATT prototype mode
+- GATT notify prototype mode
+
+If a benchmark mode is selected, the controller starts the matching benchmark
+path and logs a clear failure when required configuration is missing.
+
+### iOS log capture
+
+When running in normal `meshLink` mode with telemetry enabled, the app can
+capture stdout into the proof log so the same retained evidence stream contains
+both runtime and transport detail.
+
+### iOS execution model diagram
+
+```mermaid
+sequenceDiagram
+    participant Launch as Xcode / headless runner
+    participant View as ProofViewModel
+    participant Mode as ProofBenchmarkModeController
+    participant Runtime as MeshLink runtime / benchmark client
+    participant Logs as proof log / stdout capture
+
+    Launch->>View: start app with env vars
+    View->>Runtime: build runtime with appId + powerMode
+    View->>Mode: choose benchmark or normal mode
+    alt normal MeshLink mode
+        View->>Runtime: start()
+        Runtime->>Logs: append state / peer / transport lines
+    else benchmark mode
+        Mode->>Runtime: start benchmark path
+        Runtime->>Logs: append benchmark result lines
+    end
+    Logs-->>View: update visible log list
+```
+
+## How the physical scenario campaign fits in
+
+The retained physical campaign sits above the apps.
+It is used when you want repeatable evidence from real devices, not just a human
+walkthrough.
+
+The campaign:
+
+- discovers the fleet
+- records which devices are available
+- plans a scenario order
+- runs the scenarios in a stable order
+- writes retained JSON and HTML artifacts
+- makes fallback choices explicit instead of hiding them
+
+The campaign is especially important for direct-guided release review because it
+retains the evidence trail in files that can be audited later.
+
+## Practical distinction to keep in mind
+
+If you are trying to answer **“does the product-like experience make sense?”**,
+start with the **reference app**.
+
+If you are trying to answer **“is the transport fast / reliable / within
+threshold?”**, use the **proof apps and benchmark tests**.
+
+If you are trying to answer **“can we retain auditable evidence from a real
+fleet?”**, use the **physical scenario campaign**.
+
+## Related docs
+
+- [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
+- [About proof validation surfaces](about-proof-validation-surfaces.md)
+- [Reference app runtime seams](reference-app-runtime-seams.md)
+- [How to run the Android proof app](../../meshlink-proof/android/README.md)
+- [How to build and run the iOS proof app](../../meshlink-proof/ios/README.md)
+- [How to run the reference-app physical integration scenarios](../how-to/run-reference-app-physical-integration-scenarios.md)

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -372,27 +372,16 @@ Use this when deciding what to open first.
 | retain real-device evidence | Physical scenario campaign | It writes audited JSON / HTML artifacts from actual devices |
 | understand how the layers fit | This doc + [About proof validation surfaces](about-proof-validation-surfaces.md) | These explain the architectural split and choice of surface |
 
-## Decision tree
+## Choose-your-path matrix
 
 Use this when you are unsure which surface to open.
 
-```mermaid
-flowchart TD
-    Start[What do you want to prove?]
-    Human[Understand the product-like experience]
-    Perf[Prove timing or throughput]
-    Fleet[Retain real-device evidence]
-    Cross[Understand the layered architecture]
-    RefApp[Open the reference app]
-    Proof[Use the proof app + benchmark tests]
-    Campaign[Run the physical scenario campaign]
-    Docs[Read this doc + the proof-surfaces doc]
-
-    Start --> Human --> RefApp
-    Start --> Perf --> Proof
-    Start --> Fleet --> Campaign
-    Start --> Cross --> Docs
-```
+| Your goal | Open or run | You should expect |
+|---|---|---|
+| Understand the product-like experience | Reference app | Guided exchange, live timeline, retained history, and exports |
+| Prove timing or throughput | Proof app + benchmark tests | Retained log lines with parsed latency or throughput thresholds |
+| Retain real-device evidence | Physical scenario campaign | Audited JSON / HTML artifacts from actual devices |
+| Understand the layered architecture | This doc + [About proof validation surfaces](about-proof-validation-surfaces.md) | A clear explanation of where each surface fits |
 
 ## FAQ
 
@@ -405,17 +394,30 @@ flowchart TD
 
 ## File map appendix
 
-This is the small map of the files most often involved in each layer.
+This is the fuller map of the files most often involved in each layer.
 
 | Layer | Main files |
 |---|---|
-| Reference app UI shell | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineStore.kt` |
-| Reference automation | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt` |
-| Android proof app runtime | `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MainActivity.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt` |
+| Reference app UI shell | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsOverviewSections.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsInteractionSections.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineSections.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineRetentionSection.kt` |
+| Reference app runtime seams | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/LiveReferenceMeshRuntime.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/LiveReferenceMeshControllerAssembly.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/LiveReferenceMeshLinkController.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/navigation/SessionTransitionService.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/session/ExportPayloadPolicy.kt` |
+| Reference automation | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationActions.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDirectSenderStepRunner.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationPassiveBaselineStepRunner.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationLaunchMarkers.kt` |
+| Android proof app runtime | `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MainActivity.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofLaunchConfig.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofBenchmarkProtocol.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofBenchmarkTransport.kt` |
 | Android proof tests | `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/ColdStartBenchmark.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/PowerProfileBenchmark.kt` |
-| iOS proof app runtime | `meshlink-proof/ios/ProofApp/ProofApp.swift`, `meshlink-proof/ios/ProofApp/ContentView.swift`, `meshlink-proof/ios/ProofApp/ProofViewModel.swift` |
-| iOS benchmark modes and capture | `meshlink-proof/ios/ProofApp/ProofLaunchConfig.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkModeController.swift`, `meshlink-proof/ios/ProofApp/ProofTransportLogCapture.swift` |
-| Retained physical campaign | `meshlink-reference/scripts/run_reference_release_campaign.py`, `meshlink-reference/scripts/run_headless_reference_live_proof.py` |
+| iOS proof app runtime | `meshlink-proof/ios/ProofApp/ProofApp.swift`, `meshlink-proof/ios/ProofApp/ContentView.swift`, `meshlink-proof/ios/ProofApp/ProofViewModel.swift`, `meshlink-proof/ios/ProofApp/ProofGattBenchmarkClient.swift`, `meshlink-proof/ios/ProofApp/ProofGattNotifyBenchmarkServer.swift` |
+| iOS benchmark modes and capture | `meshlink-proof/ios/ProofApp/ProofLaunchConfig.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkModeController.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkTransport.swift`, `meshlink-proof/ios/ProofApp/ProofTransportLogCapture.swift` |
+| Retained physical campaign | `meshlink-reference/scripts/run_reference_release_campaign.py`, `meshlink-reference/scripts/run_headless_reference_live_proof.py`, `meshlink-reference/fleet-test-history/index.html` |
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| Reference app | The product-like Android and iOS experience used for guided evaluation and operator review. |
+| Proof app | The focused host used for transport validation, benchmark paths, and retained evidence. |
+| Technical timeline | The retained event stream that shows lifecycle, peer, diagnostic, message, and export evidence. |
+| Advanced controls | The runtime control surface for lifecycle, peer, trust, power, and send actions. |
+| Retained history | Session data kept after a live run ends so evidence can be revisited later. |
+| Benchmark test | An instrumented or scripted check that asserts latency, throughput, cold-start, or power thresholds. |
+| Physical scenario campaign | The higher-level retained run that executes scenarios on real devices and writes audited artifacts. |
 
 ## Related docs
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -13,6 +13,14 @@ If you are new here, read in this order:
 3. The FAQ
 4. The file map appendix
 
+## At a glance
+
+| Surface | What it is for | What it proves |
+|---|---|---|
+| Reference app | Human evaluation and operator review | The product-like experience, timeline evidence, and retained history |
+| Proof apps | Transport validation and benchmark runs | Thresholds, retained logs, and real-device evidence |
+| Automation/tests | Reproducible scripted execution | That the same claims can be driven and observed mechanically |
+
 ## The short version
 
 MeshLink has three related surfaces:
@@ -406,8 +414,10 @@ This is the fuller map of the files most often involved in each layer.
 
 | Platform | Main files |
 |---|---|
-| Android reference/proof | `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MainActivity.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt` |
-| iOS reference/proof | `meshlink-proof/ios/ProofApp/ProofApp.swift`, `meshlink-proof/ios/ProofApp/ContentView.swift`, `meshlink-proof/ios/ProofApp/ProofViewModel.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkModeController.swift` |
+| Android proof app | `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MainActivity.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofLaunchConfig.kt` |
+| Android proof tests | `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/ColdStartBenchmark.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/PowerProfileBenchmark.kt` |
+| iOS proof app | `meshlink-proof/ios/ProofApp/ProofApp.swift`, `meshlink-proof/ios/ProofApp/ContentView.swift`, `meshlink-proof/ios/ProofApp/ProofViewModel.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkModeController.swift` |
+| iOS proof capture | `meshlink-proof/ios/ProofApp/ProofGattBenchmarkClient.swift`, `meshlink-proof/ios/ProofApp/ProofGattNotifyBenchmarkServer.swift`, `meshlink-proof/ios/ProofApp/ProofTransportLogCapture.swift` |
 | Shared reference runtime | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/LiveReferenceMeshRuntime.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/session/JsonSessionHistoryRepository.kt` |
 | Shared reference automation | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDirectSenderStepRunner.kt` |
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -396,28 +396,26 @@ flowchart TD
 
 ## FAQ
 
-### Is the reference app a benchmark harness?
+| Question | Short answer |
+|---|---|
+| Is the reference app a benchmark harness? | No. It is the product-like evaluation surface for guided exchange, runtime controls, timeline evidence, and retained history. |
+| Why are there separate Android and iOS proof hosts? | Because the launch and transport seams differ by platform, and each proof host exposes the most direct way to prove the same claim. |
+| Why do the tests read logs instead of scraping UI text? | Because timing, throughput, and retained evidence are more stable in retained logs and campaign artifacts than in transient UI rendering. |
+| When should I use the physical scenario campaign? | Use it when you need auditable real-device evidence across a fleet, not just a local walkthrough or benchmark. |
 
-No. The reference app is the product-like evaluation surface. It is meant to
-show guided exchange, runtime controls, timeline evidence, and retained history.
-The proof apps and benchmark runners exist for timing and throughput claims.
+## File map appendix
 
-### Why are there separate Android and iOS proof hosts?
+This is the small map of the files most often involved in each layer.
 
-Because the platform-specific launch and transport seams differ. The proof hosts
-let each platform expose the same claim in the most direct way available on that
-platform while still keeping the normal reference-app experience separate.
-
-### Why do the tests read logs instead of scraping UI text?
-
-Because the asserted claims are timing, throughput, and retained evidence.
-Those are more stable when captured from the app’s retained log or campaign
-artifacts than from transient UI rendering.
-
-### When should I use the physical scenario campaign?
-
-Use it when you need auditable real-device evidence across a device fleet.
-It is the retained, reproducible layer above the app UI and the benchmark tests.
+| Layer | Main files |
+|---|---|
+| Reference app UI shell | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineStore.kt` |
+| Reference automation | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt` |
+| Android proof app runtime | `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MainActivity.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt` |
+| Android proof tests | `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/ColdStartBenchmark.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/PowerProfileBenchmark.kt` |
+| iOS proof app runtime | `meshlink-proof/ios/ProofApp/ProofApp.swift`, `meshlink-proof/ios/ProofApp/ContentView.swift`, `meshlink-proof/ios/ProofApp/ProofViewModel.swift` |
+| iOS benchmark modes and capture | `meshlink-proof/ios/ProofApp/ProofLaunchConfig.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkModeController.swift`, `meshlink-proof/ios/ProofApp/ProofTransportLogCapture.swift` |
+| Retained physical campaign | `meshlink-reference/scripts/run_reference_release_campaign.py`, `meshlink-reference/scripts/run_headless_reference_live_proof.py` |
 
 ## Related docs
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -22,14 +22,14 @@ If you are new here, read in this order:
 | clear up wording or intent | The FAQ |
 | find the files behind a layer | The file map appendix |
 
-## README-style excerpt
+## Quick orientation
 
 > MeshLink uses three related surfaces:
 > - the reference app for guided evaluation and operator review
 > - the proof apps for transport validation and benchmark runs
 > - the automation and tests for reproducible scripted execution
 >
-> If you only need the basics, start with the short version and then the choose-your-path matrix.
+> Start with the short version, then the choose-your-path matrix.
 
 ## At a glance
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -24,12 +24,12 @@ If you are new here, read in this order:
 
 ## README-style excerpt
 
-MeshLink uses three related surfaces:
-- the reference app for guided evaluation and operator review
-- the proof apps for transport validation and benchmark runs
-- the automation and tests for reproducible scripted execution
-
-If you only need the basics, start with the short version and then the choose-your-path matrix.
+> MeshLink uses three related surfaces:
+> - the reference app for guided evaluation and operator review
+> - the proof apps for transport validation and benchmark runs
+> - the automation and tests for reproducible scripted execution
+>
+> If you only need the basics, start with the short version and then the choose-your-path matrix.
 
 ## At a glance
 
@@ -423,6 +423,12 @@ Use this when you are unsure which surface to open.
 | Why are there separate Android and iOS proof apps? | Because the launch and transport seams differ by platform, and each proof app exposes the most direct way to prove the same claim. |
 | Why do the tests read logs instead of scraping UI text? | Because timing, throughput, and retained evidence are more stable in retained logs and campaign artifacts than in transient UI rendering. |
 | When should I use the physical scenario campaign? | Use it when you need auditable real-device evidence across a fleet, not just a local walkthrough or benchmark. |
+
+## Common misconceptions
+
+- The reference app is not the benchmark harness; it is the product-like shell for guided evaluation and operator review.
+- The proof apps are not alternate product surfaces; they are focused hosts for transport validation and retained evidence.
+- Reading retained logs is not a shortcut around verification; it is how this repository keeps timing and throughput assertions stable.
 
 ## File map appendix
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -372,6 +372,53 @@ Use this when deciding what to open first.
 | retain real-device evidence | Physical scenario campaign | It writes audited JSON / HTML artifacts from actual devices |
 | understand how the layers fit | This doc + [About proof validation surfaces](about-proof-validation-surfaces.md) | These explain the architectural split and choice of surface |
 
+## Decision tree
+
+Use this when you are unsure which surface to open.
+
+```mermaid
+flowchart TD
+    Start[What do you want to prove?]
+    Human[Understand the product-like experience]
+    Perf[Prove timing or throughput]
+    Fleet[Retain real-device evidence]
+    Cross[Understand the layered architecture]
+    RefApp[Open the reference app]
+    Proof[Use the proof app + benchmark tests]
+    Campaign[Run the physical scenario campaign]
+    Docs[Read this doc + the proof-surfaces doc]
+
+    Start --> Human --> RefApp
+    Start --> Perf --> Proof
+    Start --> Fleet --> Campaign
+    Start --> Cross --> Docs
+```
+
+## FAQ
+
+### Is the reference app a benchmark harness?
+
+No. The reference app is the product-like evaluation surface. It is meant to
+show guided exchange, runtime controls, timeline evidence, and retained history.
+The proof apps and benchmark runners exist for timing and throughput claims.
+
+### Why are there separate Android and iOS proof hosts?
+
+Because the platform-specific launch and transport seams differ. The proof hosts
+let each platform expose the same claim in the most direct way available on that
+platform while still keeping the normal reference-app experience separate.
+
+### Why do the tests read logs instead of scraping UI text?
+
+Because the asserted claims are timing, throughput, and retained evidence.
+Those are more stable when captured from the app’s retained log or campaign
+artifacts than from transient UI rendering.
+
+### When should I use the physical scenario campaign?
+
+Use it when you need auditable real-device evidence across a device fleet.
+It is the retained, reproducible layer above the app UI and the benchmark tests.
+
 ## Related docs
 
 - [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -13,6 +13,24 @@ If you are new here, read in this order:
 3. The FAQ
 4. The file map appendix
 
+## Who should read which section
+
+| If you want to... | Read this section |
+|---|---|
+| get the 30-second model | The short version and At a glance |
+| choose the right surface | The choose-your-path matrix |
+| clear up wording or intent | The FAQ |
+| find the files behind a layer | The file map appendix |
+
+## README-style excerpt
+
+MeshLink uses three related surfaces:
+- the reference app for guided evaluation and operator review
+- the proof apps for transport validation and benchmark runs
+- the automation and tests for reproducible scripted execution
+
+If you only need the basics, start with the short version and then the choose-your-path matrix.
+
 ## At a glance
 
 | Surface | What it is for | What it proves |
@@ -402,7 +420,7 @@ Use this when you are unsure which surface to open.
 | Question | Short answer |
 |---|---|
 | Is the reference app a benchmark harness? | No. It is the product-like evaluation surface for guided exchange, runtime controls, timeline evidence, and retained history. |
-| Why are there separate Android and iOS proof hosts? | Because the launch and transport seams differ by platform, and each proof host exposes the most direct way to prove the same claim. |
+| Why are there separate Android and iOS proof apps? | Because the launch and transport seams differ by platform, and each proof app exposes the most direct way to prove the same claim. |
 | Why do the tests read logs instead of scraping UI text? | Because timing, throughput, and retained evidence are more stable in retained logs and campaign artifacts than in transient UI rendering. |
 | When should I use the physical scenario campaign? | Use it when you need auditable real-device evidence across a fleet, not just a local walkthrough or benchmark. |
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -7,6 +7,12 @@ It is written for a reader landing cold. The goal is to show where the user
 experience lives, where the runtime state lives, and where the tests and proof
 runs attach.
 
+If you are new here, read in this order:
+1. The short version
+2. The choose-your-path matrix
+3. The FAQ
+4. The file map appendix
+
 ## The short version
 
 MeshLink has three related surfaces:
@@ -396,6 +402,17 @@ Use this when you are unsure which surface to open.
 
 This is the fuller map of the files most often involved in each layer.
 
+### By platform
+
+| Platform | Main files |
+|---|---|
+| Android reference/proof | `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MainActivity.kt`, `meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt`, `meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt` |
+| iOS reference/proof | `meshlink-proof/ios/ProofApp/ProofApp.swift`, `meshlink-proof/ios/ProofApp/ContentView.swift`, `meshlink-proof/ios/ProofApp/ProofViewModel.swift`, `meshlink-proof/ios/ProofApp/ProofBenchmarkModeController.swift` |
+| Shared reference runtime | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/LiveReferenceMeshRuntime.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/session/JsonSessionHistoryRepository.kt` |
+| Shared reference automation | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDirectSenderStepRunner.kt` |
+
+### By layer
+
 | Layer | Main files |
 |---|---|
 | Reference app UI shell | `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsOverviewSections.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/advanced/AdvancedControlsInteractionSections.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineScreen.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineSections.kt`, `meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/timeline/TechnicalTimelineRetentionSection.kt` |
@@ -411,13 +428,15 @@ This is the fuller map of the files most often involved in each layer.
 
 | Term | Meaning |
 |---|---|
-| Reference app | The product-like Android and iOS experience used for guided evaluation and operator review. |
-| Proof app | The focused host used for transport validation, benchmark paths, and retained evidence. |
-| Technical timeline | The retained event stream that shows lifecycle, peer, diagnostic, message, and export evidence. |
-| Advanced controls | The runtime control surface for lifecycle, peer, trust, power, and send actions. |
-| Retained history | Session data kept after a live run ends so evidence can be revisited later. |
-| Benchmark test | An instrumented or scripted check that asserts latency, throughput, cold-start, or power thresholds. |
-| Physical scenario campaign | The higher-level retained run that executes scenarios on real devices and writes audited artifacts. |
+| [Reference app](#what-the-reference-app-is-doing) | The product-like Android and iOS experience used for guided evaluation and operator review. |
+| [Proof app](#how-the-android-proof-app-tests-execute) | The focused host used for transport validation, benchmark paths, and retained evidence. |
+| [Technical timeline](#what-the-reference-app-is-doing) | The retained event stream that shows lifecycle, peer, diagnostic, message, and export evidence. |
+| [Advanced controls](#what-the-reference-app-is-doing) | The runtime control surface for lifecycle, peer, trust, power, and send actions. |
+| [Retained history](#what-the-reference-app-is-doing) | Session data kept after a live run ends so evidence can be revisited later. |
+| [Benchmark test](#how-the-android-proof-app-tests-execute) | An instrumented or scripted check that asserts latency, throughput, cold-start, or power thresholds. |
+| [Physical scenario campaign](#how-the-physical-scenario-campaign-fits-in) | The higher-level retained run that executes scenarios on real devices and writes audited artifacts. |
+
+## Related docs
 
 ## Related docs
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -19,6 +19,14 @@ MeshLink has three related surfaces:
    benchmarks, and retained physical campaigns that read the app’s own state
    and logs.
 
+If you only need the one-screen summary, use this table:
+
+| Surface | Primary goal | Typical evidence |
+|---|---|---|
+| Reference app | Explain the product-like experience | guided exchange, timeline, history, export |
+| Proof apps | Prove transport and runtime thresholds | retained logs, benchmark results, physical runs |
+| Automation/tests | Reproduce claims mechanically | scenario logs, parsed benchmark lines, retained JSON |
+
 The reference app is what a human uses to understand MeshLink. The proof apps
 and benchmark runners are what we use to prove timing, throughput, and retained
 physical behavior.
@@ -351,6 +359,18 @@ threshold?”**, use the **proof apps and benchmark tests**.
 
 If you are trying to answer **“can we retain auditable evidence from a real
 fleet?”**, use the **physical scenario campaign**.
+
+## A one-page cheat sheet
+
+Use this when deciding what to open first.
+
+| If you want to... | Open or run | Why |
+|---|---|---|
+| understand the product-like experience | Reference app | It shows guided evaluation, timeline, retained history, and exports |
+| inspect runtime state and operator controls | Advanced controls / Technical timeline | They expose the live state the operator would act on |
+| prove transport performance | Proof app + benchmark tests | They assert thresholds against retained logs |
+| retain real-device evidence | Physical scenario campaign | It writes audited JSON / HTML artifacts from actual devices |
+| understand how the layers fit | This doc + [About proof validation surfaces](about-proof-validation-surfaces.md) | These explain the architectural split and choice of surface |
 
 ## Related docs
 

--- a/docs/explanation/reference-app-and-test-architecture.md
+++ b/docs/explanation/reference-app-and-test-architecture.md
@@ -31,6 +31,17 @@ If you are new here, read in this order:
 >
 > Start with the short version, then the choose-your-path matrix.
 
+## Reusable quick orientation snippet
+
+Copy this pattern near the top of other docs when you want a brief navigation cue:
+
+> Quick orientation:
+> - the <surface A> shows <what it shows>
+> - the <surface B> shows <what it shows>
+> - the <surface C> shows <what it shows>
+>
+> If you need the full split and file map, open [Reference app and test architecture](reference-app-and-test-architecture.md).
+
 ## At a glance
 
 | Surface | What it is for | What it proves |

--- a/docs/how-to/evaluate-meshlink-with-the-reference-app.md
+++ b/docs/how-to/evaluate-meshlink-with-the-reference-app.md
@@ -236,7 +236,7 @@ Use the reference app when you need:
 - a shared Android and iOS operator surface
 - timeline evidence that is easy to walk through with another engineer
 
-For the internal architecture of the app, proof hosts, and test flow, see
+For the internal architecture of the app, proof apps, and test flow, see
 [Reference app and test architecture](../explanation/reference-app-and-test-architecture.md).
 
 Switch to the proof apps or the live-proof harness when you need:

--- a/docs/how-to/evaluate-meshlink-with-the-reference-app.md
+++ b/docs/how-to/evaluate-meshlink-with-the-reference-app.md
@@ -236,6 +236,9 @@ Use the reference app when you need:
 - a shared Android and iOS operator surface
 - timeline evidence that is easy to walk through with another engineer
 
+For the internal architecture of the app, proof hosts, and test flow, see
+[Reference app and test architecture](../explanation/reference-app-and-test-architecture.md).
+
 Switch to the proof apps or the live-proof harness when you need:
 
 - retained transport-validation evidence

--- a/docs/reference/contributor-reference.md
+++ b/docs/reference/contributor-reference.md
@@ -131,11 +131,11 @@ need to find the right seam quickly.
 
 | Concern | Primary module | Notes |
 |---|---|---|
-| Android proof host surface | Android proof `MainActivity` | Owns the minimal host UI, permission request loop, and start or stop button wiring. |
+| Android proof app surface | Android proof `MainActivity` | Owns the minimal host UI, permission request loop, and start or stop button wiring. |
 | Android proof launch parsing | `ProofLaunchConfig` | Owns intent-extra decoding for mesh domain, power mode, benchmark payload size, and proof transport selection. |
 | Android proof runtime ownership | `MeshLinkProofRuntime` | Owns MeshLink lifecycle, peer and diagnostic collection, benchmark receipts, auto-send policy, and persisted proof logs. |
 | Android proof benchmark framing | `BenchmarkPayloadEnvelope` + `BenchmarkReceipt` | Own the retained MeshLink benchmark payload and receipt shape used by the Android proof harness. |
-| Android proof permission contract | `ProofPermissionContract` | Owns the Bluetooth permission list and permission-result interpretation for the proof host. |
+| Android proof permission contract | `ProofPermissionContract` | Owns the Bluetooth permission list and permission-result interpretation for the proof app. |
 | iOS proof launch parsing | `ProofLaunchConfig` | Owns environment-variable decoding for mesh domain, power mode, benchmark payload size, telemetry, and proof transport selection. |
 | iOS proof benchmark-only mode switching | `ProofBenchmarkModeController` | Owns the GATT prototype and GATT-notify prototype start or stop validation so the view model stays focused on host-facing state. |
 | iOS proof transport-log capture | `ProofTransportLogCapture` | Owns stdout capture for transport telemetry and forwards only MeshLink transport lines back into the proof log. |


### PR DESCRIPTION
## Summary
- add a detailed reference-app/test architecture guide with Mermaid diagrams
- add cross-links across the proof-surface and repository-architecture docs
- add decision tables, FAQ, glossary, and reusable orientation snippets

## Notes
- documentation-only change
- no runtime verification required