### PR TITLE
fix(reference): resolve passive peer id before sender launch

### DIFF
--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -1246,6 +1246,17 @@ def read_passive_peer_id(android_serial: str, app_id: str, retries: int = 60, de
     return None
 
 
+def resolve_sender_target_peer_id(
+    passive_marker_path: Path,
+    discovery_wait_seconds: float,
+    discovered_peer_id: str | None,
+    target_peer_id: str | None,
+) -> str | None:
+    sender_target_peer_id = wait_for_discovered_peer_id(passive_marker_path, discovery_wait_seconds)
+    if sender_target_peer_id is None:
+        sender_target_peer_id = discovered_peer_id or target_peer_id
+    return sender_target_peer_id
+
 
 
 def launch_android_role_apps(
@@ -1770,12 +1781,17 @@ def main(argv: list[str] | None = None) -> int:
                         f"Android passive transport did not start within {passive_transport_timeout_seconds} seconds"
                     )
             if sender_process is None:
-                sender_target_peer_id = wait_for_discovered_peer_id(
+                sender_target_peer_id = resolve_sender_target_peer_id(
                     passive_marker_path,
                     discovery_wait_seconds,
+                    discovered_peer_id,
+                    args.target_peer_id,
                 )
                 if sender_target_peer_id is None:
-                    sender_target_peer_id = discovered_peer_id or args.target_peer_id
+                    raise SystemExit(
+                        "Android peer-resolution gate failed: passive peer id was not resolved from shared prefs or passive discovery markers before sender launch"
+                    )
+                discovered_peer_id = sender_target_peer_id
                 print(f"==> Passive peer id resolved for sender launch: {sender_target_peer_id}")
                 sender_process = start_android_role_app(
                     run_dir=run_dir,
@@ -1795,7 +1811,7 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"==> Android sender launched at +{time.monotonic() - run_started_at:.1f}s")
             if discovered_peer_id is None:
                 raise SystemExit(
-                    "Android peer-resolution gate failed: passive peer id was not resolved before the route phase"
+                    "Android peer-resolution gate failed: passive peer id was not resolved from shared prefs or passive discovery markers before the route phase"
                 )
             print(f"==> Peer resolution gate resolved passive peer id {discovered_peer_id}")
             sender_startup_observation = wait_for_log_marker_observation(

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_proof.py
@@ -340,6 +340,36 @@ class AndroidDirectProofTests(unittest.TestCase):
         self.assertEqual(peer_id, "passive-peer-123456")
         read_mock.assert_called_once_with("passive-1", "../shared_prefs/meshlink-app-123.xml")
 
+    def test_resolve_sender_target_peer_id_uses_passive_discovery_marker_before_fallbacks(self) -> None:
+        # Arrange
+        with patch.object(android_direct_proof, "wait_for_discovered_peer_id", return_value="marker-peer-123") as wait_mock:
+            # Act
+            peer_id = android_direct_proof.resolve_sender_target_peer_id(
+                Path("/tmp/passive-logcat.log"),
+                20.0,
+                discovered_peer_id="fallback-peer-456",
+                target_peer_id="target-peer-789",
+            )
+
+        # Assert
+        self.assertEqual(peer_id, "marker-peer-123")
+        wait_mock.assert_called_once_with(Path("/tmp/passive-logcat.log"), 20.0)
+
+    def test_resolve_sender_target_peer_id_falls_back_to_discovered_peer_id(self) -> None:
+        # Arrange
+        with patch.object(android_direct_proof, "wait_for_discovered_peer_id", return_value=None) as wait_mock:
+            # Act
+            peer_id = android_direct_proof.resolve_sender_target_peer_id(
+                Path("/tmp/passive-logcat.log"),
+                20.0,
+                discovered_peer_id="fallback-peer-456",
+                target_peer_id="target-peer-789",
+            )
+
+        # Assert
+        self.assertEqual(peer_id, "fallback-peer-456")
+        wait_mock.assert_called_once_with(Path("/tmp/passive-logcat.log"), 20.0)
+
     def test_android_proof_install_timeout_differs_for_wireless_and_usb_serials(self) -> None:
         # Arrange / Act / Assert
         self.assertEqual(


### PR DESCRIPTION
## Summary
- resolve the passive peer id from shared prefs or passive discovery markers before sender launch
- copy the resolved id back into the peer-resolution gate state so the run can continue
- add regression coverage for the peer-id fallback helper

## Verification
- PYTHONPATH=meshlink-reference/scripts/tests python -m unittest discover -s meshlink-reference/scripts/tests -p 'test_reference_android_direct_proof.py' -q
- Result: PASS, exit code 0