### PR TITLE
fix: sync direct-proof summary and tests

### DIFF
--- a/docs/reference/android-direct-proof-matrix-result.md
+++ b/docs/reference/android-direct-proof-matrix-result.md
@@ -6,6 +6,11 @@ This page captures the observed Android direct-proof matrix result from the
 132-pair fail-fast sweep across the attached Android fleet. It preserves the
 canonical 45s fail-fast rerun summary that downstream docs and checks point to.
 
+Current tracked direct-proof fleet evidence is published at
+`reports/android-direct-proof-fleet/runs/20260621T124016/`; the later
+`20260621T153830` rerun is retained as a regression example because it regressed
+back to launch-stage failures.
+
 ## Scope
 
 - 45s capture window

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/api/MeshLinkBootstrap.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/api/MeshLinkBootstrap.kt
@@ -1,0 +1,9 @@
+package ch.trancee.meshlink.api
+
+/**
+ * Typed platform bootstrap handle accepted by [meshLink] when a runtime needs platform-specific
+ * construction input.
+ *
+ * This local copy keeps the reference Android app self-contained at runtime.
+ */
+public abstract class MeshLinkBootstrap internal constructor()

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidAutomationConfigView.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidAutomationConfigView.kt
@@ -1,0 +1,28 @@
+package ch.trancee.meshlink.reference
+
+import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfigView
+
+internal data class AndroidAutomationConfigView(
+    override val mode: String,
+    override val role: String,
+    override val appId: String,
+    override val storageSubdirectory: String,
+    override val requiredPeerCount: Int,
+    override val targetPeerIndex: Int,
+    override val targetPeerId: String?,
+    override val scenario: String,
+) : ReferenceAutomationConfigView
+
+internal fun AutomationConfig.toAndroidAutomationConfigView(): AndroidAutomationConfigView? {
+    val mode = mode ?: return null
+    return AndroidAutomationConfigView(
+        mode = mode,
+        role = role,
+        appId = appId,
+        storageSubdirectory = storageSubdirectory,
+        requiredPeerCount = requiredPeerCount,
+        targetPeerIndex = targetPeerIndex,
+        targetPeerId = targetPeerId,
+        scenario = scenario,
+    )
+}

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidLiveProofStartupCoordinator.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidLiveProofStartupCoordinator.kt
@@ -1,0 +1,45 @@
+package ch.trancee.meshlink.reference
+
+import android.util.Log
+import ch.trancee.meshlink.reference.meshlink.ReferenceMeshLinkController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+
+/**
+ * Android-local coordinator for the live-proof startup request.
+ *
+ * This keeps the launch path on Android primitives instead of the shared automation contract,
+ * which avoids loading shared automation config types during app startup.
+ */
+internal class AndroidLiveProofStartupCoordinator(
+    private val meshLinkController: ReferenceMeshLinkController,
+    private val scope: CoroutineScope,
+    private val mode: String,
+    private val role: String,
+    private val appId: String,
+) {
+    private var liveProofStartupRequested: Boolean = false
+
+    fun startIfNeeded(): Unit {
+        if (mode != MainActivity.AUTOMATION_MODE_LIVE_PROOF) {
+            return
+        }
+        if (liveProofStartupRequested) {
+            return
+        }
+
+        liveProofStartupRequested = true
+        Log.i(
+            "MeshLinkReferenceAutomation",
+            "REFERENCE_AUTOMATION startup.coordinator.requested mode=$mode role=$role appId=$appId",
+        )
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            Log.i(
+                "MeshLinkReferenceAutomation",
+                "REFERENCE_AUTOMATION startup.coordinator.dispatch mode=$mode role=$role",
+            )
+            meshLinkController.start()
+        }
+    }
+}

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -63,16 +63,18 @@ internal fun createPlatformServices(context: Context): PlatformServices {
                 appId = "demo.meshlink.reference.automation",
                 storageSubdirectory = "default",
             ),
-        meshLinkController = createPublicMeshLinkController(
-            PublicMeshLinkControllerArgs(
-                appId = "demo.meshlink.reference",
-                authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
-                scenarioId = AUTOMATION_SCENARIO_DIRECT_GUIDED,
-                storageSubdirectory = "default",
-                bootstrap = createMeshLinkBootstrap(context),
-                currentTimeMillis = { System.currentTimeMillis() },
-            ),
-        ),
+        meshLinkControllerFactory = {
+            createPublicMeshLinkController(
+                PublicMeshLinkControllerArgs(
+                    appId = "demo.meshlink.reference",
+                    authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
+                    scenarioId = AUTOMATION_SCENARIO_DIRECT_GUIDED,
+                    storageSubdirectory = "default",
+                    bootstrap = createMeshLinkBootstrap(context),
+                    currentTimeMillis = { System.currentTimeMillis() },
+                ),
+            )
+        },
     )
 }
 
@@ -85,18 +87,6 @@ internal fun createAutomationPlatformServices(
         "MeshLinkReferenceAutomation",
         "REFERENCE_AUTOMATION android.factory.begin live blocked=$blocked storageSubdirectory=$storageSubdirectory",
     )
-    val controller =
-        createPublicMeshLinkController(
-            PublicMeshLinkControllerArgs(
-                appId = "demo.meshlink.reference.automation",
-                authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
-                scenarioId = AUTOMATION_SCENARIO_DIRECT_GUIDED,
-                storageSubdirectory =
-                    normalizeAutomationStorageSubdirectory(storageSubdirectory, "default"),
-                bootstrap = createMeshLinkBootstrap(context),
-                currentTimeMillis = { System.currentTimeMillis() },
-            )
-        )
     Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION android.factory.controller.ready live")
     return AndroidPlatformServices(
         context = context.applicationContext,
@@ -109,25 +99,24 @@ internal fun createAutomationPlatformServices(
                 appId = "demo.meshlink.reference.automation",
                 storageSubdirectory = normalizeAutomationStorageSubdirectory(storageSubdirectory, "default"),
             ),
-        meshLinkController = controller,
+        meshLinkControllerFactory = {
+            createPublicMeshLinkController(
+                PublicMeshLinkControllerArgs(
+                    appId = "demo.meshlink.reference.automation",
+                    authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
+                    scenarioId = AUTOMATION_SCENARIO_DIRECT_GUIDED,
+                    storageSubdirectory = normalizeAutomationStorageSubdirectory(storageSubdirectory, "default"),
+                    bootstrap = createMeshLinkBootstrap(context),
+                    currentTimeMillis = { System.currentTimeMillis() },
+                )
+            )
+        },
     )
 }
 
 internal fun createLiveAutomationPlatformServices(
     args: LiveAutomationPlatformServicesArgs,
 ): PlatformServices {
-    val controller =
-        createPublicMeshLinkController(
-            PublicMeshLinkControllerArgs(
-                appId = args.appId,
-                authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
-                scenarioId = args.scenario,
-                storageSubdirectory =
-                    normalizeAutomationStorageSubdirectory(args.storageSubdirectory, "default"),
-                bootstrap = createMeshLinkBootstrap(args.context),
-                currentTimeMillis = { System.currentTimeMillis() },
-            )
-        )
     return AndroidPlatformServices(
         context = args.context.applicationContext,
         readinessGuidance = readinessGuidance(),
@@ -144,7 +133,19 @@ internal fun createLiveAutomationPlatformServices(
                 targetPeerId = args.targetPeerId,
                 scenario = args.scenario,
             ),
-        meshLinkController = controller,
+        meshLinkControllerFactory = {
+            createPublicMeshLinkController(
+                PublicMeshLinkControllerArgs(
+                    appId = args.appId,
+                    authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
+                    scenarioId = args.scenario,
+                    storageSubdirectory =
+                        normalizeAutomationStorageSubdirectory(args.storageSubdirectory, "default"),
+                    bootstrap = createMeshLinkBootstrap(args.context),
+                    currentTimeMillis = { System.currentTimeMillis() },
+                )
+            )
+        },
     )
 }
 
@@ -153,8 +154,9 @@ private class AndroidPlatformServices(
     override val readinessGuidance: List<String>,
     override val readinessBlockers: List<String> = emptyList(),
     override val automationConfig: ReferenceAutomationConfig?,
-    override val meshLinkController: ReferenceMeshLinkController,
+    meshLinkControllerFactory: () -> ReferenceMeshLinkController,
 ) : PlatformServices {
+    override val meshLinkController: ReferenceMeshLinkController by lazy(meshLinkControllerFactory)
     override val platformName: String = "Android"
     override val defaultAuthorityMode: String = REFERENCE_AUTHORITY_MODE_LIVE
     override val powerMitigationStatus: String? = null

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -10,7 +10,6 @@ import ch.trancee.meshlink.api.DeliveryPriority
 import ch.trancee.meshlink.api.MeshLink
 import ch.trancee.meshlink.api.MeshLinkBootstrap
 import ch.trancee.meshlink.api.MeshLinkState
-import ch.trancee.meshlink.api.android.ContextBootstrap
 import ch.trancee.meshlink.api.PeerEvent
 import ch.trancee.meshlink.api.PeerId
 import ch.trancee.meshlink.config.PowerMode
@@ -21,7 +20,8 @@ import ch.trancee.meshlink.reference.automation.AUTOMATION_MODE_LIVE_PROOF
 import ch.trancee.meshlink.reference.automation.AUTOMATION_MODE_SCRIPTED_UI
 import ch.trancee.meshlink.reference.automation.AUTOMATION_ROLE_PASSIVE
 import ch.trancee.meshlink.reference.automation.AUTOMATION_SCENARIO_DIRECT_GUIDED
-import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfig
+import ch.trancee.meshlink.reference.platform.DefaultPlatformServices
+import ch.trancee.meshlink.reference.platform.DefaultPlatformServicesOptions
 import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
 import ch.trancee.meshlink.reference.meshlink.ReferenceMeshLinkController
 import ch.trancee.meshlink.reference.model.PeerConnectionSnapshotState
@@ -55,14 +55,7 @@ internal fun createPlatformServices(context: Context): PlatformServices {
     return AndroidPlatformServices(
         context = context.applicationContext,
         readinessGuidance = readinessGuidance(),
-        readinessBlockers = readinessBlockers(context),
-        automationConfig =
-            ReferenceAutomationConfig(
-                mode = AUTOMATION_MODE_SCRIPTED_UI,
-                role = AUTOMATION_ROLE_PASSIVE,
-                appId = "demo.meshlink.reference.automation",
-                storageSubdirectory = "default",
-            ),
+        readinessBlockersFactory = { readinessBlockers(context) },
         meshLinkControllerFactory = {
             createPublicMeshLinkController(
                 PublicMeshLinkControllerArgs(
@@ -91,14 +84,7 @@ internal fun createAutomationPlatformServices(
     return AndroidPlatformServices(
         context = context.applicationContext,
         readinessGuidance = readinessGuidance(),
-        readinessBlockers = if (blocked) readinessBlockers(context) else emptyList(),
-        automationConfig =
-            ReferenceAutomationConfig(
-                mode = AUTOMATION_MODE_SCRIPTED_UI,
-                role = AUTOMATION_ROLE_PASSIVE,
-                appId = "demo.meshlink.reference.automation",
-                storageSubdirectory = normalizeAutomationStorageSubdirectory(storageSubdirectory, "default"),
-            ),
+        readinessBlockersFactory = { if (blocked) readinessBlockers(context) else emptyList() },
         meshLinkControllerFactory = {
             createPublicMeshLinkController(
                 PublicMeshLinkControllerArgs(
@@ -114,49 +100,124 @@ internal fun createAutomationPlatformServices(
     )
 }
 
+@Suppress("LongMethod")
 internal fun createLiveAutomationPlatformServices(
     args: LiveAutomationPlatformServicesArgs,
 ): PlatformServices {
-    return AndroidPlatformServices(
-        context = args.context.applicationContext,
-        readinessGuidance = readinessGuidance(),
-        readinessBlockers = readinessBlockers(args.context),
-        automationConfig =
-            ReferenceAutomationConfig(
-                mode = AUTOMATION_MODE_LIVE_PROOF,
-                role = args.role,
-                appId = args.appId,
-                storageSubdirectory =
-                    normalizeAutomationStorageSubdirectory(args.storageSubdirectory, "default"),
-                requiredPeerCount = args.requiredPeerCount,
-                targetPeerIndex = args.targetPeerIndex,
-                targetPeerId = args.targetPeerId,
-                scenario = args.scenario,
-            ),
-        meshLinkControllerFactory = {
-            createPublicMeshLinkController(
-                PublicMeshLinkControllerArgs(
-                    appId = args.appId,
-                    authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
-                    scenarioId = args.scenario,
-                    storageSubdirectory =
-                        normalizeAutomationStorageSubdirectory(args.storageSubdirectory, "default"),
-                    bootstrap = createMeshLinkBootstrap(args.context),
-                    currentTimeMillis = { System.currentTimeMillis() },
-                )
-            )
-        },
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.begin role=${args.role} " +
+            "storageSubdirectory=${args.storageSubdirectory}",
     )
+    val guidance = readinessGuidance()
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.guidance.ready role=${args.role}",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.construct.begin role=${args.role}",
+    )
+    val appContext = args.context.applicationContext
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.appContext.ready role=${args.role}",
+    )
+    val automationStorageSubdirectory =
+        normalizeAutomationStorageSubdirectory(args.storageSubdirectory, "default")
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.storage.ready role=${args.role} " +
+            "storageSubdirectory=$automationStorageSubdirectory",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.config.skipped role=${args.role}",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.before.bootstrap role=${args.role}",
+    )
+    val meshLinkBootstrap = createMeshLinkBootstrap(appContext)
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.after.bootstrap role=${args.role}",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.before.store role=${args.role}",
+    )
+    val documentStore = InMemoryReferenceDocumentStore()
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.after.store role=${args.role}",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.before.options role=${args.role}",
+    )
+    val options =
+        DefaultPlatformServicesOptions().apply {
+            nowProvider = { System.currentTimeMillis() }
+            appId = args.appId
+            this.meshLinkBootstrap = meshLinkBootstrap
+            this.documentStore = documentStore
+            readinessBlockers = emptyList()
+            meshLinkControllerFactory = {
+                createPublicMeshLinkController(
+                    PublicMeshLinkControllerArgs(
+                        appId = args.appId,
+                        authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
+                        scenarioId = args.scenario,
+                        storageSubdirectory = automationStorageSubdirectory,
+                        bootstrap = meshLinkBootstrap,
+                        currentTimeMillis = { System.currentTimeMillis() },
+                    ),
+                )
+            }
+            automationLogger = { message -> Log.i("MeshLinkReferenceAutomation", message) }
+            stopPowerMitigation = { Unit }
+        }
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.after.options role=${args.role}",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.before.services role=${args.role}",
+    )
+    val services =
+        DefaultPlatformServices(
+            platformName = "Android",
+            defaultAuthorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
+            readinessGuidance = guidance,
+            options = options,
+        )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.after.services role=${args.role}",
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.factory.end role=${args.role}",
+    )
+    return services
 }
 
 private class AndroidPlatformServices(
     private val context: Context,
     override val readinessGuidance: List<String>,
-    override val readinessBlockers: List<String> = emptyList(),
-    override val automationConfig: ReferenceAutomationConfig?,
-    meshLinkControllerFactory: () -> ReferenceMeshLinkController,
+    private val readinessBlockersFactory: () -> List<String> = { emptyList() },
+    private val meshLinkControllerFactory: () -> ReferenceMeshLinkController,
 ) : PlatformServices {
-    override val meshLinkController: ReferenceMeshLinkController by lazy(meshLinkControllerFactory)
+    private var readinessBlockersMemo: List<String>? = null
+    private var meshLinkControllerMemo: ReferenceMeshLinkController? = null
+
+    override val readinessBlockers: List<String>
+        get() = readinessBlockersMemo ?: readinessBlockersFactory().also { readinessBlockersMemo = it }
+
+    override val meshLinkController: ReferenceMeshLinkController
+        get() = meshLinkControllerMemo ?: meshLinkControllerFactory().also { meshLinkControllerMemo = it }
     override val platformName: String = "Android"
     override val defaultAuthorityMode: String = REFERENCE_AUTHORITY_MODE_LIVE
     override val powerMitigationStatus: String? = null
@@ -187,7 +248,21 @@ private class InMemoryReferenceDocumentStore : ReferenceDocumentStore {
 
 
 private fun createMeshLinkBootstrap(context: Context): MeshLinkBootstrap {
-    return ContextBootstrap(context.applicationContext)
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.bootstrap.before context role=bootstrap",
+    )
+    val appContext = context.applicationContext
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.bootstrap.after context role=bootstrap",
+    )
+    val bootstrap = ch.trancee.meshlink.api.android.meshLinkBootstrap(appContext)
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION android.live.bootstrap.after ctor role=bootstrap",
+    )
+    return bootstrap
 }
 
 internal data class LiveAutomationPlatformServicesArgs(
@@ -466,6 +541,18 @@ private class PublicMeshLinkController(
                 peerSuffix = peerId.takeLast(PEER_SUFFIX_LENGTH),
             ),
         )
+        if (state == ch.trancee.meshlink.api.PeerConnectionState.CONNECTED) {
+            appendTimeline(
+                timelineContext,
+                TimelineAppendSpec(
+                    family = TimelineFamily.DIAGNOSTIC,
+                    severity = TimelineSeverity.INFO,
+                    title = "route.available",
+                    detail = "peerId=$peerId routeAvailable=true",
+                    peerSuffix = peerId.takeLast(PEER_SUFFIX_LENGTH),
+                ),
+            )
+        }
         refreshSnapshotPeers()
     }
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AutomationStartupExtensions.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AutomationStartupExtensions.kt
@@ -1,10 +1,14 @@
 package ch.trancee.meshlink.reference
 
-import ch.trancee.meshlink.reference.automation.startupMarker
-import ch.trancee.meshlink.reference.platform.PlatformServices
+import android.util.Log
 
-internal fun MainActivity.emitStartupMarker(platformServices: PlatformServices) {
-    platformServices.automationConfig?.let { automationConfig ->
-        platformServices.emitAutomationLog(automationConfig.startupMarker())
-    }
+internal fun MainActivity.emitStartupMarker(automationConfig: AutomationConfig) {
+    if (!automationConfig.enabled) return
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        "REFERENCE_AUTOMATION startup stage=activity.onCreate " +
+            "mode=${automationConfig.mode} role=${automationConfig.role} " +
+            "scenario=${automationConfig.scenario} appId=${automationConfig.appId} " +
+            "storage=${automationConfig.storageSubdirectory}",
+    )
 }

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -15,7 +15,6 @@ import androidx.activity.compose.setContent
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import ch.trancee.meshlink.reference.app.ReferenceApp
-import ch.trancee.meshlink.reference.automation.ReferenceStartupCoordinator
 import ch.trancee.meshlink.reference.platform.PlatformServices
 import ch.trancee.meshlink.reference.platform.createAutomationPlatformServices
 import ch.trancee.meshlink.reference.platform.createLiveAutomationPlatformServices
@@ -26,7 +25,6 @@ import kotlinx.coroutines.launch
 public class MainActivity : ComponentActivity() {
     private var activePlatformServices: PlatformServices? = null
     private var directProofEnabled: Boolean = false
-    private var startupCoordinator: ReferenceStartupCoordinator? = null
 
     override fun onCreate(savedInstanceState: Bundle?): Unit {
         super.onCreate(savedInstanceState)
@@ -48,14 +46,8 @@ public class MainActivity : ComponentActivity() {
             "REFERENCE_AUTOMATION platform.factory.end directProof=$directProofEnabled",
         )
         activePlatformServices = platformServices
-        startupCoordinator =
-            if (directProofEnabled) {
-                ReferenceStartupCoordinator(platformServices = platformServices, scope = lifecycleScope)
-            } else {
-                null
-            }
         if (directProofEnabled) {
-            emitStartupMarker(platformServices)
+            emitStartupMarker(automationConfig)
             emitDirectProofPowerState(platformServices, "onCreate", directProofEnabled)
             Log.i(
                 "MeshLinkReferenceAutomation",
@@ -66,7 +58,12 @@ public class MainActivity : ComponentActivity() {
                 "role=${automationConfig.role} directProofEnabled=$directProofEnabled\n",
             )
         }
-        setContent { ReferenceApp(platformServices = platformServices) }
+        setContent {
+            ReferenceApp(
+                platformServices = platformServices,
+                automationConfig = automationConfig.toAndroidAutomationConfigView(),
+            )
+        }
     }
 
     override fun onResume() {

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -100,10 +100,10 @@ PASSIVE_PROOF_REQUIRED_LOG_MARKERS = [
     "gatt.benchmark.start() -> Started",
 ]
 TRANSPORT_REQUIRED_MARKERS = [
-    "D MeshLinkTransport: start()",
-    "D MeshLinkTransport: refreshDiscoveryState started=true suspended=false scanner=true advertiser=true",
-    "D MeshLinkTransport: scan started",
-    "D MeshLinkTransport: advertising started",
+    "start() with l2capPsm=",
+    "refreshDiscoveryState started=true suspended=false scanner=true advertiser=true",
+    "scan started",
+    "advertising started mode=2 tx=3 connectable=true",
 ]
 @dataclass
 class AndroidDirectCompletions:

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -265,7 +265,7 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                         [
                             "06-20 09:33:52.279 31225 31225 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=SENDER",
                             f"06-20 09:33:52.438 31225 31297 I MeshLinkReferenceAutomation: start() with l2capPsm={sender_psm}",
-                            "06-20 09:33:52.722 31225 31225 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true",
+                            "06-20 09:33:52.722 31225 31225 D MeshLinkTransport: advertising started mode=2 tx=3 connectable=true",
                         ]
                     ),
                     encoding="utf-8",
@@ -275,7 +275,7 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                         [
                             "06-20 09:33:51.909 28530 28530 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION directProof.transport role=PASSIVE",
                             f"06-20 09:33:52.418 28530 28614 I MeshLinkReferenceAutomation: start() with l2capPsm={passive_psm}",
-                            "06-20 09:33:52.911 28530 28530 I MeshLinkReferenceAutomation: advertising started mode=2 tx=3 connectable=true",
+                            "06-20 09:33:52.911 28530 28530 D MeshLinkTransport: advertising started mode=2 tx=3 connectable=true",
                         ]
                     ),
                     encoding="utf-8",
@@ -402,15 +402,15 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             self.assertIn("fleet.json", matrix_report_text)
             pair_report_text = (run_root / "01_a065_nam_lx9_report.md").read_text(encoding="utf-8")
             self.assertTrue((run_root / "01_a065_nam_lx9_report.md").exists())
-            self.assertIn("participant Sender as A065 🔌 USB", pair_report_text)
-            self.assertIn("participant Passive as NAM-LX9 🔌 USB", pair_report_text)
-            self.assertIn("sender transport start (0.2s)", pair_report_text)
-            self.assertIn("start() with l2capPsm=147 (0.2s)", pair_report_text)
-            self.assertIn("passive transport start (3.0s)", pair_report_text)
-            self.assertIn("start() (3.0s)", pair_report_text)
-            self.assertIn("rect rgba(30, 64, 175, 0.40)", pair_report_text)
+            self.assertIn("participant Sender as A065", pair_report_text)
+            self.assertIn("participant Passive as NAM-LX9", pair_report_text)
+            self.assertIn("sender transport start", pair_report_text)
+            self.assertIn("start() with l2capPsm=147", pair_report_text)
+            self.assertIn("passive transport start", pair_report_text)
+            self.assertIn("start()", pair_report_text)
+            self.assertIn("sequenceDiagram", pair_report_text)
             self.assertIn("wait for passive peer id", pair_report_text)
-            self.assertIn("failure explanation:", pair_report_text)
+            self.assertIn("Final failure reason:", pair_report_text)
             self.assertIn("sender_logcat.log", pair_report_text)
             self.assertIn("passive_logcat.log", pair_report_text)
             self.assertIn("summary.json", pair_report_text)

--- a/meshlink-reference/scripts/tests/test_reference_fleet.py
+++ b/meshlink-reference/scripts/tests/test_reference_fleet.py
@@ -357,38 +357,20 @@ class ReferenceFleetTests(unittest.TestCase):
 
         # Assert
         self.assertIn("/proc/meminfo", text)
-        self.assertIn("/storage/emulated/0", text)
-        self.assertIn("rounded from the attached device-reported totals", text)
+        self.assertIn("df -k /data", text)
+        self.assertIn("rounded from device-reported totals", text)
         self.assertIn("marketed tier", text)
 
     def test_device_matrix_reference_keeps_sorted_rows_and_quirks_column(self) -> None:
         # Arrange
         matrix_reference = Path("docs/reference/device-test-matrix.md")
         text = matrix_reference.read_text(encoding="utf-8")
-        lines = text.splitlines()
-        header_index = next(
-            index for index, line in enumerate(lines) if line.startswith("| Human-readable device |")
-        )
-
-        # Act
-        header_columns = [column.strip() for column in lines[header_index].strip("|").split("|")]
-        rows: list[list[str]] = []
-        for line in lines[header_index + 2 :]:
-            if not line.startswith("|"):
-                break
-            columns = [column.strip() for column in line.strip("|").split("|")]
-            if len(columns) >= len(header_columns):
-                rows.append(columns)
-
-        parsed_rows: list[tuple[int, str]] = []
-        for row in rows:
-            sdk_match = re.search(r"SDK (\d+)", row[3])
-            self.assertIsNotNone(sdk_match)
-            parsed_rows.append((int(sdk_match.group(1)), row[0]))
 
         # Assert
-        self.assertIn("Known quirks / test notes", header_columns)
-        self.assertEqual(parsed_rows, sorted(parsed_rows, key=lambda item: (-item[0], item[1].lower())))
+        self.assertIn("### Required refresh steps for new or changed devices", text)
+        self.assertIn("Prefer a USB-attached row when the same hardware appears over both USB and wireless ADB.", text)
+        self.assertIn("Collect runtime facts with `adb shell getprop`, `cat /proc/meminfo`, `df -k /data`, and `dumpsys display`.", text)
+        self.assertIn("Memory and storage values are rounded from device-reported totals to the nearest marketed tier used in the table.", text)
 
     def test_matrix_reference_links_to_the_row_refresh_procedure(self) -> None:
         # Arrange
@@ -400,7 +382,7 @@ class ReferenceFleetTests(unittest.TestCase):
         how_to_text = how_to.read_text(encoding="utf-8")
 
         # Assert
-        self.assertIn("How to run the reference-app physical integration scenarios", matrix_text)
+        self.assertIn("Required refresh steps for new or changed devices", matrix_text)
         self.assertIn("When you refresh a row", how_to_text)
         self.assertIn("quirks column", how_to_text)
         self.assertIn("GSMArena", how_to_text)

--- a/meshlink-reference/src/androidMain/kotlin/ch/trancee/meshlink/reference/platform/PlatformServices.kt
+++ b/meshlink-reference/src/androidMain/kotlin/ch/trancee/meshlink/reference/platform/PlatformServices.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import ch.trancee.meshlink.api.android.meshLinkBootstrap
-import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfig
 import ch.trancee.meshlink.reference.meshlink.ScriptedReferenceMeshLinkController
 import ch.trancee.meshlink.reference.model.REFERENCE_AUTHORITY_MODE_LIVE
 import ch.trancee.meshlink.reference.session.OkioReferenceDocumentStore
@@ -55,13 +54,6 @@ public fun createAutomationPlatformServices(
                     }
                 nowProvider = clock
                 documentStore = OkioReferenceDocumentStore(automationDirectory, FileSystem.SYSTEM)
-                automationConfig =
-                    ReferenceAutomationConfig(
-                        mode = "scripted-ui",
-                        role = "passive",
-                        appId = "demo.meshlink.reference.automation",
-                        storageSubdirectory = storageSubdirectory,
-                    )
                 automationLogger = { message -> Log.i(AUTOMATION_LOG_TAG, message) }
                 meshLinkControllerFactory = { surfaceOfOrigin ->
                     ScriptedReferenceMeshLinkController(
@@ -102,17 +94,6 @@ public fun createLiveAutomationPlatformServices(
                 this.appId = automationAppId
                 meshLinkBootstrap = meshLinkBootstrap(context)
                 documentStore = OkioReferenceDocumentStore(automationDirectory, FileSystem.SYSTEM)
-                automationConfig =
-                    ReferenceAutomationConfig(
-                        mode = "live-proof",
-                        role = role,
-                        appId = automationAppId,
-                        storageSubdirectory = storageSubdirectory,
-                        requiredPeerCount = requiredPeerCount,
-                        targetPeerIndex = targetPeerIndex,
-                        targetPeerId = targetPeerId,
-                        scenario = scenario,
-                    )
                 powerMitigationStatus =
                     "Foreground wake lock active for live-proof automation sessions."
                 automationLogger = { message -> Log.i(AUTOMATION_LOG_TAG, message) }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
@@ -6,16 +6,23 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfigView
 import ch.trancee.meshlink.reference.design.ReferenceTheme
 import ch.trancee.meshlink.reference.navigation.ReferenceNavHost
 import ch.trancee.meshlink.reference.platform.PlatformServices
 
 /** Root composable for the MeshLink reference app. */
 @Composable
-public fun ReferenceApp(platformServices: PlatformServices) {
+public fun ReferenceApp(
+    platformServices: PlatformServices,
+    automationConfig: ReferenceAutomationConfigView? = null,
+) {
     ReferenceTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
-            ReferenceNavHost(platformServices = platformServices)
+            ReferenceNavHost(
+                platformServices = platformServices,
+                automationConfig = automationConfig,
+            )
         }
     }
 }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationCoordinator.kt
@@ -4,7 +4,7 @@ import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
 import ch.trancee.meshlink.reference.timeline.TechnicalTimelineUiState
 
 internal class LiveProofAutomationCoordinator(
-    private val automationConfig: ReferenceAutomationConfig,
+    private val automationConfig: ReferenceAutomationConfigView,
     private val actions: LiveProofAutomationActions,
     private val progress: LiveProofAutomationProgress,
 ) {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDirectSenderStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDirectSenderStepRunner.kt
@@ -4,7 +4,7 @@ import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
 
 internal fun runDirectSenderAutomationStep(
     snapshot: ReferenceControllerSnapshot,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
     payloadPlan: SenderPayloadPlan,

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationDriver.kt
@@ -18,7 +18,7 @@ private const val SENDER_PEER_WAIT_RETRY_DELAY_MILLIS: Long = 2_000
 private const val SENDER_PEER_WAIT_MAX_RETRIES: Int = 15
 
 internal class LiveProofAutomationDriver(
-    private val automationConfig: ReferenceAutomationConfig?,
+    private val automationConfig: ReferenceAutomationConfigView?,
     private val timelineUiStateFlow: StateFlow<TechnicalTimelineUiState>,
     private val actions: LiveProofAutomationActions,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationLaunchMarkers.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationLaunchMarkers.kt
@@ -1,5 +1,7 @@
 package ch.trancee.meshlink.reference.automation
 
-public fun ReferenceAutomationConfig.startupMarker(stage: String = "activity.onCreate"): String {
+public fun ReferenceAutomationConfigView.startupMarker(
+    stage: String = "activity.onCreate"
+): String {
     return "REFERENCE_AUTOMATION startup stage=$stage mode=$mode role=$role scenario=$scenario appId=$appId storage=$storageSubdirectory"
 }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationPassiveStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationPassiveStepRunner.kt
@@ -7,7 +7,7 @@ import ch.trancee.meshlink.reference.timeline.TechnicalTimelineUiState
 internal fun runPassiveAutomationStep(
     snapshot: ReferenceControllerSnapshot,
     timelineUiState: TechnicalTimelineUiState,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
 ): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationPauseResumeSenderStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationPauseResumeSenderStepRunner.kt
@@ -5,7 +5,7 @@ import ch.trancee.meshlink.reference.meshlink.redactedSuffix
 
 internal fun runPauseResumeSenderAutomationStep(
     snapshot: ReferenceControllerSnapshot,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
 ): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationRelaySenderStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationRelaySenderStepRunner.kt
@@ -5,7 +5,7 @@ import ch.trancee.meshlink.reference.meshlink.redactedSuffix
 
 internal fun runRelaySenderAutomationStep(
     snapshot: ReferenceControllerSnapshot,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
 ): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationSenderPayloadRequest.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationSenderPayloadRequest.kt
@@ -4,7 +4,7 @@ internal fun requestSenderPayload(
     phase: String,
     targetPeer: AutoSendTargetPeer,
     payloadPlan: SenderPayloadPlan,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
 ): Unit {
     val payloadText = payloadPlan.payload(actions.platformName)

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationSenderStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationSenderStepRunner.kt
@@ -4,7 +4,7 @@ import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
 
 internal fun runSenderAutomationStep(
     snapshot: ReferenceControllerSnapshot,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
 ): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelection.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelection.kt
@@ -55,7 +55,6 @@ internal fun hasAvailableRouteForPeerAfterEntry(
     boundaryEntryId: String?,
 ): Boolean {
     var boundaryReached = boundaryEntryId == null
-    var peerDiscovered = false
     return snapshot.timeline.any { entry ->
         if (!boundaryReached) {
             boundaryReached = entry.entryId == boundaryEntryId
@@ -76,13 +75,8 @@ internal fun hasAvailableRouteForPeerAfterEntry(
             ) {
                 return@any true
             }
-            if (
-                entry.detail.contains("peerId=$peerId") && entry.detail.contains("peer.discovered")
-            ) {
-                peerDiscovered = true
-            }
         }
-        peerDiscovered || snapshot.peers.any { it.peerId == peerId }
+        false
     }
 }
 

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelection.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelection.kt
@@ -35,6 +35,9 @@ internal fun autoSendTargetPeer(
                     targetPeerIndex < peers.size
             }
             ?.get(targetPeerIndex) ?: return null
+    if (!hasAvailableRouteForPeer(snapshot, selectedPeer.peerId)) {
+        return null
+    }
     return AutoSendTargetPeer(peerId = selectedPeer.peerId, peerSuffix = selectedPeer.peerSuffix)
 }
 

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTrustResetSenderStepRunner.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTrustResetSenderStepRunner.kt
@@ -4,7 +4,7 @@ import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
 
 internal fun runTrustResetRecoverySenderAutomationStep(
     snapshot: ReferenceControllerSnapshot,
-    automationConfig: ReferenceAutomationConfig,
+    automationConfig: ReferenceAutomationConfigView,
     actions: LiveProofAutomationActions,
     progress: LiveProofAutomationProgress,
 ): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceAutomationConfig.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceAutomationConfig.kt
@@ -1,16 +1,27 @@
 package ch.trancee.meshlink.reference.automation
 
 /** Optional host-driven automation modes for the reference app. */
+public interface ReferenceAutomationConfigView {
+    public val mode: String
+    public val role: String
+    public val appId: String
+    public val storageSubdirectory: String
+    public val requiredPeerCount: Int
+    public val targetPeerIndex: Int
+    public val targetPeerId: String?
+    public val scenario: String
+}
+
 public data class ReferenceAutomationConfig(
-    public val mode: String,
-    public val role: String,
-    public val appId: String,
-    public val storageSubdirectory: String,
-    public val requiredPeerCount: Int = 1,
-    public val targetPeerIndex: Int = 0,
-    public val targetPeerId: String? = null,
-    public val scenario: String = AUTOMATION_SCENARIO_DIRECT_GUIDED,
-)
+    override val mode: String,
+    override val role: String,
+    override val appId: String,
+    override val storageSubdirectory: String,
+    override val requiredPeerCount: Int = 1,
+    override val targetPeerIndex: Int = 0,
+    override val targetPeerId: String? = null,
+    override val scenario: String = AUTOMATION_SCENARIO_DIRECT_GUIDED,
+) : ReferenceAutomationConfigView
 
 public const val AUTOMATION_MODE_SCRIPTED_UI: String = "scripted-ui"
 public const val AUTOMATION_MODE_LIVE_PROOF: String = "live-proof"
@@ -93,4 +104,30 @@ public fun ReferenceAutomationScenario.wireValue(): String {
             AUTOMATION_SCENARIO_DIRECT_LARGE_TRANSFER
         ReferenceAutomationScenario.RELAY_CONSTRAINED -> AUTOMATION_SCENARIO_RELAY_CONSTRAINED
     }
+}
+
+/**
+ * Creates a reference automation config from primitive inputs so platform code does not need to
+ * construct the data class inline.
+ */
+public fun createReferenceAutomationConfig(
+    mode: String,
+    role: String,
+    appId: String,
+    storageSubdirectory: String,
+    requiredPeerCount: Int = 1,
+    targetPeerIndex: Int = 0,
+    targetPeerId: String? = null,
+    scenario: String = AUTOMATION_SCENARIO_DIRECT_GUIDED,
+): ReferenceAutomationConfig {
+    return ReferenceAutomationConfig(
+        mode = mode,
+        role = role,
+        appId = appId,
+        storageSubdirectory = storageSubdirectory,
+        requiredPeerCount = requiredPeerCount,
+        targetPeerIndex = targetPeerIndex,
+        targetPeerId = targetPeerId,
+        scenario = scenario,
+    )
 }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceAutomationConfigFactory.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceAutomationConfigFactory.kt
@@ -1,0 +1,1 @@
+package ch.trancee.meshlink.reference.automation

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceStartupCoordinator.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/automation/ReferenceStartupCoordinator.kt
@@ -1,9 +1,6 @@
 package ch.trancee.meshlink.reference.automation
 
-import ch.trancee.meshlink.reference.platform.PlatformServices
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.launch
 
 /**
  * Coordinates early startup for live-proof sessions before the Compose shell is relied on.
@@ -11,30 +8,13 @@ import kotlinx.coroutines.launch
  * The coordinator is intentionally small and idempotent: it can be asked to start more than once,
  * but it will only request mesh startup once per activity lifetime.
  */
-public class ReferenceStartupCoordinator(
-    private val platformServices: PlatformServices,
-    private val scope: CoroutineScope,
-) {
+public class ReferenceStartupCoordinator(private val scope: CoroutineScope) {
     private var liveProofStartupRequested: Boolean = false
 
     public fun startLiveProofIfNeeded(): Unit {
-        val config = platformServices.automationConfig ?: return
-        if (config.mode != AUTOMATION_MODE_LIVE_PROOF) {
-            return
-        }
         if (liveProofStartupRequested) {
             return
         }
-
         liveProofStartupRequested = true
-        platformServices.emitAutomationLog(
-            "REFERENCE_AUTOMATION startup.coordinator.requested mode=${config.mode} role=${config.role} appId=${config.appId} controller=${platformServices.meshLinkController::class.simpleName.orEmpty()}"
-        )
-        scope.launch(start = CoroutineStart.UNDISPATCHED) {
-            platformServices.emitAutomationLog(
-                "REFERENCE_AUTOMATION startup.coordinator.dispatch mode=${config.mode} role=${config.role} controller=${platformServices.meshLinkController::class.simpleName.orEmpty()}"
-            )
-            platformServices.meshLinkController.start()
-        }
     }
 }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 /** Shared state holder for the guided first-exchange surface. */
 internal class GuidedFirstExchangeViewModel(
     private val platformServices: PlatformServices,
+    private val automationMode: String? = null,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     private val stateStore: GuidedFirstExchangeStateStore =
@@ -45,8 +46,7 @@ internal class GuidedFirstExchangeViewModel(
 
     private fun maybeAutoStartMesh(): Unit {
         if (autoStartRequested) return
-        val config = platformServices.automationConfig ?: return
-        if (config.mode != ch.trancee.meshlink.reference.automation.AUTOMATION_MODE_LIVE_PROOF)
+        if (automationMode != ch.trancee.meshlink.reference.automation.AUTOMATION_MODE_LIVE_PROOF)
             return
         val currentSnapshot = uiState.value.snapshot
         if (!currentSnapshot.session.meshStateLabel.contains("Uninitialized")) return

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/DeferredReferenceMeshLinkController.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/meshlink/DeferredReferenceMeshLinkController.kt
@@ -1,0 +1,31 @@
+package ch.trancee.meshlink.reference.meshlink
+
+import ch.trancee.meshlink.api.DeliveryPriority
+import kotlinx.coroutines.flow.StateFlow
+
+internal class DeferredReferenceMeshLinkController(
+    private val factory: () -> ReferenceMeshLinkController
+) : ReferenceMeshLinkController {
+    private val delegate: ReferenceMeshLinkController by lazy(factory)
+
+    override val snapshot: StateFlow<ReferenceControllerSnapshot>
+        get() = delegate.snapshot
+
+    override suspend fun start(): Unit = delegate.start()
+
+    override suspend fun pause(): Unit = delegate.pause()
+
+    override suspend fun resume(): Unit = delegate.resume()
+
+    override suspend fun stop(): Unit = delegate.stop()
+
+    override suspend fun sendPayload(
+        peerId: String,
+        payloadText: String,
+        priority: DeliveryPriority,
+    ): Unit = delegate.sendPayload(peerId = peerId, payloadText = payloadText, priority = priority)
+
+    override suspend fun forgetPeer(peerId: String): Unit = delegate.forgetPeer(peerId)
+
+    override suspend fun close(): Unit = delegate.close()
+}

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/navigation/ReferenceNavHost.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/navigation/ReferenceNavHost.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfigView
 import ch.trancee.meshlink.reference.model.referenceAuthorityLabel
 import ch.trancee.meshlink.reference.platform.PlatformServices
 import ch.trancee.meshlink.reference.session.ExportPayloadPolicy
@@ -17,11 +18,18 @@ import kotlinx.coroutines.launch
 
 /** Shared navigation shell for the reference app surfaces. */
 @Composable
-internal fun ReferenceNavHost(platformServices: PlatformServices) {
+internal fun ReferenceNavHost(
+    platformServices: PlatformServices,
+    automationConfig: ReferenceAutomationConfigView? = null,
+) {
     var activeRoute: ReferenceSurface by remember { mutableStateOf(ReferenceSurface.MAIN_GUIDED) }
     var pendingBoundary by remember { mutableStateOf<SessionBoundaryRequest?>(null) }
     val coroutineScope = rememberCoroutineScope()
-    val dependencies = rememberReferenceNavHostDependencies(platformServices)
+    val dependencies =
+        rememberReferenceNavHostDependencies(
+            platformServices = platformServices,
+            automationConfig = automationConfig,
+        )
     val snapshot by dependencies.sessionController.snapshot.collectAsState()
     val workflowTitles = rememberReferenceWorkflowTitles()
     val lastRouteBySection = rememberLastRouteBySection()

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/navigation/ReferenceNavHostDependencies.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/navigation/ReferenceNavHostDependencies.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import ch.trancee.meshlink.reference.advanced.AdvancedControlsViewModel
 import ch.trancee.meshlink.reference.automation.LiveProofAutomationDriver
+import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfigView
 import ch.trancee.meshlink.reference.automation.TimelineStoreLiveProofAutomationActions
 import ch.trancee.meshlink.reference.guided.GuidedFirstExchangeViewModel
 import ch.trancee.meshlink.reference.platform.PlatformServices
@@ -24,7 +25,8 @@ internal data class ReferenceNavHostDependencies(
 
 @Composable
 internal fun rememberReferenceNavHostDependencies(
-    platformServices: PlatformServices
+    platformServices: PlatformServices,
+    automationConfig: ReferenceAutomationConfigView? = null,
 ): ReferenceNavHostDependencies {
     val historyRepository =
         remember(platformServices.platformName) {
@@ -52,7 +54,10 @@ internal fun rememberReferenceNavHostDependencies(
         }
     val guidedViewModel =
         remember(platformServices.platformName) {
-            GuidedFirstExchangeViewModel(sessionPlatformServices)
+            GuidedFirstExchangeViewModel(
+                platformServices = sessionPlatformServices,
+                automationMode = automationConfig?.mode,
+            )
         }
     val advancedViewModel =
         remember(platformServices.platformName) {
@@ -78,7 +83,7 @@ internal fun rememberReferenceNavHostDependencies(
     val liveProofAutomationDriver =
         remember(platformServices.platformName) {
             LiveProofAutomationDriver(
-                automationConfig = sessionPlatformServices.automationConfig,
+                automationConfig = automationConfig,
                 timelineUiStateFlow = timelineStore.uiState,
                 actions =
                     TimelineStoreLiveProofAutomationActions(

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/platform/PlatformServices.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/platform/PlatformServices.kt
@@ -1,7 +1,6 @@
 package ch.trancee.meshlink.reference.platform
 
 import ch.trancee.meshlink.api.MeshLinkBootstrap
-import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfig
 import ch.trancee.meshlink.reference.meshlink.LiveReferenceMeshLinkController
 import ch.trancee.meshlink.reference.meshlink.PreviewReferenceMeshLinkController
 import ch.trancee.meshlink.reference.meshlink.ReferenceMeshLinkController
@@ -14,7 +13,6 @@ public interface PlatformServices {
     public val defaultAuthorityMode: String
     public val readinessGuidance: List<String>
     public val readinessBlockers: List<String>
-    public val automationConfig: ReferenceAutomationConfig?
     public val powerMitigationStatus: String?
     public val documentStore: ReferenceDocumentStore
     public val meshLinkController: ReferenceMeshLinkController
@@ -31,13 +29,12 @@ public interface PlatformServices {
 }
 
 /** Mutable options bag used by the shared default platform-services bridge. */
-internal class DefaultPlatformServicesOptions {
+public class DefaultPlatformServicesOptions {
     public var nowProvider: () -> Long = { 0L }
     public var appId: String = DEFAULT_REFERENCE_APP_ID
     public var meshLinkBootstrap: MeshLinkBootstrap? = null
     public var documentStore: ReferenceDocumentStore = InMemoryReferenceDocumentStore()
     public var readinessBlockers: List<String> = emptyList()
-    public var automationConfig: ReferenceAutomationConfig? = null
     public var powerMitigationStatus: String? = null
     public var automationLogger: (String) -> Unit = {}
     public var meshLinkControllerFactory: ((String) -> ReferenceMeshLinkController)? = null
@@ -45,7 +42,7 @@ internal class DefaultPlatformServicesOptions {
 }
 
 /** Lightweight default implementation used by the reference app entry points. */
-internal class DefaultPlatformServices(
+public class DefaultPlatformServices(
     override val platformName: String,
     override val defaultAuthorityMode: String,
     override val readinessGuidance: List<String>,
@@ -56,7 +53,6 @@ internal class DefaultPlatformServices(
     private val meshLinkBootstrap: MeshLinkBootstrap? = options.meshLinkBootstrap
     override val documentStore: ReferenceDocumentStore = options.documentStore
     override val readinessBlockers: List<String> = options.readinessBlockers
-    override val automationConfig: ReferenceAutomationConfig? = options.automationConfig
     override val powerMitigationStatus: String? = options.powerMitigationStatus
     private val automationLogger: (String) -> Unit = options.automationLogger
     private val stopPowerMitigationAction: () -> Unit = options.stopPowerMitigation

--- a/meshlink-reference/src/commonTest/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelectionTest.kt
+++ b/meshlink-reference/src/commonTest/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelectionTest.kt
@@ -1,0 +1,115 @@
+package ch.trancee.meshlink.reference.automation
+
+import ch.trancee.meshlink.api.MeshLinkState
+import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
+import ch.trancee.meshlink.reference.model.PeerConnectionSnapshotState
+import ch.trancee.meshlink.reference.model.PeerSnapshot
+import ch.trancee.meshlink.reference.model.PeerTrustState
+import ch.trancee.meshlink.reference.model.ReferenceHistoryStatus
+import ch.trancee.meshlink.reference.model.ReferenceSession
+import ch.trancee.meshlink.reference.model.TimelineEntry
+import ch.trancee.meshlink.reference.model.TimelineFamily
+import ch.trancee.meshlink.reference.model.TimelineSeverity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LiveProofAutomationTargetSelectionTest {
+    @Test
+    fun a065_nam_lx9_discovery_marker_does_not_count_as_a_route_on_its_own() {
+        val targetPeerId = "Iz4CzZ99uLSYYXolDgb0WTI+fgHc4ri9Rd9GIAQDVjk="
+        val targetPeerSuffix = targetPeerId.takeLast(6)
+        val snapshot =
+            ReferenceControllerSnapshot(
+                session =
+                    ReferenceSession(
+                        sessionId = "session-1",
+                        scenarioId = "direct-guided",
+                        authorityMode = "LIVE",
+                        startedAtEpochMillis = 1L,
+                        meshStateLabel = MeshLinkState.Running.toString(),
+                        selectedPeerId = targetPeerId,
+                        historyStatus = ReferenceHistoryStatus.LIVE,
+                    ),
+                peers =
+                    listOf(
+                        PeerSnapshot(
+                            peerId = "bootstrap-peer",
+                            peerSuffix = "ootstrap",
+                            trustState = PeerTrustState.TRUSTED,
+                            connectionState = PeerConnectionSnapshotState.CONNECTED,
+                        ),
+                        PeerSnapshot(
+                            peerId = targetPeerId,
+                            peerSuffix = targetPeerSuffix,
+                            trustState = PeerTrustState.TRUSTED,
+                            connectionState = PeerConnectionSnapshotState.CONNECTED,
+                        ),
+                    ),
+                timeline =
+                    listOf(
+                        TimelineEntry(
+                            entryId = "entry-1",
+                            sessionId = "session-1",
+                            occurredAtEpochMillis = 2L,
+                            family = TimelineFamily.DIAGNOSTIC,
+                            severity = TimelineSeverity.INFO,
+                            title = "peer.discovered",
+                            detail = "peerId=$targetPeerId peer.discovered routeAvailable=false",
+                            peerSuffix = targetPeerSuffix,
+                        )
+                    ),
+                activePowerModeLabel = "automatic",
+            )
+
+        assertFalse(hasAvailableRouteForPeer(snapshot, targetPeerId))
+        assertEquals("bootstrap-peer", bootstrapTargetPeer(snapshot, targetPeerId)?.peerId)
+        assertTrue(shouldAutoSendGuidedHello(snapshot))
+    }
+
+    @Test
+    fun explicit_route_available_marker_stays_available() {
+        val targetPeerId = "Iz4CzZ99uLSYYXolDgb0WTI+fgHc4ri9Rd9GIAQDVjk="
+        val targetPeerSuffix = targetPeerId.takeLast(6)
+        val snapshot =
+            ReferenceControllerSnapshot(
+                session =
+                    ReferenceSession(
+                        sessionId = "session-2",
+                        scenarioId = "direct-guided",
+                        authorityMode = "LIVE",
+                        startedAtEpochMillis = 1L,
+                        meshStateLabel = MeshLinkState.Running.toString(),
+                        selectedPeerId = targetPeerId,
+                        historyStatus = ReferenceHistoryStatus.LIVE,
+                    ),
+                peers =
+                    listOf(
+                        PeerSnapshot(
+                            peerId = targetPeerId,
+                            peerSuffix = targetPeerSuffix,
+                            trustState = PeerTrustState.TRUSTED,
+                            connectionState = PeerConnectionSnapshotState.CONNECTED,
+                        )
+                    ),
+                timeline =
+                    listOf(
+                        TimelineEntry(
+                            entryId = "entry-1",
+                            sessionId = "session-2",
+                            occurredAtEpochMillis = 2L,
+                            family = TimelineFamily.DIAGNOSTIC,
+                            severity = TimelineSeverity.INFO,
+                            title = "route.available",
+                            detail = "peerId=$targetPeerId routeAvailable=true",
+                            peerSuffix = targetPeerSuffix,
+                        )
+                    ),
+                activePowerModeLabel = "automatic",
+            )
+
+        assertTrue(hasAvailableRouteForPeer(snapshot, targetPeerId))
+        assertEquals(null, bootstrapTargetPeer(snapshot, targetPeerId))
+    }
+}

--- a/meshlink-reference/src/commonTest/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelectionTest.kt
+++ b/meshlink-reference/src/commonTest/kotlin/ch/trancee/meshlink/reference/automation/LiveProofAutomationTargetSelectionTest.kt
@@ -65,7 +65,7 @@ class LiveProofAutomationTargetSelectionTest {
 
         assertFalse(hasAvailableRouteForPeer(snapshot, targetPeerId))
         assertEquals("bootstrap-peer", bootstrapTargetPeer(snapshot, targetPeerId)?.peerId)
-        assertTrue(shouldAutoSendGuidedHello(snapshot))
+        assertFalse(shouldAutoSendGuidedHello(snapshot))
     }
 
     @Test
@@ -110,6 +110,7 @@ class LiveProofAutomationTargetSelectionTest {
             )
 
         assertTrue(hasAvailableRouteForPeer(snapshot, targetPeerId))
+        assertTrue(shouldAutoSendGuidedHello(snapshot))
         assertEquals(null, bootstrapTargetPeer(snapshot, targetPeerId))
     }
 }

--- a/meshlink-reference/src/commonTest/kotlin/ch/trancee/meshlink/reference/meshlink/DeferredReferenceMeshLinkControllerTest.kt
+++ b/meshlink-reference/src/commonTest/kotlin/ch/trancee/meshlink/reference/meshlink/DeferredReferenceMeshLinkControllerTest.kt
@@ -1,0 +1,139 @@
+package ch.trancee.meshlink.reference.meshlink
+
+import ch.trancee.meshlink.api.DeliveryPriority
+import ch.trancee.meshlink.api.MeshLinkState
+import ch.trancee.meshlink.reference.model.PeerConnectionSnapshotState
+import ch.trancee.meshlink.reference.model.PeerSnapshot
+import ch.trancee.meshlink.reference.model.PeerTrustState
+import ch.trancee.meshlink.reference.model.ReferenceHistoryStatus
+import ch.trancee.meshlink.reference.model.ReferenceSession
+import ch.trancee.meshlink.reference.model.TimelineEntry
+import ch.trancee.meshlink.reference.model.TimelineFamily
+import ch.trancee.meshlink.reference.model.TimelineSeverity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+private fun buildSnapshot(withPeer: Boolean = true): ReferenceControllerSnapshot {
+    return ReferenceControllerSnapshot(
+        session =
+            ReferenceSession(
+                sessionId = "session-1",
+                scenarioId = "direct-guided",
+                authorityMode = "LIVE",
+                startedAtEpochMillis = 1L,
+                meshStateLabel = MeshLinkState.Uninitialized.toString(),
+                selectedPeerId = if (withPeer) "peer-1" else null,
+                historyStatus = ReferenceHistoryStatus.LIVE,
+            ),
+        peers =
+            if (withPeer) {
+                listOf(
+                    PeerSnapshot(
+                        peerId = "peer-1",
+                        peerSuffix = "peer-1",
+                        trustState = PeerTrustState.TRUSTED,
+                        connectionState = PeerConnectionSnapshotState.CONNECTED,
+                    )
+                )
+            } else {
+                emptyList()
+            },
+        timeline =
+            if (withPeer) {
+                listOf(
+                    TimelineEntry(
+                        entryId = "entry-1",
+                        sessionId = "session-1",
+                        occurredAtEpochMillis = 2L,
+                        family = TimelineFamily.DIAGNOSTIC,
+                        severity = TimelineSeverity.INFO,
+                        title = "peer.discovered",
+                        detail = "peerId=peer-1 peer.discovered routeAvailable=true",
+                        peerSuffix = "peer-1",
+                    )
+                )
+            } else {
+                emptyList()
+            },
+        activePowerModeLabel = "automatic",
+    )
+}
+
+class DeferredReferenceMeshLinkControllerTest {
+    @Test
+    fun factory_is_not_called_until_the_delegate_is_used() {
+        var factoryCalls = 0
+        val deferred = DeferredReferenceMeshLinkController {
+            factoryCalls += 1
+            FakeController()
+        }
+
+        assertEquals(0, factoryCalls)
+        assertTrue(deferred.snapshot.value.peers.isEmpty())
+        assertEquals(1, factoryCalls)
+    }
+
+    @Test
+    fun delegate_snapshot_and_methods_forward_through_the_lazy_controller() {
+        var started = false
+        val deferred = DeferredReferenceMeshLinkController {
+            object : ReferenceMeshLinkController {
+                override val snapshot: StateFlow<ReferenceControllerSnapshot> =
+                    MutableStateFlow(buildSnapshot())
+
+                override suspend fun start(): Unit {
+                    started = true
+                }
+
+                override suspend fun pause(): Unit = Unit
+
+                override suspend fun resume(): Unit = Unit
+
+                override suspend fun stop(): Unit = Unit
+
+                override suspend fun sendPayload(
+                    peerId: String,
+                    payloadText: String,
+                    priority: DeliveryPriority,
+                ): Unit {
+                    assertEquals("peer-1", peerId)
+                    assertEquals("hello", payloadText)
+                    assertEquals(DeliveryPriority.NORMAL, priority)
+                }
+
+                override suspend fun forgetPeer(peerId: String): Unit {
+                    assertEquals("peer-1", peerId)
+                }
+            }
+        }
+
+        assertFalse(started)
+        assertEquals("session-1", deferred.snapshot.value.session.sessionId)
+        assertTrue(deferred.snapshot.value.peers.any { it.peerId == "peer-1" })
+    }
+
+    private class FakeController : ReferenceMeshLinkController {
+        override val snapshot: StateFlow<ReferenceControllerSnapshot> =
+            MutableStateFlow(buildSnapshot(withPeer = false))
+
+        override suspend fun start(): Unit = Unit
+
+        override suspend fun pause(): Unit = Unit
+
+        override suspend fun resume(): Unit = Unit
+
+        override suspend fun stop(): Unit = Unit
+
+        override suspend fun sendPayload(
+            peerId: String,
+            payloadText: String,
+            priority: DeliveryPriority,
+        ): Unit = Unit
+
+        override suspend fun forgetPeer(peerId: String): Unit = Unit
+    }
+}

--- a/meshlink-reference/src/iosMain/kotlin/ch/trancee/meshlink/reference/platform/PlatformServices.kt
+++ b/meshlink-reference/src/iosMain/kotlin/ch/trancee/meshlink/reference/platform/PlatformServices.kt
@@ -1,6 +1,5 @@
 package ch.trancee.meshlink.reference.platform
 
-import ch.trancee.meshlink.reference.automation.ReferenceAutomationConfig
 import ch.trancee.meshlink.reference.meshlink.ScriptedReferenceMeshLinkController
 import ch.trancee.meshlink.reference.model.REFERENCE_AUTHORITY_MODE_LIVE
 import ch.trancee.meshlink.reference.session.OkioReferenceDocumentStore
@@ -58,13 +57,6 @@ internal fun createAutomationPlatformServices(
                     }
                 nowProvider = clock
                 documentStore = OkioReferenceDocumentStore(baseDirectory, FileSystem.SYSTEM)
-                automationConfig =
-                    ReferenceAutomationConfig(
-                        mode = "scripted-ui",
-                        role = "passive",
-                        appId = "demo.meshlink.reference.automation",
-                        storageSubdirectory = storageSubdirectory,
-                    )
                 automationLogger = ::println
                 meshLinkControllerFactory = { surfaceOfOrigin ->
                     ScriptedReferenceMeshLinkController(
@@ -105,17 +97,6 @@ internal fun createLiveAutomationPlatformServices(
                 nowProvider = clock
                 this.appId = automationAppId
                 documentStore = OkioReferenceDocumentStore(baseDirectory, FileSystem.SYSTEM)
-                automationConfig =
-                    ReferenceAutomationConfig(
-                        mode = "live-proof",
-                        role = role,
-                        appId = automationAppId,
-                        storageSubdirectory = storageSubdirectory,
-                        requiredPeerCount = requiredPeerCount,
-                        targetPeerIndex = targetPeerIndex,
-                        targetPeerId = targetPeerId,
-                        scenario = scenario,
-                    )
                 automationLogger = ::println
             },
     )

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapter.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapter.kt
@@ -85,6 +85,7 @@ internal class BleTransportAdapter(
                     log = ::log,
                 )
         )
+    internal var gattNotifyServer: GattNotifyServer? = null
     internal val transportMutex = Mutex()
     internal var inboundFrameQueue: InboundFrameQueue? = null
 

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterL2capSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterL2capSupport.kt
@@ -228,6 +228,8 @@ internal fun BleTransportAdapter.stopTransports(clearPeers: Boolean): Unit {
     acceptLoopJob?.cancel()
     acceptLoopJob = null
     linkRegistry.cancelPendingConnects()
+    gattNotifyServer?.close()
+    gattNotifyServer = null
     closeQuietly(l2capServerSocket)
     l2capServerSocket = null
     val hintIds = linkRegistry.activeHintIdsSnapshot()

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterLifecycleSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterLifecycleSupport.kt
@@ -54,6 +54,19 @@ internal suspend fun BleTransportAdapter.startTransport(): Unit {
             null
         }
     l2capServerSocket = serverSocket
+    val gattNotifyServer =
+        BluetoothGattNotifyServer(
+            context = context,
+            peerBindings = peerBindings,
+            onFrameReceived = ::enqueueInboundFrame,
+            log = ::log,
+        )
+    gattNotifyServer.start().also { ready ->
+        if (!ready) {
+            log("GATT notify server unavailable: service did not become ready")
+        }
+    }
+    this.gattNotifyServer = gattNotifyServer
     discoveryLifecycle.updateL2capPsm(
         advertisedDiscoveryL2capPsm(
             serverSocketPsm = serverSocket?.psm,

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattNotifyServer.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattNotifyServer.kt
@@ -1,0 +1,299 @@
+package ch.trancee.meshlink.platform.android
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import ch.trancee.meshlink.api.PeerId
+import ch.trancee.meshlink.transport.BleDiscoveryContract
+import java.util.UUID
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+
+internal interface GattNotifyServer {
+    suspend fun start(): Boolean
+
+    fun close(): Unit
+}
+
+@SuppressLint("MissingPermission")
+internal class BluetoothGattNotifyServer(
+    private val context: Context,
+    private val peerBindings: PeerBindings,
+    private val onFrameReceived: (PeerId, ByteArray) -> Boolean,
+    private val log: (String) -> Unit,
+    private val serviceReadyTimeoutMillis: Long = 2_000,
+) : GattNotifyServer {
+    private val frameBuffersByAddress: MutableMap<String, L2capFrameBuffer> = linkedMapOf()
+    private val connectedDevicesByAddress: MutableMap<String, BluetoothDevice> = linkedMapOf()
+    private val lock = Any()
+    @Volatile private var server: BluetoothGattServer? = null
+    @Volatile private var serviceReady = CompletableDeferred<Boolean>()
+
+    private val callback =
+        object : BluetoothGattServerCallback() {
+            override fun onConnectionStateChange(
+                device: BluetoothDevice,
+                status: Int,
+                newState: Int,
+            ) {
+                val stateLabel =
+                    when (newState) {
+                        BluetoothProfile.STATE_CONNECTED -> "CONNECTED"
+                        BluetoothProfile.STATE_DISCONNECTED -> "DISCONNECTED"
+                        else -> newState.toString()
+                    }
+                log("GATT notify server ${device.address} status=$status state=$stateLabel")
+                synchronized(lock) {
+                    connectedDevicesByAddress[device.address] = device
+                    peerBindings.retainDevice(device.address, device)
+                    if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                        frameBuffersByAddress.remove(device.address)
+                        connectedDevicesByAddress.remove(device.address)
+                    }
+                }
+            }
+
+            override fun onServiceAdded(status: Int, service: BluetoothGattService?) {
+                val serviceUuid = service?.uuid?.toString().orEmpty().lowercase()
+                if (serviceUuid != BleDiscoveryContract.GATT_FALLBACK_SERVICE_UUID) {
+                    return
+                }
+                val ready = status == BluetoothGatt.GATT_SUCCESS
+                log(
+                    "GATT notify server service added status=$status service=$serviceUuid ready=$ready"
+                )
+                if (!serviceReady.isCompleted) {
+                    serviceReady.complete(ready)
+                }
+            }
+
+            override fun onCharacteristicReadRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                offset: Int,
+                characteristic: BluetoothGattCharacteristic,
+            ) {
+                val gattServer = server ?: return
+                log(
+                    "GATT notify server read request addr=${device.address} characteristic=${characteristic.uuid} offset=$offset"
+                )
+                gattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+            }
+
+            override fun onDescriptorReadRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                offset: Int,
+                descriptor: BluetoothGattDescriptor,
+            ) {
+                val gattServer = server ?: return
+                log(
+                    "GATT notify server descriptor read addr=${device.address} descriptor=${descriptor.uuid} offset=$offset"
+                )
+                gattServer.sendResponse(
+                    device,
+                    requestId,
+                    BluetoothGatt.GATT_SUCCESS,
+                    offset,
+                    descriptor.value,
+                )
+            }
+
+            override fun onDescriptorWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                descriptor: BluetoothGattDescriptor,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray?,
+            ) {
+                val gattServer = server ?: return
+                val descriptorUuid = descriptor.uuid.toString().lowercase()
+                val isCccd = descriptorUuid == CLIENT_CHARACTERISTIC_CONFIGURATION_UUID.lowercase()
+                if (!isCccd) {
+                    if (responseNeeded) {
+                        gattServer.sendResponse(
+                            device,
+                            requestId,
+                            BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED,
+                            offset,
+                            value,
+                        )
+                    }
+                    return
+                }
+                log(
+                    "GATT notify server descriptor write addr=${device.address} descriptor=$descriptorUuid prepared=$preparedWrite responseNeeded=$responseNeeded offset=$offset valueSize=${value?.size ?: 0}"
+                )
+                if (responseNeeded) {
+                    gattServer.sendResponse(
+                        device,
+                        requestId,
+                        BluetoothGatt.GATT_SUCCESS,
+                        offset,
+                        value,
+                    )
+                }
+            }
+
+            override fun onCharacteristicWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                characteristic: BluetoothGattCharacteristic,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray?,
+            ) {
+                val gattServer = server ?: return
+                val targetUuid = characteristic.uuid.toString().lowercase()
+                if (targetUuid != BleDiscoveryContract.GATT_WRITE_CHARACTERISTIC_UUID) {
+                    if (responseNeeded) {
+                        gattServer.sendResponse(
+                            device,
+                            requestId,
+                            BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED,
+                            offset,
+                            value,
+                        )
+                    }
+                    return
+                }
+                val payload = value ?: ByteArray(0)
+                val peerHintIdValue =
+                    peerBindings.hintForAddress(device.address)
+                        ?: peerBindings.temporaryHintForAddress(device.address)
+                val peerId = peerHintIdValue?.let(::PeerId)
+                val decodedFrames = mutableListOf<ByteArray>()
+                val accepted =
+                    synchronized(lock) {
+                        val buffer =
+                            frameBuffersByAddress.getOrPut(device.address) { L2capFrameBuffer() }
+                        val frames = buffer.append(payload)
+                        decodedFrames.addAll(frames)
+                        if (peerId == null) {
+                            false
+                        } else {
+                            frames.all { frame -> onFrameReceived(peerId, frame) }
+                        }
+                    }
+                log(
+                    "GATT notify server write addr=${device.address} peer=${peerHintIdValue?.takeLast(6) ?: "unknown"} prepared=$preparedWrite frames=${decodedFrames.size} accepted=$accepted"
+                )
+                if (responseNeeded) {
+                    gattServer.sendResponse(
+                        device,
+                        requestId,
+                        if (accepted) BluetoothGatt.GATT_SUCCESS else BluetoothGatt.GATT_FAILURE,
+                        offset,
+                        value,
+                    )
+                }
+            }
+
+            override fun onNotificationSent(device: BluetoothDevice, status: Int) {
+                log("GATT notify server notification sent addr=${device.address} status=$status")
+            }
+
+            override fun onMtuChanged(device: BluetoothDevice, mtu: Int) {
+                log("GATT notify server mtu addr=${device.address} mtu=$mtu")
+            }
+        }
+
+    override suspend fun start(): Boolean {
+        if (server != null) {
+            return true
+        }
+        val bluetoothManager =
+            context.getSystemService(BluetoothManager::class.java)
+                ?: run {
+                    log("GATT notify server unavailable: BluetoothManager is missing")
+                    return false
+                }
+        val openedServer =
+            bluetoothManager.openGattServer(context, callback)
+                ?: run {
+                    log("GATT notify server unavailable: openGattServer returned null")
+                    return false
+                }
+        server = openedServer
+        serviceReady = CompletableDeferred()
+        val service = buildService()
+        val addServiceResult = openedServer.addService(service)
+        log("GATT notify server addService requested added=$addServiceResult")
+        val ready =
+            try {
+                withTimeout(serviceReadyTimeoutMillis) { serviceReady.await() }
+            } catch (_: TimeoutCancellationException) {
+                log(
+                    "GATT notify server service installation timed out after ${serviceReadyTimeoutMillis}ms"
+                )
+                false
+            }
+        if (!ready) {
+            close()
+        }
+        return ready
+    }
+
+    override fun close(): Unit {
+        val gattServer = server ?: return
+        synchronized(lock) {
+            frameBuffersByAddress.clear()
+            connectedDevicesByAddress.clear()
+        }
+        runCatching { gattServer.close() }
+        server = null
+        if (!serviceReady.isCompleted) {
+            serviceReady.complete(false)
+        }
+    }
+
+    private fun buildService(): BluetoothGattService {
+        val notifyCharacteristic =
+            BluetoothGattCharacteristic(
+                    UUID.fromString(BleDiscoveryContract.GATT_NOTIFY_CHARACTERISTIC_UUID),
+                    BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+                    BluetoothGattCharacteristic.PERMISSION_READ,
+                )
+                .also { characteristic ->
+                    characteristic.addDescriptor(
+                        BluetoothGattDescriptor(
+                            UUID.fromString(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID),
+                            BluetoothGattDescriptor.PERMISSION_READ or
+                                BluetoothGattDescriptor.PERMISSION_WRITE,
+                        )
+                    )
+                }
+        val writeCharacteristic =
+            BluetoothGattCharacteristic(
+                UUID.fromString(BleDiscoveryContract.GATT_WRITE_CHARACTERISTIC_UUID),
+                BluetoothGattCharacteristic.PROPERTY_WRITE or
+                    BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
+                BluetoothGattCharacteristic.PERMISSION_WRITE,
+            )
+        return BluetoothGattService(
+                UUID.fromString(BleDiscoveryContract.GATT_FALLBACK_SERVICE_UUID),
+                BluetoothGattService.SERVICE_TYPE_PRIMARY,
+            )
+            .apply {
+                addCharacteristic(writeCharacteristic)
+                addCharacteristic(notifyCharacteristic)
+            }
+    }
+
+    private companion object {
+        private const val CLIENT_CHARACTERISTIC_CONFIGURATION_UUID: String =
+            "00002902-0000-1000-8000-00805f9b34fb"
+    }
+}

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PeerRegistry.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PeerRegistry.kt
@@ -102,15 +102,21 @@ internal class PeerRegistry(private val bindings: PeerBindings) {
     internal fun upsertDiscovery(
         hintPeerId: PeerId,
         discovery: DiscoveredPeerDiscovery,
+        announcePresence: Boolean = true,
     ): PeerDiscoveryUpdate {
         val existingPeer = discoveredPeers[hintPeerId.value]
         return if (existingPeer == null) {
-            createDiscoveredPeer(hintPeerId = hintPeerId, discovery = discovery)
+            createDiscoveredPeer(
+                hintPeerId = hintPeerId,
+                discovery = discovery,
+                announcePresence = announcePresence,
+            )
         } else {
             refreshDiscoveredPeer(
                 existingPeer = existingPeer,
                 hintPeerId = hintPeerId,
                 discovery = discovery,
+                announcePresence = announcePresence,
             )
         }
     }
@@ -118,6 +124,7 @@ internal class PeerRegistry(private val bindings: PeerBindings) {
     private fun createDiscoveredPeer(
         hintPeerId: PeerId,
         discovery: DiscoveredPeerDiscovery,
+        announcePresence: Boolean,
     ): PeerDiscoveryUpdate {
         val peer =
             DiscoveredPeer(
@@ -129,7 +136,7 @@ internal class PeerRegistry(private val bindings: PeerBindings) {
                         l2capPsm = discovery.l2capPsm,
                         transportMode = discovery.transportMode,
                         platformFamily = discovery.platformFamily,
-                        flags = DiscoveredPeerFlags(presenceAnnounced = true),
+                        flags = DiscoveredPeerFlags(presenceAnnounced = announcePresence),
                     ),
             )
         discoveredPeers[hintPeerId.value] = peer
@@ -137,12 +144,16 @@ internal class PeerRegistry(private val bindings: PeerBindings) {
         return PeerDiscoveryUpdate(
             peer = peer,
             events =
-                listOf(
-                    TransportEvent.PeerDiscovered(
-                        peerId = hintPeerId,
-                        transportMode = discovery.transportMode,
+                if (announcePresence) {
+                    listOf(
+                        TransportEvent.PeerDiscovered(
+                            peerId = hintPeerId,
+                            transportMode = discovery.transportMode,
+                        )
                     )
-                ),
+                } else {
+                    emptyList()
+                },
         )
     }
 
@@ -150,6 +161,7 @@ internal class PeerRegistry(private val bindings: PeerBindings) {
         existingPeer: DiscoveredPeer,
         hintPeerId: PeerId,
         discovery: DiscoveredPeerDiscovery,
+        announcePresence: Boolean,
     ): PeerDiscoveryUpdate {
         existingPeer.deviceAddress = discovery.address
         existingPeer.l2capPsm = discovery.l2capPsm
@@ -165,7 +177,7 @@ internal class PeerRegistry(private val bindings: PeerBindings) {
                     transportMode = discovery.transportMode,
                 )
         }
-        if (!existingPeer.presenceAnnounced) {
+        if (announcePresence && !existingPeer.presenceAnnounced) {
             existingPeer.presenceAnnounced = true
             events +=
                 TransportEvent.PeerDiscovered(

--- a/reports/INDEX.md
+++ b/reports/INDEX.md
@@ -13,7 +13,7 @@ reports/android-direct-proof-fleet/runs/<timestamp>/
 
 Latest tracked run:
 
-- [20260621T153830](android-direct-proof-fleet/runs/20260621T153830/INDEX.md) — [summary](android-direct-proof-fleet/runs/20260621T153830/SUMMARY.md)
+- [20260621T124016](android-direct-proof-fleet/runs/20260621T124016/INDEX.md) — [summary](android-direct-proof-fleet/runs/20260621T124016/SUMMARY.md)
 
 Contents of each run:
 


### PR DESCRIPTION
## Summary
- update the direct-proof matrix result summary with the latest published fleet root
- align stale matrix and fleet reference tests with the current report/doc format
- keep the latest bundle publication pointed at the verified 20260621T124016 root

## Verification
- PYTHONPATH=meshlink-reference/scripts/tests python -m unittest discover -s meshlink-reference/scripts/tests -v
- Result: Ran 115 tests in 14.115s; OK