### PR TITLE
Android direct-proof foreign scan diagnostics

### DIFF
--- a/meshlink-reference/android/build.gradle.kts
+++ b/meshlink-reference/android/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_21) } }
 
 dependencies {
     implementation(project(":meshlink-reference"))
+    implementation(project(":meshlink"))
     implementation(libs.androidx.activity.compose)
 }
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidDiscoverySeed.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidDiscoverySeed.kt
@@ -1,0 +1,73 @@
+package ch.trancee.meshlink.reference
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val RETAINED_DISCOVERY_SEED_FILE = "automation-discovery-seed.txt"
+private const val SHARED_PREFS_PREFIX = "meshlink-"
+private const val SHARED_PREFS_IDENTITY_SUFFIX = ":x25519-public"
+private const val RETAINED_DISCOVERY_SEED_WAIT_MILLIS = 5_000L
+private const val RETAINED_DISCOVERY_SEED_POLL_MILLIS = 250L
+
+internal fun launchRetainedDiscoverySeedProbe(
+    context: Context,
+    appId: String,
+    emitAutomationLog: (String) -> Unit,
+    scope: CoroutineScope,
+): Unit {
+    if (appId.isBlank() || appId == "unknown") return
+    scope.launch {
+        val seed = waitForRetainedDiscoverySeed(context, appId)
+        if (seed == null) {
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION retained.discovery-seed unavailable appId=$appId",
+            )
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION startup-state=retained.discoverySeed.unavailable appId=$appId",
+            )
+            return@launch
+        }
+        writeRetainedDiscoverySeedArtifact(context, seed)
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION retained.discovery-seed appId=$appId peerId=$seed source=shared_prefs",
+        )
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=retained.discoverySeed appId=$appId peerId=$seed",
+        )
+    }
+}
+
+internal fun readRetainedDiscoverySeed(context: Context, appId: String): String? {
+    val sharedPrefs = context.getSharedPreferences("$SHARED_PREFS_PREFIX$appId", Context.MODE_PRIVATE)
+    val identityKey = "identity:$appId$SHARED_PREFS_IDENTITY_SUFFIX"
+    val directSeed = sharedPrefs.getString(identityKey, null)?.trim().orEmpty()
+    if (directSeed.isNotBlank()) {
+        return directSeed
+    }
+    return sharedPrefs.all.entries.firstOrNull { entry ->
+        entry.key.endsWith(SHARED_PREFS_IDENTITY_SUFFIX) &&
+            entry.value is String &&
+            (entry.value as String).isNotBlank()
+    }?.value as? String
+}
+
+private suspend fun waitForRetainedDiscoverySeed(context: Context, appId: String): String? {
+    val deadline = System.currentTimeMillis() + RETAINED_DISCOVERY_SEED_WAIT_MILLIS
+    while (System.currentTimeMillis() < deadline) {
+        val seed = readRetainedDiscoverySeed(context, appId)
+        if (!seed.isNullOrBlank()) {
+            return seed
+        }
+        delay(RETAINED_DISCOVERY_SEED_POLL_MILLIS)
+    }
+    return readRetainedDiscoverySeed(context, appId)
+}
+
+private fun writeRetainedDiscoverySeedArtifact(context: Context, seed: String): Unit {
+    context.openFileOutput(RETAINED_DISCOVERY_SEED_FILE, Context.MODE_PRIVATE).use { output ->
+        output.write(seed.toByteArray(Charsets.UTF_8))
+        output.flush()
+    }
+}

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -57,24 +57,8 @@ internal fun createPlatformServices(context: Context, appId: String): AndroidPla
         readinessGuidance = readinessGuidance(),
         readinessBlockersFactory = { readinessBlockers(context) },
         meshLinkControllerFactory = {
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.factoryLambda.begin",
-            )
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.bootstrap.begin",
-            )
             val bootstrap = createMeshLinkBootstrap(context)
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.bootstrap.end",
-            )
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.controllerArgs.begin",
-            )
-            val controllerArgs =
+            createPublicMeshLinkController(
                 PublicMeshLinkControllerArgs(
                     appId = appId,
                     authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
@@ -82,17 +66,8 @@ internal fun createPlatformServices(context: Context, appId: String): AndroidPla
                     storageSubdirectory = "default",
                     bootstrap = bootstrap,
                     currentTimeMillis = { System.currentTimeMillis() },
-                )
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.controllerArgs.end",
+                ),
             )
-            val controller = createPublicMeshLinkController(controllerArgs)
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.factoryLambda.end",
-            )
-            controller
         },
     )
 }
@@ -110,19 +85,6 @@ private data class PublicMeshLinkControllerArgs(
 private fun createPublicMeshLinkController(
     args: PublicMeshLinkControllerArgs,
 ): ReferenceMeshLinkController {
-    Log.i(
-        AUTOMATION_LOG_TAG,
-        buildString {
-            append("REFERENCE_AUTOMATION android.meshlink.controller.begin appId=")
-            append(args.appId)
-            append(" scenario=")
-            append(args.scenarioId)
-            append(" storage=")
-            append(args.storageSubdirectory)
-            append(" thread=")
-            append(Thread.currentThread().name)
-        },
-    )
     val controller =
         PublicMeshLinkController(
             meshLinkRuntimeFactory = {
@@ -189,19 +151,6 @@ private fun createPublicMeshLinkController(
             storageSubdirectory = args.storageSubdirectory,
             appId = args.appId,
         )
-    Log.i(
-        AUTOMATION_LOG_TAG,
-        buildString {
-            append("REFERENCE_AUTOMATION android.meshlink.controller.end appId=")
-            append(args.appId)
-            append(" scenario=")
-            append(args.scenarioId)
-            append(" storage=")
-            append(args.storageSubdirectory)
-            append(" thread=")
-            append(Thread.currentThread().name)
-        },
-    )
     return controller
 }
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -80,52 +80,103 @@ private data class PublicMeshLinkControllerArgs(
     val currentTimeMillis: () -> Long,
 )
 
+@Suppress("LongMethod")
 private fun createPublicMeshLinkController(
     args: PublicMeshLinkControllerArgs,
 ): ReferenceMeshLinkController {
-    return PublicMeshLinkController(
-        meshLinkRuntimeFactory = {
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                buildString {
-                    append("REFERENCE_AUTOMATION android.meshlink.begin create appId=")
-                    append(args.appId)
-                    append(" scenario=")
-                    append(args.scenarioId)
-                    append(" storage=")
-                    append(args.storageSubdirectory)
-                },
-            )
-            val runtime =
-                meshLink(
-                    config =
-                        MeshLinkConfig(
-                            appId = args.appId,
-                            regulatoryRegion = RegulatoryRegion.DEFAULT,
-                            powerMode = PowerMode.Automatic,
-                            deliveryRetryDeadline = 15.seconds,
-                        ),
-                    bootstrap = args.bootstrap,
-                )
-            Log.i(
-                AUTOMATION_LOG_TAG,
-                buildString {
-                    append("REFERENCE_AUTOMATION android.meshlink.end create appId=")
-                    append(args.appId)
-                    append(" scenario=")
-                    append(args.scenarioId)
-                    append(" storage=")
-                    append(args.storageSubdirectory)
-                },
-            )
-            runtime
+    Log.i(
+        AUTOMATION_LOG_TAG,
+        buildString {
+            append("REFERENCE_AUTOMATION android.meshlink.controller.begin appId=")
+            append(args.appId)
+            append(" scenario=")
+            append(args.scenarioId)
+            append(" storage=")
+            append(args.storageSubdirectory)
+            append(" thread=")
+            append(Thread.currentThread().name)
         },
-        currentTimeMillis = args.currentTimeMillis,
-        authorityMode = args.authorityMode,
-        scenarioId = args.scenarioId,
-        storageSubdirectory = args.storageSubdirectory,
-        appId = args.appId,
     )
+    val controller =
+        PublicMeshLinkController(
+            meshLinkRuntimeFactory = {
+                Log.i(
+                    AUTOMATION_LOG_TAG,
+                    buildString {
+                        append("REFERENCE_AUTOMATION android.meshlink.begin create appId=")
+                        append(args.appId)
+                        append(" scenario=")
+                        append(args.scenarioId)
+                        append(" storage=")
+                        append(args.storageSubdirectory)
+                    },
+                )
+                Log.i(
+                    AUTOMATION_LOG_TAG,
+                    buildString {
+                        append("REFERENCE_AUTOMATION android.meshlink.construct.begin appId=")
+                        append(args.appId)
+                        append(" scenario=")
+                        append(args.scenarioId)
+                        append(" thread=")
+                        append(Thread.currentThread().name)
+                    },
+                )
+                val runtime =
+                    meshLink(
+                        config =
+                            MeshLinkConfig(
+                                appId = args.appId,
+                                regulatoryRegion = RegulatoryRegion.DEFAULT,
+                                powerMode = PowerMode.Automatic,
+                                deliveryRetryDeadline = 15.seconds,
+                            ),
+                        bootstrap = args.bootstrap,
+                    )
+                Log.i(
+                    AUTOMATION_LOG_TAG,
+                    buildString {
+                        append("REFERENCE_AUTOMATION android.meshlink.construct.end appId=")
+                        append(args.appId)
+                        append(" scenario=")
+                        append(args.scenarioId)
+                        append(" thread=")
+                        append(Thread.currentThread().name)
+                    },
+                )
+                Log.i(
+                    AUTOMATION_LOG_TAG,
+                    buildString {
+                        append("REFERENCE_AUTOMATION android.meshlink.end create appId=")
+                        append(args.appId)
+                        append(" scenario=")
+                        append(args.scenarioId)
+                        append(" storage=")
+                        append(args.storageSubdirectory)
+                    },
+                )
+                runtime
+            },
+            currentTimeMillis = args.currentTimeMillis,
+            authorityMode = args.authorityMode,
+            scenarioId = args.scenarioId,
+            storageSubdirectory = args.storageSubdirectory,
+            appId = args.appId,
+        )
+    Log.i(
+        AUTOMATION_LOG_TAG,
+        buildString {
+            append("REFERENCE_AUTOMATION android.meshlink.controller.end appId=")
+            append(args.appId)
+            append(" scenario=")
+            append(args.scenarioId)
+            append(" storage=")
+            append(args.storageSubdirectory)
+            append(" thread=")
+            append(Thread.currentThread().name)
+        },
+    )
+    return controller
 }
 
 @Suppress("TooManyFunctions")

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -57,16 +57,42 @@ internal fun createPlatformServices(context: Context, appId: String): AndroidPla
         readinessGuidance = readinessGuidance(),
         readinessBlockersFactory = { readinessBlockers(context) },
         meshLinkControllerFactory = {
-            createPublicMeshLinkController(
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.factoryLambda.begin",
+            )
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.bootstrap.begin",
+            )
+            val bootstrap = createMeshLinkBootstrap(context)
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.bootstrap.end",
+            )
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.controllerArgs.begin",
+            )
+            val controllerArgs =
                 PublicMeshLinkControllerArgs(
                     appId = appId,
                     authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
                     scenarioId = "direct-guided",
                     storageSubdirectory = "default",
-                    bootstrap = createMeshLinkBootstrap(context),
+                    bootstrap = bootstrap,
                     currentTimeMillis = { System.currentTimeMillis() },
-                ),
+                )
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.controllerArgs.end",
             )
+            val controller = createPublicMeshLinkController(controllerArgs)
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.factoryLambda.end",
+            )
+            controller
         },
     )
 }

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -140,6 +141,7 @@ private class PublicMeshLinkController(
     private val runtimeMutex = Mutex()
     @Volatile private var meshLinkRuntime: MeshLink? = null
     @Volatile private var runtimeCollectorsStarted: Boolean = false
+    @Volatile private var discoveryWatchScheduled: Boolean = false
     private val sessionId = "$appId-${currentTimeMillis()}"
     private val startedAt = currentTimeMillis()
     private val peers: LinkedHashMap<String, PeerSnapshot> = linkedMapOf()
@@ -195,27 +197,113 @@ private class PublicMeshLinkController(
             }
 
     private fun startRuntimeCollectors(runtime: MeshLink): Unit {
+        observeMeshState(runtime)
+        observePeerEvents(runtime)
+        observeDiagnosticEvents(runtime)
+        observeMessages(runtime)
+    }
+
+    private fun observeMeshState(runtime: MeshLink): Unit {
         scope.launch {
             runtime.state.collect { state ->
+                Log.i(
+                    AUTOMATION_LOG_TAG,
+                    buildString {
+                        append("REFERENCE_AUTOMATION runtime.state value=")
+                        append(state)
+                    },
+                )
                 updateSnapshot { current ->
                     current.copy(
                         session = current.session.copy(meshStateLabel = state.toString()),
                     )
                 }
-            }
-        }
-        scope.launch {
-            runtime.peerEvents.collect { event ->
-                when (event) {
-                    is PeerEvent.Found -> updatePeer(event.peerId.value, event.state, "found")
-                    is PeerEvent.StateChanged ->
-                        updatePeer(event.peerId.value, event.state, "state-changed")
-                    is PeerEvent.Lost -> removePeer(event.peerId.value)
+                logPeerSnapshot("meshState=$state")
+                if (state == MeshLinkState.Running && !discoveryWatchScheduled) {
+                    discoveryWatchScheduled = true
+                    scope.launch {
+                        delay(3.seconds)
+                        val current = snapshot.value
+                        if (current.peers.isEmpty()) {
+                            Log.i(
+                                AUTOMATION_LOG_TAG,
+                                buildString {
+                                    append("REFERENCE_AUTOMATION peer.discovery.pending elapsedSeconds=3.0 count=")
+                                    append(current.peers.size)
+                                    append(" selectedPeerId=")
+                                    append(current.session.selectedPeerId ?: "none")
+                                },
+                            )
+                        }
+                    }
                 }
             }
         }
+    }
+
+    private fun observePeerEvents(runtime: MeshLink): Unit {
         scope.launch {
+            Log.i(AUTOMATION_LOG_TAG, "REFERENCE_AUTOMATION runtime.peerEvents.collect.begin")
+            runtime.peerEvents.collect { event ->
+                when (event) {
+                    is PeerEvent.Found -> {
+                        Log.i(
+                            AUTOMATION_LOG_TAG,
+                            buildString {
+                                append("REFERENCE_AUTOMATION runtime.peerEvent type=Found peerId=")
+                                append(event.peerId.value)
+                                append(" state=")
+                                append(event.state)
+                            },
+                        )
+                        updatePeer(event.peerId.value, event.state, "found")
+                    }
+                    is PeerEvent.StateChanged -> {
+                        Log.i(
+                            AUTOMATION_LOG_TAG,
+                            buildString {
+                                append("REFERENCE_AUTOMATION runtime.peerEvent type=StateChanged peerId=")
+                                append(event.peerId.value)
+                                append(" state=")
+                                append(event.state)
+                            },
+                        )
+                        updatePeer(event.peerId.value, event.state, "state-changed")
+                    }
+                    is PeerEvent.Lost -> {
+                        Log.i(
+                            AUTOMATION_LOG_TAG,
+                            buildString {
+                                append("REFERENCE_AUTOMATION runtime.peerEvent type=Lost peerId=")
+                                append(event.peerId.value)
+                            },
+                        )
+                        removePeer(event.peerId.value)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun observeDiagnosticEvents(runtime: MeshLink): Unit {
+        scope.launch {
+            Log.i(AUTOMATION_LOG_TAG, "REFERENCE_AUTOMATION runtime.diagnosticEvents.collect.begin")
             runtime.diagnosticEvents.collect { event ->
+                Log.i(
+                    AUTOMATION_LOG_TAG,
+                    buildString {
+                        append("REFERENCE_AUTOMATION runtime.diagnostic code=")
+                        append(event.code)
+                        append(" severity=")
+                        append(event.severity)
+                        append(" stage=")
+                        append(event.stage)
+                        append(" peerSuffix=")
+                        append(event.peerSuffix ?: "none")
+                        append(" reason=")
+                        append(event.reason ?: "none")
+                    },
+                )
                 appendTimeline(
                     timelineContext,
                     TimelineAppendSpec(
@@ -227,6 +315,9 @@ private class PublicMeshLinkController(
                 )
             }
         }
+    }
+
+    private fun observeMessages(runtime: MeshLink): Unit {
         scope.launch {
             runtime.messages.collect { message ->
                 appendTimeline(
@@ -247,6 +338,13 @@ private class PublicMeshLinkController(
 
     override suspend fun start(): Unit {
         val result = resolveMeshLinkRuntime().start()
+        Log.i(
+            AUTOMATION_LOG_TAG,
+            buildString {
+                append("REFERENCE_AUTOMATION runtime.start result=")
+                append(result)
+            },
+        )
         appendTimeline(
             timelineContext,
             TimelineAppendSpec(
@@ -344,6 +442,23 @@ private class PublicMeshLinkController(
         meshLinkRuntime?.let { runCatching { it.stop() } }
     }
 
+    private fun logPeerSnapshot(reason: String): Unit {
+        val current = snapshot.value
+        Log.i(
+            AUTOMATION_LOG_TAG,
+            buildString {
+                append("REFERENCE_AUTOMATION peer.snapshot reason=")
+                append(reason)
+                append(" count=")
+                append(current.peers.size)
+                append(" selectedPeerId=")
+                append(current.session.selectedPeerId ?: "none")
+                append(" suffixes=")
+                append(current.peers.joinToString(prefix = "[", postfix = "]") { it.peerSuffix })
+            },
+        )
+    }
+
     private fun updatePeer(
         peerId: String,
         state: ch.trancee.meshlink.api.PeerConnectionState,
@@ -391,6 +506,7 @@ private class PublicMeshLinkController(
             )
         }
         refreshSnapshotPeers()
+        logPeerSnapshot("updatePeer reason=$reason peerId=$peerId state=$state")
     }
 
     private fun removePeer(peerId: String): Unit {
@@ -413,6 +529,7 @@ private class PublicMeshLinkController(
             ),
         )
         refreshSnapshotPeers()
+        logPeerSnapshot("removePeer peerId=$peerId")
     }
 
     private fun refreshSnapshotPeers(): Unit {

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -49,9 +49,26 @@ import ch.trancee.meshlink.reference.model.REFERENCE_AUTHORITY_MODE_LIVE
 
 private const val AUTOMATION_LOG_TAG: String = "MeshLinkReferenceAutomation"
 private const val PEER_SUFFIX_LENGTH: Int = 6
+private const val FNV_OFFSET_BASIS: UInt = 0x811C9DC5u
+private const val FNV_PRIME: UInt = 16777619u
+private const val BYTE_MASK: UInt = 0xFFu
+private const val USHORT_MASK: UInt = 0xFFFFu
+private const val FNV_FOLD_SHIFT: Int = 16
 
 internal fun createPlatformServices(context: Context, appId: String): AndroidPlatformServices {
     Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION android.factory.begin scripted")
+    val meshHash = computeAppMeshHash(appId)
+    Log.i(
+        AUTOMATION_LOG_TAG,
+        buildString {
+            append("REFERENCE_AUTOMATION startup.meshHashSummary appId=")
+            append(appId)
+            append(" activeMeshHash=")
+            append(meshHash)
+            append(" advertisedMeshHash=")
+            append(meshHash)
+        },
+    )
     return AndroidPlatformServices(
         context = context.applicationContext,
         readinessGuidance = readinessGuidance(),
@@ -616,6 +633,17 @@ private fun readinessBlockers(
     }
     blockers += powerManagement
     return blockers
+}
+
+private fun computeAppMeshHash(appId: String): UShort {
+    val bytes = appId.encodeToByteArray()
+    val seedBytes = if (bytes.isNotEmpty()) bytes else byteArrayOf(0)
+    var state = FNV_OFFSET_BASIS
+    for (byte in seedBytes) {
+        state = (state xor (byte.toUInt() and BYTE_MASK)) * FNV_PRIME
+    }
+    val folded = (((state shr FNV_FOLD_SHIFT) xor (state and USHORT_MASK)) and USHORT_MASK)
+    return folded.toUShort()
 }
 
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -40,9 +40,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 import ch.trancee.meshlink.reference.model.REFERENCE_AUTHORITY_MODE_LIVE
 
+private const val AUTOMATION_LOG_TAG: String = "MeshLinkReferenceAutomation"
 private const val PEER_SUFFIX_LENGTH: Int = 6
 
 internal fun createPlatformServices(context: Context): AndroidPlatformServices {
@@ -78,19 +82,29 @@ private data class PublicMeshLinkControllerArgs(
 private fun createPublicMeshLinkController(
     args: PublicMeshLinkControllerArgs,
 ): ReferenceMeshLinkController {
-    val meshLinkRuntime: MeshLink =
-        meshLink(
-            config =
-                MeshLinkConfig(
-                    appId = args.appId,
-                    regulatoryRegion = RegulatoryRegion.DEFAULT,
-                    powerMode = PowerMode.Automatic,
-                    deliveryRetryDeadline = 15.seconds,
-                ),
-            bootstrap = args.bootstrap,
-        )
     return PublicMeshLinkController(
-        meshLinkRuntime = meshLinkRuntime,
+        meshLinkRuntimeFactory = {
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.begin create appId=${args.appId} scenario=${args.scenarioId} storage=${args.storageSubdirectory}",
+            )
+            val runtime =
+                meshLink(
+                    config =
+                        MeshLinkConfig(
+                            appId = args.appId,
+                            regulatoryRegion = RegulatoryRegion.DEFAULT,
+                            powerMode = PowerMode.Automatic,
+                            deliveryRetryDeadline = 15.seconds,
+                        ),
+                    bootstrap = args.bootstrap,
+                )
+            Log.i(
+                AUTOMATION_LOG_TAG,
+                "REFERENCE_AUTOMATION android.meshlink.end create appId=${args.appId} scenario=${args.scenarioId} storage=${args.storageSubdirectory}",
+            )
+            runtime
+        },
         currentTimeMillis = args.currentTimeMillis,
         authorityMode = args.authorityMode,
         scenarioId = args.scenarioId,
@@ -100,7 +114,7 @@ private fun createPublicMeshLinkController(
 }
 
 private class PublicMeshLinkController(
-    private val meshLinkRuntime: MeshLink,
+    private val meshLinkRuntimeFactory: () -> MeshLink,
     private val currentTimeMillis: () -> Long,
     authorityMode: String,
     scenarioId: String,
@@ -108,6 +122,9 @@ private class PublicMeshLinkController(
     appId: String,
 ) : ReferenceMeshLinkController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val runtimeMutex = Mutex()
+    @Volatile private var meshLinkRuntime: MeshLink? = null
+    @Volatile private var runtimeCollectorsStarted: Boolean = false
     private val sessionId = "$appId-${currentTimeMillis()}"
     private val startedAt = currentTimeMillis()
     private val peers: LinkedHashMap<String, PeerSnapshot> = linkedMapOf()
@@ -148,9 +165,23 @@ private class PublicMeshLinkController(
 
     override val snapshot: StateFlow<ReferenceControllerSnapshot> = _snapshot.asStateFlow()
 
-    init {
+    private suspend fun resolveMeshLinkRuntime(): MeshLink {
+        meshLinkRuntime?.let { return it }
+        return runtimeMutex.withLock {
+            meshLinkRuntime?.let { return it }
+            val created = withContext(Dispatchers.Default) { meshLinkRuntimeFactory() }
+            meshLinkRuntime = created
+            if (!runtimeCollectorsStarted) {
+                runtimeCollectorsStarted = true
+                startRuntimeCollectors(created)
+            }
+            created
+        }
+    }
+
+    private fun startRuntimeCollectors(runtime: MeshLink): Unit {
         scope.launch {
-            meshLinkRuntime.state.collect { state ->
+            runtime.state.collect { state ->
                 updateSnapshot { current ->
                     current.copy(
                         session = current.session.copy(meshStateLabel = state.toString()),
@@ -159,7 +190,7 @@ private class PublicMeshLinkController(
             }
         }
         scope.launch {
-            meshLinkRuntime.peerEvents.collect { event ->
+            runtime.peerEvents.collect { event ->
                 when (event) {
                     is PeerEvent.Found -> updatePeer(event.peerId.value, event.state, "found")
                     is PeerEvent.StateChanged ->
@@ -169,7 +200,7 @@ private class PublicMeshLinkController(
             }
         }
         scope.launch {
-            meshLinkRuntime.diagnosticEvents.collect { event ->
+            runtime.diagnosticEvents.collect { event ->
                 appendTimeline(
                     timelineContext,
                     TimelineAppendSpec(
@@ -182,7 +213,7 @@ private class PublicMeshLinkController(
             }
         }
         scope.launch {
-            meshLinkRuntime.messages.collect { message ->
+            runtime.messages.collect { message ->
                 appendTimeline(
                     timelineContext,
                     TimelineAppendSpec(
@@ -200,7 +231,7 @@ private class PublicMeshLinkController(
     }
 
     override suspend fun start(): Unit {
-        val result = meshLinkRuntime.start()
+        val result = resolveMeshLinkRuntime().start()
         appendTimeline(
             timelineContext,
             TimelineAppendSpec(
@@ -213,7 +244,7 @@ private class PublicMeshLinkController(
     }
 
     override suspend fun pause(): Unit {
-        val result = meshLinkRuntime.pause()
+        val result = resolveMeshLinkRuntime().pause()
         appendTimeline(
             timelineContext,
             TimelineAppendSpec(
@@ -226,7 +257,7 @@ private class PublicMeshLinkController(
     }
 
     override suspend fun resume(): Unit {
-        val result = meshLinkRuntime.resume()
+        val result = resolveMeshLinkRuntime().resume()
         appendTimeline(
             timelineContext,
             TimelineAppendSpec(
@@ -239,7 +270,7 @@ private class PublicMeshLinkController(
     }
 
     override suspend fun stop(): Unit {
-        val result = meshLinkRuntime.stop()
+        val result = resolveMeshLinkRuntime().stop()
         appendTimeline(
             timelineContext,
             TimelineAppendSpec(
@@ -260,7 +291,7 @@ private class PublicMeshLinkController(
         priority: DeliveryPriority,
     ): Unit {
         val result =
-            meshLinkRuntime.send(
+            resolveMeshLinkRuntime().send(
                 peerId = PeerId(peerId),
                 payload = payloadText.encodeToByteArray(),
                 priority = priority,
@@ -280,7 +311,7 @@ private class PublicMeshLinkController(
     }
 
     override suspend fun forgetPeer(peerId: String): Unit {
-        val result = meshLinkRuntime.forgetPeer(PeerId(peerId))
+        val result = resolveMeshLinkRuntime().forgetPeer(PeerId(peerId))
         appendTimeline(
             timelineContext,
             TimelineAppendSpec(
@@ -295,7 +326,7 @@ private class PublicMeshLinkController(
 
     override suspend fun close(): Unit {
         scope.cancel()
-        meshLinkRuntime.stop()
+        meshLinkRuntime?.let { runCatching { it.stop() } }
     }
 
     private fun updatePeer(

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -86,7 +86,14 @@ private fun createPublicMeshLinkController(
         meshLinkRuntimeFactory = {
             Log.i(
                 AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.begin create appId=${args.appId} scenario=${args.scenarioId} storage=${args.storageSubdirectory}",
+                buildString {
+                    append("REFERENCE_AUTOMATION android.meshlink.begin create appId=")
+                    append(args.appId)
+                    append(" scenario=")
+                    append(args.scenarioId)
+                    append(" storage=")
+                    append(args.storageSubdirectory)
+                },
             )
             val runtime =
                 meshLink(
@@ -101,7 +108,14 @@ private fun createPublicMeshLinkController(
                 )
             Log.i(
                 AUTOMATION_LOG_TAG,
-                "REFERENCE_AUTOMATION android.meshlink.end create appId=${args.appId} scenario=${args.scenarioId} storage=${args.storageSubdirectory}",
+                buildString {
+                    append("REFERENCE_AUTOMATION android.meshlink.end create appId=")
+                    append(args.appId)
+                    append(" scenario=")
+                    append(args.scenarioId)
+                    append(" storage=")
+                    append(args.storageSubdirectory)
+                },
             )
             runtime
         },
@@ -113,6 +127,7 @@ private fun createPublicMeshLinkController(
     )
 }
 
+@Suppress("TooManyFunctions")
 private class PublicMeshLinkController(
     private val meshLinkRuntimeFactory: () -> MeshLink,
     private val currentTimeMillis: () -> Long,
@@ -165,19 +180,19 @@ private class PublicMeshLinkController(
 
     override val snapshot: StateFlow<ReferenceControllerSnapshot> = _snapshot.asStateFlow()
 
-    private suspend fun resolveMeshLinkRuntime(): MeshLink {
-        meshLinkRuntime?.let { return it }
-        return runtimeMutex.withLock {
-            meshLinkRuntime?.let { return it }
-            val created = withContext(Dispatchers.Default) { meshLinkRuntimeFactory() }
-            meshLinkRuntime = created
-            if (!runtimeCollectorsStarted) {
-                runtimeCollectorsStarted = true
-                startRuntimeCollectors(created)
+    private suspend fun resolveMeshLinkRuntime(): MeshLink =
+        meshLinkRuntime
+            ?: runtimeMutex.withLock {
+                meshLinkRuntime
+                    ?: withContext(Dispatchers.Default) { meshLinkRuntimeFactory() }
+                        .also { created ->
+                            meshLinkRuntime = created
+                            if (!runtimeCollectorsStarted) {
+                                runtimeCollectorsStarted = true
+                                startRuntimeCollectors(created)
+                            }
+                        }
             }
-            created
-        }
-    }
 
     private fun startRuntimeCollectors(runtime: MeshLink): Unit {
         scope.launch {

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServices.kt
@@ -49,7 +49,7 @@ import ch.trancee.meshlink.reference.model.REFERENCE_AUTHORITY_MODE_LIVE
 private const val AUTOMATION_LOG_TAG: String = "MeshLinkReferenceAutomation"
 private const val PEER_SUFFIX_LENGTH: Int = 6
 
-internal fun createPlatformServices(context: Context): AndroidPlatformServices {
+internal fun createPlatformServices(context: Context, appId: String): AndroidPlatformServices {
     Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION android.factory.begin scripted")
     return AndroidPlatformServices(
         context = context.applicationContext,
@@ -58,7 +58,7 @@ internal fun createPlatformServices(context: Context): AndroidPlatformServices {
         meshLinkControllerFactory = {
             createPublicMeshLinkController(
                 PublicMeshLinkControllerArgs(
-                    appId = "demo.meshlink.reference",
+                    appId = appId,
                     authorityMode = REFERENCE_AUTHORITY_MODE_LIVE,
                     scenarioId = "direct-guided",
                     storageSubdirectory = "default",

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
@@ -1,6 +1,7 @@
 package ch.trancee.meshlink.reference
 
 import android.content.Context
+import android.util.Log
 import ch.trancee.meshlink.api.MeshLinkBootstrap
 import ch.trancee.meshlink.api.android.meshLinkBootstrap
 import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
@@ -27,7 +28,27 @@ internal class AndroidPlatformServices(
     val readinessBlockers: List<String>
         get() = readinessBlockersFactory(context)
 
-    val meshLinkController: ReferenceMeshLinkController by lazy(meshLinkControllerFactory)
+    private val meshLinkControllerLock: Any = Any()
+    @Volatile private var meshLinkControllerInstance: ReferenceMeshLinkController? = null
+
+    val meshLinkController: ReferenceMeshLinkController
+        get() {
+            meshLinkControllerInstance?.let { return it }
+            return synchronized(meshLinkControllerLock) {
+                meshLinkControllerInstance?.let { return@synchronized it }
+                Log.i(
+                    "MeshLinkReferenceAutomation",
+                    "REFERENCE_AUTOMATION android.meshLinkController.access begin",
+                )
+                val created = meshLinkControllerFactory()
+                meshLinkControllerInstance = created
+                Log.i(
+                    "MeshLinkReferenceAutomation",
+                    "REFERENCE_AUTOMATION android.meshLinkController.access end",
+                )
+                created
+            }
+        }
 
     fun stopPowerMitigation(): Unit = stopPowerMitigationAction()
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
@@ -23,7 +23,9 @@ internal class AndroidPlatformServices(
     val documentStore: Any? = null,
     private val currentTimeMillisProvider: () -> Long = { System.currentTimeMillis() },
     private val stopPowerMitigationAction: () -> Unit = {},
-    private val emitAutomationLogAction: (String) -> Unit = {},
+    private val emitAutomationLogAction: (String) -> Unit = { message ->
+        Log.i("MeshLinkReferenceAutomation", message)
+    },
 ) {
     val readinessBlockers: List<String>
         get() = readinessBlockersFactory(context)

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
@@ -48,6 +48,10 @@ internal class AndroidPlatformServices(
                     "REFERENCE_AUTOMATION android.meshLinkController.access begin",
                 )
                 meshLinkControllerFactoryInProgress = true
+                Log.i(
+                    "MeshLinkReferenceAutomation",
+                    "REFERENCE_AUTOMATION android.meshLinkController.factoryInvoke.begin",
+                )
                 val watchdog =
                     Thread {
                         try {
@@ -65,6 +69,10 @@ internal class AndroidPlatformServices(
                 watchdog.isDaemon = true
                 watchdog.start()
                 val created = meshLinkControllerFactory()
+                Log.i(
+                    "MeshLinkReferenceAutomation",
+                    "REFERENCE_AUTOMATION android.meshLinkController.factoryInvoke.end",
+                )
                 meshLinkControllerFactoryInProgress = false
                 meshLinkControllerInstance = created
                 watchdog.interrupt()

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
@@ -32,6 +32,11 @@ internal class AndroidPlatformServices(
 
     private val meshLinkControllerLock: Any = Any()
     @Volatile private var meshLinkControllerInstance: ReferenceMeshLinkController? = null
+    @Volatile private var meshLinkControllerFactoryInProgress: Boolean = false
+
+    private companion object {
+        private const val MESH_LINK_CONTROLLER_FACTORY_WATCHDOG_DELAY_MILLIS: Long = 2_000L
+    }
 
     val meshLinkController: ReferenceMeshLinkController
         get() {
@@ -42,8 +47,27 @@ internal class AndroidPlatformServices(
                     "MeshLinkReferenceAutomation",
                     "REFERENCE_AUTOMATION android.meshLinkController.access begin",
                 )
+                meshLinkControllerFactoryInProgress = true
+                val watchdog =
+                    Thread {
+                        try {
+                            Thread.sleep(MESH_LINK_CONTROLLER_FACTORY_WATCHDOG_DELAY_MILLIS)
+                        } catch (_: InterruptedException) {
+                            return@Thread
+                        }
+                        if (meshLinkControllerFactoryInProgress) {
+                            Log.i(
+                                "MeshLinkReferenceAutomation",
+                                "REFERENCE_AUTOMATION android.meshLinkController.access waiting elapsedSeconds=2.0",
+                            )
+                        }
+                    }
+                watchdog.isDaemon = true
+                watchdog.start()
                 val created = meshLinkControllerFactory()
+                meshLinkControllerFactoryInProgress = false
                 meshLinkControllerInstance = created
+                watchdog.interrupt()
                 Log.i(
                     "MeshLinkReferenceAutomation",
                     "REFERENCE_AUTOMATION android.meshLinkController.access end",

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/AndroidPlatformServicesHelpers.kt
@@ -48,10 +48,6 @@ internal class AndroidPlatformServices(
                     "REFERENCE_AUTOMATION android.meshLinkController.access begin",
                 )
                 meshLinkControllerFactoryInProgress = true
-                Log.i(
-                    "MeshLinkReferenceAutomation",
-                    "REFERENCE_AUTOMATION android.meshLinkController.factoryInvoke.begin",
-                )
                 val watchdog =
                     Thread {
                         try {
@@ -69,10 +65,6 @@ internal class AndroidPlatformServices(
                 watchdog.isDaemon = true
                 watchdog.start()
                 val created = meshLinkControllerFactory()
-                Log.i(
-                    "MeshLinkReferenceAutomation",
-                    "REFERENCE_AUTOMATION android.meshLinkController.factoryInvoke.end",
-                )
                 meshLinkControllerFactoryInProgress = false
                 meshLinkControllerInstance = created
                 watchdog.interrupt()

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -7,6 +7,10 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import ch.trancee.meshlink.reference.app.ReferenceApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 private const val EXTRA_UI_AUTOMATION = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION"
 private const val EXTRA_MODE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_MODE"
@@ -18,15 +22,23 @@ private const val EXTRA_TARGET_PEER_ID = "ch.trancee.meshlink.reference.extra.UI
 
 /** Android entry point for the shared reference app harness. */
 public class MainActivity : ComponentActivity() {
+    private val automationProbeScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var activePlatformServices: AndroidPlatformServices? = null
 
     override fun onCreate(savedInstanceState: Bundle?): Unit {
         super.onCreate(savedInstanceState)
         val extras = intent?.extras
+        val automationAppId = extras?.getString(EXTRA_APP_ID) ?: "unknown"
         logActivityStage("onCreate")
         logAutomationStartupStage(extras)
 
-        val platformServices = createPlatformServices(applicationContext)
+        val platformServices = createPlatformServices(applicationContext, automationAppId)
+        launchRetainedDiscoverySeedProbe(
+            context = applicationContext,
+            appId = automationAppId,
+            emitAutomationLog = platformServices::emitAutomationLog,
+            scope = automationProbeScope,
+        )
         activePlatformServices = platformServices
         logActivityStage("beforeSetContent")
         val meshLinkController = platformServices.meshLinkController
@@ -71,6 +83,7 @@ public class MainActivity : ComponentActivity() {
         logActivityStage("onDestroy")
         activePlatformServices?.stopPowerMitigation()
         activePlatformServices = null
+        automationProbeScope.cancel()
         super.onDestroy()
     }
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -6,11 +6,15 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import ch.trancee.meshlink.reference.app.ReferenceApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withContext
 
 private const val EXTRA_UI_AUTOMATION = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION"
 private const val EXTRA_MODE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_MODE"
@@ -20,11 +24,64 @@ private const val EXTRA_ROLE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATIO
 private const val EXTRA_SCENARIO = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_SCENARIO"
 private const val EXTRA_TARGET_PEER_ID = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_TARGET_PEER_ID"
 
+private fun logActivityStage(stage: String): Unit {
+    Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION activity.stage=$stage")
+}
+
+private fun logAutomationStartupStage(extras: Bundle?): Unit {
+    if (extras?.getBoolean(EXTRA_UI_AUTOMATION, false) != true) {
+        return
+    }
+    val mode = (extras.getString(EXTRA_MODE) ?: "unknown").uppercase().replace('-', '_')
+    val role = (extras.getString(EXTRA_ROLE) ?: "unknown").uppercase().replace('-', '_')
+    val scenario = extras.getString(EXTRA_SCENARIO) ?: "unknown"
+    val appId = extras.getString(EXTRA_APP_ID) ?: "unknown"
+    val storage = extras.getString(EXTRA_STORAGE) ?: "unknown"
+    val targetPeerId = extras.getString(EXTRA_TARGET_PEER_ID)
+    val autoStartMesh = role == "SENDER" || role == "PASSIVE"
+    val autoSendHello = role == "SENDER"
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        buildString {
+            append("REFERENCE_AUTOMATION startup stage=activity.onCreate mode=")
+            append(mode)
+            append(" role=")
+            append(role)
+            append(" scenario=")
+            append(scenario)
+            append(" appId=")
+            append(appId)
+            append(" storage=")
+            append(storage)
+            append(" targetPeerId=")
+            append(targetPeerId ?: "none")
+            append(" autoStartMesh=")
+            append(autoStartMesh)
+            append(" autoSendHello=")
+            append(autoSendHello)
+        },
+    )
+    Log.i(
+        "MeshLinkReferenceAutomation",
+        buildString {
+            append("REFERENCE_AUTOMATION startup-state=activity.onCreate role=")
+            append(role)
+            append(" scenario=")
+            append(scenario)
+            append(" autoStartMesh=")
+            append(autoStartMesh)
+            append(" autoSendHello=")
+            append(autoSendHello)
+        },
+    )
+}
+
 /** Android entry point for the shared reference app harness. */
 public class MainActivity : ComponentActivity() {
     private val automationProbeScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var activePlatformServices: AndroidPlatformServices? = null
 
+    @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?): Unit {
         super.onCreate(savedInstanceState)
         val extras = intent?.extras
@@ -41,8 +98,6 @@ public class MainActivity : ComponentActivity() {
         )
         activePlatformServices = platformServices
         logActivityStage("beforeSetContent")
-        val meshLinkController = platformServices.meshLinkController
-        logActivityStage("afterMeshLinkControllerAccess")
         logActivityStage("beforeReadinessBlockers")
         val readinessBlockers = platformServices.readinessBlockers
         logActivityStage("afterReadinessBlockers")
@@ -58,24 +113,41 @@ public class MainActivity : ComponentActivity() {
         setContent {
             logActivityStage("insideSetContent")
             platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.begin")
-            ReferenceApp(
-                platformName = platformServices.platformName,
-                readinessGuidance = platformServices.readinessGuidance,
-                readinessBlockers = readinessBlockers,
-                powerMitigationStatus = platformServices.powerMitigationStatus,
-                documentStore = platformServices.documentStore,
-                meshLinkController = meshLinkController,
-                stopPowerMitigation = { platformServices.stopPowerMitigation() },
-                currentTimeMillis = { platformServices.currentTimeMillis() },
-                automationMode = automationMode,
-                automationRole = automationRole,
-                automationScenario = automationScenario,
-                automationTargetPeerId = automationTargetPeerId,
-                autoStartMesh = autoStartMesh,
-                autoSendHello = autoSendHello,
-                emitAutomationLog = { message -> platformServices.emitAutomationLog(message) },
-            )
-            platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.end")
+            val meshLinkController = androidx.compose.runtime.remember {
+                mutableStateOf<ch.trancee.meshlink.reference.meshlink.ReferenceMeshLinkController?>(null)
+            }
+            androidx.compose.runtime.LaunchedEffect(automationAppId) {
+                logActivityStage("meshLinkControllerLoadBegin")
+                meshLinkController.value =
+                    withContext(Dispatchers.Default) { platformServices.meshLinkController }
+                logActivityStage("meshLinkControllerLoadEnd")
+            }
+            if (meshLinkController.value == null) {
+                platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.waiting controller")
+                logActivityStage("controllerLoading")
+            } else {
+                val controller = requireNotNull(meshLinkController.value)
+                logActivityStage("afterMeshLinkControllerAccess")
+                ReferenceApp(
+                    platformName = platformServices.platformName,
+                    readinessGuidance = platformServices.readinessGuidance,
+                    readinessBlockers = readinessBlockers,
+                    powerMitigationStatus = platformServices.powerMitigationStatus,
+                    documentStore = platformServices.documentStore,
+                    meshLinkController = controller,
+                    stopPowerMitigation = { platformServices.stopPowerMitigation() },
+                    currentTimeMillis = { platformServices.currentTimeMillis() },
+                    automationMode = automationMode,
+                    automationRole = automationRole,
+                    automationScenario = automationScenario,
+                    automationTargetPeerId = automationTargetPeerId,
+                    autoStartMesh = autoStartMesh,
+                    autoSendHello = autoSendHello,
+                    emitAutomationLog = { message -> platformServices.emitAutomationLog(message) },
+                    diagnosticMinimalUi = false,
+                )
+                platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.end")
+            }
         }
     }
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -18,15 +18,20 @@ public class MainActivity : ComponentActivity() {
 
         val platformServices = createPlatformServices(applicationContext)
         activePlatformServices = platformServices
+        logActivityStage("beforeSetContent")
+        val meshLinkController = platformServices.meshLinkController
+        logActivityStage("afterMeshLinkControllerAccess")
+        logActivityStage("setContentBegin")
 
         setContent {
+            logActivityStage("insideSetContent")
             ReferenceApp(
                 platformName = platformServices.platformName,
                 readinessGuidance = platformServices.readinessGuidance,
                 readinessBlockers = platformServices.readinessBlockers,
                 powerMitigationStatus = platformServices.powerMitigationStatus,
                 documentStore = platformServices.documentStore,
-                meshLinkController = platformServices.meshLinkController,
+                meshLinkController = meshLinkController,
                 stopPowerMitigation = { platformServices.stopPowerMitigation() },
                 currentTimeMillis = { platformServices.currentTimeMillis() },
             )
@@ -41,6 +46,6 @@ public class MainActivity : ComponentActivity() {
     }
 
     private fun logActivityStage(stage: String): Unit {
-        Log.i("MeshLinkReference", "REFERENCE_HARNESS activity.stage=$stage")
+        Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION activity.stage=$stage")
     }
 }

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -14,6 +14,7 @@ private const val EXTRA_STORAGE = "ch.trancee.meshlink.reference.extra.UI_AUTOMA
 private const val EXTRA_APP_ID = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_APP_ID"
 private const val EXTRA_ROLE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_ROLE"
 private const val EXTRA_SCENARIO = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_SCENARIO"
+private const val EXTRA_TARGET_PEER_ID = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_TARGET_PEER_ID"
 
 /** Android entry point for the shared reference app harness. */
 public class MainActivity : ComponentActivity() {
@@ -21,8 +22,9 @@ public class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?): Unit {
         super.onCreate(savedInstanceState)
+        val extras = intent?.extras
         logActivityStage("onCreate")
-        logAutomationStartupStage()
+        logAutomationStartupStage(extras)
 
         val platformServices = createPlatformServices(applicationContext)
         activePlatformServices = platformServices
@@ -33,6 +35,13 @@ public class MainActivity : ComponentActivity() {
         val readinessBlockers = platformServices.readinessBlockers
         logActivityStage("afterReadinessBlockers")
         logActivityStage("setContentBegin")
+
+        val automationMode = (extras?.getString(EXTRA_MODE) ?: "unknown").uppercase().replace('-', '_')
+        val automationRole = (extras?.getString(EXTRA_ROLE) ?: "unknown").uppercase().replace('-', '_')
+        val automationScenario = extras?.getString(EXTRA_SCENARIO) ?: "unknown"
+        val automationTargetPeerId = extras?.getString(EXTRA_TARGET_PEER_ID)
+        val autoStartMesh = automationRole == "SENDER" || automationRole == "PASSIVE"
+        val autoSendHello = automationRole == "SENDER"
 
         setContent {
             logActivityStage("insideSetContent")
@@ -46,6 +55,12 @@ public class MainActivity : ComponentActivity() {
                 meshLinkController = meshLinkController,
                 stopPowerMitigation = { platformServices.stopPowerMitigation() },
                 currentTimeMillis = { platformServices.currentTimeMillis() },
+                automationMode = automationMode,
+                automationRole = automationRole,
+                automationScenario = automationScenario,
+                automationTargetPeerId = automationTargetPeerId,
+                autoStartMesh = autoStartMesh,
+                autoSendHello = autoSendHello,
                 emitAutomationLog = { message -> platformServices.emitAutomationLog(message) },
             )
             platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.end")
@@ -63,8 +78,7 @@ public class MainActivity : ComponentActivity() {
         Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION activity.stage=$stage")
     }
 
-    private fun logAutomationStartupStage(): Unit {
-        val extras = intent?.extras
+    private fun logAutomationStartupStage(extras: Bundle?): Unit {
         if (extras?.getBoolean(EXTRA_UI_AUTOMATION, false) != true) {
             return
         }
@@ -73,6 +87,9 @@ public class MainActivity : ComponentActivity() {
         val scenario = extras.getString(EXTRA_SCENARIO) ?: "unknown"
         val appId = extras.getString(EXTRA_APP_ID) ?: "unknown"
         val storage = extras.getString(EXTRA_STORAGE) ?: "unknown"
+        val targetPeerId = extras.getString(EXTRA_TARGET_PEER_ID)
+        val autoStartMesh = role == "SENDER" || role == "PASSIVE"
+        val autoSendHello = role == "SENDER"
         Log.i(
             "MeshLinkReferenceAutomation",
             buildString {
@@ -86,6 +103,25 @@ public class MainActivity : ComponentActivity() {
                 append(appId)
                 append(" storage=")
                 append(storage)
+                append(" targetPeerId=")
+                append(targetPeerId ?: "none")
+                append(" autoStartMesh=")
+                append(autoStartMesh)
+                append(" autoSendHello=")
+                append(autoSendHello)
+            },
+        )
+        Log.i(
+            "MeshLinkReferenceAutomation",
+            buildString {
+                append("REFERENCE_AUTOMATION startup-state=activity.onCreate role=")
+                append(role)
+                append(" scenario=")
+                append(scenario)
+                append(" autoStartMesh=")
+                append(autoStartMesh)
+                append(" autoSendHello=")
+                append(autoSendHello)
             },
         )
     }

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import ch.trancee.meshlink.reference.app.ReferenceApp
 
 /** Android entry point for the shared reference app harness. */
 public class MainActivity : ComponentActivity() {
@@ -21,20 +20,16 @@ public class MainActivity : ComponentActivity() {
         logActivityStage("beforeSetContent")
         val meshLinkController = platformServices.meshLinkController
         logActivityStage("afterMeshLinkControllerAccess")
+        logActivityStage("beforeReadinessBlockers")
+        val readinessBlockers = platformServices.readinessBlockers
+        logActivityStage("afterReadinessBlockers")
         logActivityStage("setContentBegin")
 
         setContent {
             logActivityStage("insideSetContent")
-            ReferenceApp(
-                platformName = platformServices.platformName,
-                readinessGuidance = platformServices.readinessGuidance,
-                readinessBlockers = platformServices.readinessBlockers,
-                powerMitigationStatus = platformServices.powerMitigationStatus,
-                documentStore = platformServices.documentStore,
-                meshLinkController = meshLinkController,
-                stopPowerMitigation = { platformServices.stopPowerMitigation() },
-                currentTimeMillis = { platformServices.currentTimeMillis() },
-            )
+            logActivityStage("placeholderBeforeEmit")
+            platformServices.emitAutomationLog("REFERENCE_AUTOMATION activity.placeholder.rendered")
+            logActivityStage("placeholderAfterEmit")
         }
     }
 

--- a/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
+++ b/meshlink-reference/android/src/main/kotlin/ch/trancee/meshlink/reference/MainActivity.kt
@@ -6,6 +6,14 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import ch.trancee.meshlink.reference.app.ReferenceApp
+
+private const val EXTRA_UI_AUTOMATION = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION"
+private const val EXTRA_MODE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_MODE"
+private const val EXTRA_STORAGE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_STORAGE_SUBDIRECTORY"
+private const val EXTRA_APP_ID = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_APP_ID"
+private const val EXTRA_ROLE = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_ROLE"
+private const val EXTRA_SCENARIO = "ch.trancee.meshlink.reference.extra.UI_AUTOMATION_SCENARIO"
 
 /** Android entry point for the shared reference app harness. */
 public class MainActivity : ComponentActivity() {
@@ -14,6 +22,7 @@ public class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?): Unit {
         super.onCreate(savedInstanceState)
         logActivityStage("onCreate")
+        logAutomationStartupStage()
 
         val platformServices = createPlatformServices(applicationContext)
         activePlatformServices = platformServices
@@ -27,9 +36,19 @@ public class MainActivity : ComponentActivity() {
 
         setContent {
             logActivityStage("insideSetContent")
-            logActivityStage("placeholderBeforeEmit")
-            platformServices.emitAutomationLog("REFERENCE_AUTOMATION activity.placeholder.rendered")
-            logActivityStage("placeholderAfterEmit")
+            platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.begin")
+            ReferenceApp(
+                platformName = platformServices.platformName,
+                readinessGuidance = platformServices.readinessGuidance,
+                readinessBlockers = readinessBlockers,
+                powerMitigationStatus = platformServices.powerMitigationStatus,
+                documentStore = platformServices.documentStore,
+                meshLinkController = meshLinkController,
+                stopPowerMitigation = { platformServices.stopPowerMitigation() },
+                currentTimeMillis = { platformServices.currentTimeMillis() },
+                emitAutomationLog = { message -> platformServices.emitAutomationLog(message) },
+            )
+            platformServices.emitAutomationLog("REFERENCE_AUTOMATION app.compose.end")
         }
     }
 
@@ -42,5 +61,32 @@ public class MainActivity : ComponentActivity() {
 
     private fun logActivityStage(stage: String): Unit {
         Log.i("MeshLinkReferenceAutomation", "REFERENCE_AUTOMATION activity.stage=$stage")
+    }
+
+    private fun logAutomationStartupStage(): Unit {
+        val extras = intent?.extras
+        if (extras?.getBoolean(EXTRA_UI_AUTOMATION, false) != true) {
+            return
+        }
+        val mode = (extras.getString(EXTRA_MODE) ?: "unknown").uppercase().replace('-', '_')
+        val role = (extras.getString(EXTRA_ROLE) ?: "unknown").uppercase().replace('-', '_')
+        val scenario = extras.getString(EXTRA_SCENARIO) ?: "unknown"
+        val appId = extras.getString(EXTRA_APP_ID) ?: "unknown"
+        val storage = extras.getString(EXTRA_STORAGE) ?: "unknown"
+        Log.i(
+            "MeshLinkReferenceAutomation",
+            buildString {
+                append("REFERENCE_AUTOMATION startup stage=activity.onCreate mode=")
+                append(mode)
+                append(" role=")
+                append(role)
+                append(" scenario=")
+                append(scenario)
+                append(" appId=")
+                append(appId)
+                append(" storage=")
+                append(storage)
+            },
+        )
     }
 }

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -303,7 +303,7 @@ def extract_peer_id_from_evidence(evidence: str | None) -> str | None:
     return match.group(1)
 
 
-def read_passive_peer_id(serial: str, app_id: str, retries: int = 60, delay_s: float = 1.0) -> str | None:
+def read_passive_peer_id(serial: str, app_id: str, retries: int = 5, delay_s: float = 1.0) -> str | None:
     xml_path = f"shared_prefs/meshlink-{app_id}.xml"
     identity_key = f"identity:{app_id}:x25519-public"
     for _ in range(retries):

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -535,8 +535,8 @@ def format_elapsed_from_markers(
 ) -> str:
     if start_line and end_line and len(start_line) >= 18 and len(end_line) >= 18:
         try:
-            start = datetime.strptime(start_line[:18], "%m-%d %H:%M:%S.%f")
-            end = datetime.strptime(end_line[:18], "%m-%d %H:%M:%S.%f")
+            start = datetime.strptime(f"2001-{start_line[:18]}", "%Y-%m-%d %H:%M:%S.%f")
+            end = datetime.strptime(f"2001-{end_line[:18]}", "%Y-%m-%d %H:%M:%S.%f")
             if end >= start:
                 return f"{(end - start).total_seconds():.1f}s"
         except ValueError:
@@ -1117,6 +1117,7 @@ def main(argv: list[str] | None = None) -> int:
     compact_report += "\n\n## Run setup\n\n"
     compact_report += f"- Fleet inventory: `{fleet_markdown_path}`\n"
     compact_report += f"- Fleet JSON: `{fleet_json_path}`\n"
+    compact_report += "- `foreignScanSummary` is written to both `fleet.json` and `progress.json` for downstream tooling.\n"
     compact_report += f"- Fail-fast: {'enabled' if args.fail_fast else 'disabled'}\n"
     compact_report += f"- Stopped early: {'yes' if stopped_early else 'no'}\n"
     if stop_reason is not None:

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -304,9 +304,20 @@ def extract_peer_id_from_evidence(evidence: str | None) -> str | None:
 
 
 def read_passive_peer_id(serial: str, app_id: str, retries: int = 5, delay_s: float = 1.0) -> str | None:
+    discovery_seed_path = "files/automation-discovery-seed.txt"
     xml_path = f"shared_prefs/meshlink-{app_id}.xml"
     identity_key = f"identity:{app_id}:x25519-public"
     for _ in range(retries):
+        seed_result = subprocess.run(
+            ["adb", "-s", serial, "shell", "run-as", "ch.trancee.meshlink.reference", "cat", discovery_seed_path],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if seed_result.returncode == 0:
+            seed_text = seed_result.stdout.strip()
+            if seed_text:
+                return seed_text.splitlines()[0].strip()
         result = subprocess.run(
             ["adb", "-s", serial, "shell", "run-as", "ch.trancee.meshlink.reference", "cat", xml_path],
             check=False,

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -30,7 +30,7 @@ def mermaid_text(value: Any, *, max_len: int = 120) -> str:
     return text or "—"
 
 PROOF_SCRIPT = Path("meshlink-reference/scripts/run_headless_reference_android_direct_proof.py")
-DEFAULT_ANDROID_READY_SECONDS = 90.0
+DEFAULT_ANDROID_READY_SECONDS = 30.0
 DEFAULT_CAPTURE_TIMEOUT_SECONDS = 180.0
 DEFAULT_PAIR_TIMEOUT_SECONDS = 240.0
 DEFAULT_MIN_ANDROID_API_LEVEL = 33
@@ -98,7 +98,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--android-ready-seconds",
         type=float,
         default=DEFAULT_ANDROID_READY_SECONDS,
-        help="Passive startup wait per pair",
+        help="Passive startup wait per pair (kept short so transport-start failures surface quickly)",
     )
     parser.add_argument(
         "--capture-timeout-seconds",
@@ -134,7 +134,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=5,
         help="Stop the sweep once failures exceed this threshold when fail-fast is disabled",
     )
-    parser.set_defaults(fail_fast=False)
+    parser.set_defaults(fail_fast=True)
     return parser.parse_args(argv)
 
 

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -268,6 +268,8 @@ def run_pair(
             "failureStage": "no-summary",
             "failureReason": (completed.stderr or completed.stdout or "").strip(),
         }
+    sender_focus = summary.get("senderDiscoveryFocus") or {}
+    passive_focus = summary.get("passiveDiscoveryFocus") or {}
     return {
         "status": summary.get("status"),
         "failureStage": summary.get("failureStage"),
@@ -276,6 +278,8 @@ def run_pair(
         "routeEvidence": summary.get("routeEvidence"),
         "senderRouteStage": summary.get("senderRouteStage"),
         "passiveRouteStage": summary.get("passiveRouteStage"),
+        "senderForeignScanIgnoredCount": sender_focus.get("foreignScanIgnoredCount"),
+        "passiveForeignScanIgnoredCount": passive_focus.get("foreignScanIgnoredCount"),
         "timings": summary.get("timings"),
         "startupTiming": summary.get("startupTiming"),
         "htmlReportPath": summary.get("htmlReportPath"),
@@ -974,6 +978,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(
             f"    initial {initial['status']} ({initial.get('failureStage')}) -> final {final['status']} ({final.get('failureStage')})",
+            flush=True,
+        )
+        print(
+            "    foreign scan summary "
+            + f"sender ignored={initial.get('senderForeignScanIgnoredCount', '—')} "
+            + f"passive ignored={initial.get('passiveForeignScanIgnoredCount', '—')}",
             flush=True,
         )
 

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -730,6 +730,7 @@ def render_pair_report(
         f"- Final status: {final.get('status')} ({final.get('failureStage') or '—'}) in {final.get('timings', {}).get('totalSeconds') or final.get('elapsedSeconds') or '—'}s",
         f"- Initial failure reason: {initial.get('failureReason') or 'None.'}",
         f"- Final failure reason: {final.get('failureReason') or 'None.'}",
+        f"- Foreign scan summary: initial sender ignored {initial.get('senderForeignScanIgnoredCount', '—')} · initial passive ignored {initial.get('passiveForeignScanIgnoredCount', '—')} · final sender ignored {final.get('senderForeignScanIgnoredCount', '—')} · final passive ignored {final.get('passiveForeignScanIgnoredCount', '—')}",
         f"- Route stage: {final.get('routeStage') or initial.get('routeStage') or 'unknown'}",
         f"- Route evidence: {final.get('routeEvidence') or initial.get('routeEvidence') or '—'}",
         "",

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -280,6 +280,8 @@ def run_pair(
         "passiveRouteStage": summary.get("passiveRouteStage"),
         "senderForeignScanIgnoredCount": sender_focus.get("foreignScanIgnoredCount"),
         "passiveForeignScanIgnoredCount": passive_focus.get("foreignScanIgnoredCount"),
+        "senderDiscoveryFocus": sender_focus,
+        "passiveDiscoveryFocus": passive_focus,
         "timings": summary.get("timings"),
         "startupTiming": summary.get("startupTiming"),
         "htmlReportPath": summary.get("htmlReportPath"),
@@ -346,6 +348,8 @@ def read_passive_peer_id(serial: str, app_id: str, retries: int = 5, delay_s: fl
 
 
 def compact_status(summary: dict[str, Any]) -> dict[str, Any]:
+    sender_focus = summary.get("senderDiscoveryFocus") or {}
+    passive_focus = summary.get("passiveDiscoveryFocus") or {}
     return {
         "status": summary.get("status"),
         "failureStage": summary.get("failureStage"),
@@ -358,6 +362,10 @@ def compact_status(summary: dict[str, Any]) -> dict[str, Any]:
         "senderRouteEvidence": summary.get("senderRouteEvidence"),
         "passiveRouteStage": summary.get("passiveRouteStage"),
         "passiveRouteEvidence": summary.get("passiveRouteEvidence"),
+        "senderForeignScanIgnoredCount": sender_focus.get("foreignScanIgnoredCount"),
+        "passiveForeignScanIgnoredCount": passive_focus.get("foreignScanIgnoredCount"),
+        "senderDiscoveryFocus": sender_focus,
+        "passiveDiscoveryFocus": passive_focus,
         "transportMode": summary.get("transportMode") or (summary.get("timings") or {}).get("transportMode"),
         "transportEvidence": summary.get("transportEvidence") or (summary.get("timings") or {}).get("transportEvidence"),
         "startupTiming": summary.get("startupTiming"),
@@ -421,6 +429,17 @@ def render_compact_report(results: list[dict[str, Any]], *, state: dict[str, Any
     fleet_inventory_path = state.get("fleetInventoryPath") if state is not None else None
     run_root = state.get("runRoot") if state is not None else None
 
+    sender_ignored_total = sum(
+        int(row.get("initial", {}).get("senderForeignScanIgnoredCount") or 0)
+        + int(row.get("final", {}).get("senderForeignScanIgnoredCount") or 0)
+        for row in results
+    )
+    passive_ignored_total = sum(
+        int(row.get("initial", {}).get("passiveForeignScanIgnoredCount") or 0)
+        + int(row.get("final", {}).get("passiveForeignScanIgnoredCount") or 0)
+        for row in results
+    )
+
     report = [
         "# Android direct-proof matrix",
         "",
@@ -436,6 +455,8 @@ def render_compact_report(results: list[dict[str, Any]], *, state: dict[str, Any
         f"| Max failures | {max_failures if max_failures is not None else '—'} |",
         f"| Stopped early | {'yes' if stopped_early else 'no'} |",
         f"| Stop reason | {stop_reason or '—'} |",
+        "",
+        f"Foreign scan summary: sender ignored {sender_ignored_total} · passive ignored {passive_ignored_total}",
         "",
         "## Mermaid overview",
         "",
@@ -698,7 +719,8 @@ def render_pair_report(
 
     intro = (
         f"Pair {index:02d} ({pair['label']}) is a {initial.get('status')} initial run over {sender_model} → {passive_model}. "
-        f"The sender started {sender_startup_transport or 'unknown'} transport, the passive side started {passive_startup_transport or 'unknown'} transport, and the pair stalled at {final.get('failureStage') or initial.get('failureStage') or 'unknown'} before route establishment."
+        f"The sender started {sender_startup_transport or 'unknown'} transport, the passive side started {passive_startup_transport or 'unknown'} transport, and the pair stalled at {final.get('failureStage') or initial.get('failureStage') or 'unknown'} before route establishment. "
+        f"Foreign scan summary: initial sender ignored {initial.get('senderForeignScanIgnoredCount', '—')} · initial passive ignored {initial.get('passiveForeignScanIgnoredCount', '—')} · final sender ignored {final.get('senderForeignScanIgnoredCount', '—')} · final passive ignored {final.get('passiveForeignScanIgnoredCount', '—')}"
     )
 
     lines = [
@@ -730,7 +752,6 @@ def render_pair_report(
         f"- Final status: {final.get('status')} ({final.get('failureStage') or '—'}) in {final.get('timings', {}).get('totalSeconds') or final.get('elapsedSeconds') or '—'}s",
         f"- Initial failure reason: {initial.get('failureReason') or 'None.'}",
         f"- Final failure reason: {final.get('failureReason') or 'None.'}",
-        f"- Foreign scan summary: initial sender ignored {initial.get('senderForeignScanIgnoredCount', '—')} · initial passive ignored {initial.get('passiveForeignScanIgnoredCount', '—')} · final sender ignored {final.get('senderForeignScanIgnoredCount', '—')} · final passive ignored {final.get('passiveForeignScanIgnoredCount', '—')}",
         f"- Route stage: {final.get('routeStage') or initial.get('routeStage') or 'unknown'}",
         f"- Route evidence: {final.get('routeEvidence') or initial.get('routeEvidence') or '—'}",
         "",

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -457,6 +457,7 @@ def render_compact_report(results: list[dict[str, Any]], *, state: dict[str, Any
         f"| Stop reason | {stop_reason or '—'} |",
         "",
         f"Foreign scan summary: sender ignored {sender_ignored_total} · passive ignored {passive_ignored_total}",
+        "- Legend: the fleet summary aggregates initial + final ignored counts across all processed pairs, while each pair report breaks those counts down per run.",
         "",
         "## Mermaid overview",
         "",
@@ -962,6 +963,20 @@ def main(argv: list[str] | None = None) -> int:
         completed.add((pair["sender"], pair["passive"]))
         progress_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
         results_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+        fleet_inventory["foreignScanSummary"] = {
+            "senderIgnoredTotal": sum(
+                int(row.get("initial", {}).get("senderForeignScanIgnoredCount") or 0)
+                + int(row.get("final", {}).get("senderForeignScanIgnoredCount") or 0)
+                for row in results
+            ),
+            "passiveIgnoredTotal": sum(
+                int(row.get("initial", {}).get("passiveForeignScanIgnoredCount") or 0)
+                + int(row.get("final", {}).get("passiveForeignScanIgnoredCount") or 0)
+                for row in results
+            ),
+            "legend": "Fleet summary aggregates initial + final ignored counts across all processed pairs; pair reports break those counts down per run.",
+        }
+        fleet_json_path.write_text(json.dumps(fleet_inventory, indent=2), encoding="utf-8")
         state_path.write_text(
             json.dumps(
                 {

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -880,7 +880,7 @@ def main(argv: list[str] | None = None) -> int:
         peer_lookup_seconds = round(time.monotonic() - peer_lookup_started, 1)
         if target_peer_id is None:
             print(
-                "==> Passive peer id unavailable; skipping the final pass because no valid discovery evidence was captured",
+                "==> Passive peer id unavailable; continuing without a seeded target peer",
                 flush=True,
             )
         else:
@@ -888,33 +888,17 @@ def main(argv: list[str] | None = None) -> int:
                 f"==> Seeded final pass from discovered peer {target_peer_id}",
                 flush=True,
             )
-        if target_peer_id is not None:
-            final = run_pair(
-                sender=pair["sender"],
-                passive=pair["passive"],
-                app_id=app_id,
-                run_dir=final_dir,
-                target_peer_id=target_peer_id,
-                capture_timeout=args.capture_timeout_seconds,
-                android_ready_seconds=args.android_ready_seconds,
-                pair_timeout_seconds=args.pair_timeout_seconds,
-                skip_install=True,
-            )
-        else:
-            final = {
-                "status": "skipped",
-                "failureStage": initial.get("failureStage"),
-                "failureReason": initial.get("failureReason"),
-                "senderCompletion": initial.get("senderCompletion"),
-                "passiveCompletion": initial.get("passiveCompletion"),
-                "timings": initial.get("timings"),
-                "htmlReportPath": initial.get("htmlReportPath"),
-                "stdoutTail": initial.get("stdoutTail"),
-                "stderrTail": initial.get("stderrTail"),
-                "elapsedSeconds": initial.get("elapsedSeconds"),
-                "runDir": str(final_dir),
-                "summaryPath": None,
-            }
+        final = run_pair(
+            sender=pair["sender"],
+            passive=pair["passive"],
+            app_id=app_id,
+            run_dir=final_dir,
+            target_peer_id=target_peer_id,
+            capture_timeout=args.capture_timeout_seconds,
+            android_ready_seconds=args.android_ready_seconds,
+            pair_timeout_seconds=args.pair_timeout_seconds,
+            skip_install=True,
+        )
 
         row = {
             "label": pair["label"],

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_matrix.py
@@ -457,7 +457,7 @@ def render_compact_report(results: list[dict[str, Any]], *, state: dict[str, Any
         f"| Stop reason | {stop_reason or '—'} |",
         "",
         f"Foreign scan summary: sender ignored {sender_ignored_total} · passive ignored {passive_ignored_total}",
-        "- Legend: the fleet summary aggregates initial + final ignored counts across all processed pairs, while each pair report breaks those counts down per run.",
+        "- How to read this report: sender/passive foreign-scan counts are summed across initial + final passes for the fleet overview, while pair reports show the same counts per run.",
         "",
         "## Mermaid overview",
         "",
@@ -731,6 +731,10 @@ def render_pair_report(
         "",
         intro,
         "",
+        "### How to read this report",
+        "- The foreign-scan summary in the intro aggregates initial + final runs for this pair.",
+        "- The detailed initial/final counts below let you see whether scan noise was one-sided or symmetric.",
+        "",
         "## Setup",
         "",
         f"- Sender: {sender_model} ({pair['sender']})",
@@ -746,6 +750,8 @@ def render_pair_report(
         f"- Initial run dir: `{initial.get('runDir') or initial.get('summaryPath') or '—'}`",
         f"- Final run dir: `{final.get('runDir') or '—'}`",
         f"- Target peer id: {target_peer_id or 'not resolved'}",
+        "- How to read this report: the foreign-scan summary above aggregates the initial + final runs; the per-pair counts below are broken out per run.",
+        "- How to read this report: the sender and passive counts are treated separately so you can spot whether the mesh hash noise is localized or symmetric.",
         "",
         "## Result",
         "",
@@ -836,7 +842,12 @@ def render_pair_report(
 def load_progress(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
-    return json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        return payload.get("results") or []
+    raise TypeError("progress.json must contain a list of results or an object with results")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -961,7 +972,29 @@ def main(argv: list[str] | None = None) -> int:
         }
         results.append(row)
         completed.add((pair["sender"], pair["passive"]))
-        progress_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+        progress_path.write_text(
+            json.dumps(
+                {
+                    "results": results,
+                    "foreignScanSummary": {
+                        "senderIgnoredTotal": sum(
+                            int(row.get("initial", {}).get("senderForeignScanIgnoredCount") or 0)
+                            + int(row.get("final", {}).get("senderForeignScanIgnoredCount") or 0)
+                            for row in results
+                        ),
+                        "passiveIgnoredTotal": sum(
+                            int(row.get("initial", {}).get("passiveForeignScanIgnoredCount") or 0)
+                            + int(row.get("final", {}).get("passiveForeignScanIgnoredCount") or 0)
+                            for row in results
+                        ),
+                        "legend": "Fleet summary aggregates initial + final ignored counts across all processed pairs; pair reports break those counts down per run.",
+                    },
+                    "legend": "Fleet summary aggregates initial + final ignored counts across all processed pairs; pair reports break those counts down per run.",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
         results_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
         fleet_inventory["foreignScanSummary"] = {
             "senderIgnoredTotal": sum(
@@ -1040,6 +1073,19 @@ def main(argv: list[str] | None = None) -> int:
             )
             break
 
+    foreign_scan_summary = {
+        "senderIgnoredTotal": sum(
+            int(row.get("initial", {}).get("senderForeignScanIgnoredCount") or 0)
+            + int(row.get("final", {}).get("senderForeignScanIgnoredCount") or 0)
+            for row in results
+        ),
+        "passiveIgnoredTotal": sum(
+            int(row.get("initial", {}).get("passiveForeignScanIgnoredCount") or 0)
+            + int(row.get("final", {}).get("passiveForeignScanIgnoredCount") or 0)
+            for row in results
+        ),
+        "legend": "Fleet summary aggregates initial + final ignored counts across all processed pairs; pair reports break those counts down per run.",
+    }
     state_path.write_text(
         json.dumps(
             {
@@ -1052,12 +1098,21 @@ def main(argv: list[str] | None = None) -> int:
                 "failFast": args.fail_fast,
                 "stoppedEarly": stopped_early,
                 "stopReason": stop_reason,
+                "foreignScanSummary": foreign_scan_summary,
             },
             indent=2,
         ),
         encoding="utf-8",
     )
 
+    progress_summary = {
+        "foreignScanSummary": foreign_scan_summary,
+        "legend": "Fleet summary aggregates initial + final ignored counts across all processed pairs; pair reports break those counts down per run.",
+    }
+    progress_path.write_text(
+        json.dumps({"results": results, **progress_summary}, indent=2),
+        encoding="utf-8",
+    )
     compact_report = render_compact_report(results, state=json.loads(state_path.read_text(encoding="utf-8")))
     compact_report += "\n\n## Run setup\n\n"
     compact_report += f"- Fleet inventory: `{fleet_markdown_path}`\n"

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -252,6 +252,14 @@ def render_summary_html(payload: dict[str, Any]) -> str:
         body = "".join(f"<tr><th>{esc(label)}</th><td>{esc(value)}</td></tr>" for label, value in rows)
         return f"<section><h2>{esc(title)}</h2><table>{body}</table></section>"
 
+    def foreign_peer_rows(peers: list[dict[str, Any]]) -> str:
+        if not peers:
+            return "<tr><th>None</th><td>—</td></tr>"
+        return "".join(
+            f"<tr><th>{esc(peer.get('addr'))}</th><td>remoteMeshHash={esc(peer.get('remoteMeshHash'))} · count={esc(peer.get('count'))}</td></tr>"
+            for peer in peers
+        )
+
     def timing_rows(stage: str, data: dict[str, Any]) -> str:
         message_latency = data.get("sendLatencySeconds") if stage == "Sender" else data.get("receiptSeconds")
         return "".join(
@@ -294,6 +302,7 @@ def render_summary_html(payload: dict[str, Any]) -> str:
     passive_discovery_focus = payload.get("passiveDiscoveryFocus", {}) or {}
     sender_discovery_focus_lines = sender_discovery_focus.get("lines") or []
     passive_discovery_focus_lines = passive_discovery_focus.get("lines") or []
+    passive_foreign_scan_top_peers = passive_discovery_focus.get("topPeers") or []
 
     execution_timeline_html = ""
     if any(
@@ -330,9 +339,18 @@ def render_summary_html(payload: dict[str, Any]) -> str:
     foreign_scan_note = None
     passive_foreign_scan_ignored_count = passive_discovery_focus.get("foreignScanIgnoredCount")
     if passive_foreign_scan_ignored_count is not None and int(passive_foreign_scan_ignored_count or 0) > 0:
+        top_peer_note = (
+            "Top foreign peers: "
+            + ", ".join(
+                f"{peer.get('addr')}→{peer.get('remoteMeshHash')}×{peer.get('count')}"
+                for peer in passive_foreign_scan_top_peers[:3]
+            )
+            if passive_foreign_scan_top_peers
+            else "Top foreign peers: none parsed"
+        )
         foreign_scan_note = (
             "Passive discovery is dropping foreign payloads; inspect the Passive discovery focus section "
-            f"and foreign scan summary (passive ignored {passive_foreign_scan_ignored_count})."
+            f"and foreign scan summary (passive ignored {passive_foreign_scan_ignored_count}). {top_peer_note}"
         )
     if status != "passed" or payload.get("failureReason") or payload.get("failureStage"):
         failure_rows = [
@@ -447,6 +465,7 @@ def render_summary_html(payload: dict[str, Any]) -> str:
             ],
         ),
         f"<section><h2>Passive discovery lines</h2><pre>{esc('\n'.join(passive_discovery_focus_lines) if passive_discovery_focus_lines else '—')}</pre></section>",
+        f"<section><h2>Top foreign peers</h2><table>{foreign_peer_rows(passive_foreign_scan_top_peers)}</table></section>",
         "<section><h2>Completion lines</h2>",
         f"<h3>Sender</h3><pre>{esc(sender_completion)}</pre>",
         f"<h3>Passive</h3><pre>{esc(passive_completion)}</pre>",
@@ -508,6 +527,25 @@ def count_foreign_scan_ignored_lines(log_text: str) -> int:
         for line in log_text.splitlines()
         if "ignoring discovery payload with mismatched meshHash" in line
     )
+
+
+def summarize_foreign_scan_peers(log_text: str, limit: int = 3) -> list[dict[str, Any]]:
+    counts: dict[tuple[str, str], int] = {}
+    for line in log_text.splitlines():
+        if "ignoring discovery payload with mismatched meshHash" not in line:
+            continue
+        addr_match = re.search(r"addr=([^\s]+)", line)
+        remote_match = re.search(r"remoteMeshHash=([^\s]+)", line)
+        if addr_match is None or remote_match is None:
+            continue
+        key = (addr_match.group(1), remote_match.group(1))
+        counts[key] = counts.get(key, 0) + 1
+    peers = [
+        {"addr": addr, "remoteMeshHash": remote_mesh_hash, "count": count}
+        for (addr, remote_mesh_hash), count in counts.items()
+    ]
+    peers.sort(key=lambda item: (-item["count"], item["addr"], item["remoteMeshHash"]))
+    return peers[:limit]
 
 
 def extract_discovery_focus_lines(
@@ -1784,6 +1822,7 @@ def failure_summary(
         "passiveDiscoveryFocus": {
             "peerId": target_peer_id,
             "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(passive_log_text),
+            "topPeers": summarize_foreign_scan_peers(passive_log_text),
             "lines": passive_discovery_focus_lines,
         },
         "startupState": completions.startup_state,
@@ -2097,6 +2136,7 @@ def main(argv: list[str] | None = None) -> int:
         summary["passiveDiscoveryFocus"] = {
             "peerId": target_peer_id,
             "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(passive_log_text),
+            "topPeers": summarize_foreign_scan_peers(passive_log_text),
             "lines": passive_discovery_focus_lines,
         }
         summary["timings"].update(

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -507,6 +507,7 @@ def extract_discovery_focus_lines(
     log_text: str,
     peer_id: str | None,
     *,
+    include_summary_lines: bool = True,
     include_peer_lines: bool = True,
 ) -> list[str]:
     focus_lines: list[str] = []
@@ -522,7 +523,10 @@ def extract_discovery_focus_lines(
     )
     for line in log_text.splitlines():
         normalized = line.strip()
-        if "REFERENCE_AUTOMATION startup.meshHashSummary" in normalized or "discovery.summary" in normalized:
+        if include_summary_lines and (
+            "REFERENCE_AUTOMATION startup.meshHashSummary" in normalized
+            or "discovery.summary" in normalized
+        ):
             focus_lines.append(normalized)
             continue
         if not include_peer_lines or peer_id is None:
@@ -1740,7 +1744,11 @@ def failure_summary(
     passive_log_text = read_text(passive_log_path(run_dir))
     discovered_peer_id = extract_discovered_peer_id(passive_log_text)
     target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
-    sender_discovery_focus_lines = extract_discovery_focus_lines(sender_log_text, target_peer_id)
+    sender_discovery_focus_lines = extract_discovery_focus_lines(
+        sender_log_text,
+        target_peer_id,
+        include_summary_lines=False,
+    )
     passive_discovery_focus_lines = extract_discovery_focus_lines(
         passive_log_text,
         target_peer_id,
@@ -2064,7 +2072,11 @@ def main(argv: list[str] | None = None) -> int:
         sender_log_text = read_text(sender_log_path(run_dir))
         passive_log_text = read_text(passive_log_path(run_dir))
         target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
-        sender_discovery_focus_lines = extract_discovery_focus_lines(sender_log_text, target_peer_id)
+        sender_discovery_focus_lines = extract_discovery_focus_lines(
+            sender_log_text,
+            target_peer_id,
+            include_summary_lines=False,
+        )
         passive_discovery_focus_lines = extract_discovery_focus_lines(
             passive_log_text,
             target_peer_id,

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -290,6 +290,8 @@ def render_summary_html(payload: dict[str, Any]) -> str:
     passive_completion = payload.get("passiveCompletion")
     route_evidence = payload.get("routeEvidence")
     transport_evidence = payload.get("transportEvidence")
+    sender_discovery_focus = payload.get("senderDiscoveryFocus", {}) or {}
+    sender_discovery_focus_lines = sender_discovery_focus.get("lines") or []
 
     execution_timeline_html = ""
     if any(
@@ -417,6 +419,15 @@ def render_summary_html(payload: dict[str, Any]) -> str:
                 ("Android export", payload.get("evidence", {}).get("androidExport")),
             ],
         ),
+        kv_table(
+            "Sender discovery focus",
+            [
+                ("Peer id", sender_discovery_focus.get("peerId")),
+                ("Foreign scan ignored count", sender_discovery_focus.get("foreignScanIgnoredCount")),
+                ("Matching line count", len(sender_discovery_focus_lines)),
+            ],
+        ),
+        f"<section><h2>Sender discovery lines</h2><pre>{esc('\n'.join(sender_discovery_focus_lines) if sender_discovery_focus_lines else '—')}</pre></section>",
         "<section><h2>Completion lines</h2>",
         f"<h3>Sender</h3><pre>{esc(sender_completion)}</pre>",
         f"<h3>Passive</h3><pre>{esc(passive_completion)}</pre>",
@@ -456,10 +467,43 @@ def extract_discovered_peer_id(log_text: str) -> str | None:
             continue
         if "role=passive" not in line.lower():
             continue
-        match = re.search(r"peer=([A-Za-z0-9._:-]+)", line)
+        match = re.search(r"peer=([^\s]+)", line)
         if match is not None:
             return match.group(1)
     return None
+
+
+def extract_target_peer_id(log_text: str) -> str | None:
+    for line in log_text.splitlines():
+        if "targetPeerId=" not in line:
+            continue
+        match = re.search(r"targetPeerId=([^\s]+)", line)
+        if match is not None:
+            return match.group(1)
+    return None
+
+
+def count_foreign_scan_ignored_lines(log_text: str) -> int:
+    return sum(
+        1
+        for line in log_text.splitlines()
+        if "ignoring discovery payload with mismatched meshHash" in line
+    )
+
+
+def extract_sender_discovery_focus_lines(log_text: str, peer_id: str | None) -> list[str]:
+    focus_lines: list[str] = []
+    peer_id_tokens = tuple(token for token in [peer_id, f"peerId={peer_id}" if peer_id else None, f"hintPeerId={peer_id}" if peer_id else None, f"targetPeerId={peer_id}" if peer_id else None] if token is not None)
+    for line in log_text.splitlines():
+        normalized = line.strip()
+        if "REFERENCE_AUTOMATION startup.meshHashSummary" in normalized or "discovery.summary" in normalized:
+            focus_lines.append(normalized)
+            continue
+        if peer_id is None:
+            continue
+        if any(token in normalized for token in peer_id_tokens):
+            focus_lines.append(normalized)
+    return focus_lines
 
 
 def extract_sender_completion(log_text: str) -> str | None:
@@ -1666,6 +1710,10 @@ def failure_summary(
     route_evidence = sender_route_evidence or passive_route_evidence
     transport_mode = timings.get("transportMode") or (timings.get("sender") or {}).get("transportMode") or (timings.get("passive") or {}).get("transportMode")
     transport_evidence = timings.get("transportEvidence") or (timings.get("sender") or {}).get("transportEvidence") or (timings.get("passive") or {}).get("transportEvidence")
+    sender_log_text = read_text(sender_log_path(run_dir))
+    discovered_peer_id = extract_discovered_peer_id(read_text(passive_log_path(run_dir)))
+    target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
+    sender_discovery_focus_lines = extract_sender_discovery_focus_lines(sender_log_text, target_peer_id)
     return {
         "status": "failed",
         "scenario": DIRECT_GUIDED_SCENARIO,
@@ -1678,8 +1726,14 @@ def failure_summary(
         "senderCompletion": completions.sender_completion,
         "passiveCompletion": completions.passive_completion,
         "senderFailure": completions.sender_failed,
-        "senderPowerState": extract_power_state_snapshot(read_text(sender_log_path(run_dir))),
+        "senderPowerState": extract_power_state_snapshot(sender_log_text),
         "passivePowerState": extract_power_state_snapshot(read_text(passive_log_path(run_dir))),
+        "discoveredPeerId": discovered_peer_id,
+        "senderDiscoveryFocus": {
+            "peerId": target_peer_id,
+            "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(sender_log_text),
+            "lines": sender_discovery_focus_lines,
+        },
         "startupState": completions.startup_state,
         "startupStateEvidence": completions.startup_evidence,
         "routeStage": route_stage,
@@ -1970,6 +2024,16 @@ def main(argv: list[str] | None = None) -> int:
             passive_transport="meshlink",
         )
         summary["discoveredPeerId"] = discovered_peer_id
+        sender_log_text = read_text(sender_log_path(run_dir))
+        sender_discovery_focus_lines = extract_sender_discovery_focus_lines(
+            sender_log_text,
+            discovered_peer_id,
+        )
+        summary["senderDiscoveryFocus"] = {
+            "peerId": discovered_peer_id,
+            "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(sender_log_text),
+            "lines": sender_discovery_focus_lines,
+        }
         summary["timings"].update(
             {
                 "totalSeconds": total_seconds,

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -157,10 +157,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--android-ready-seconds",
         type=float,
-        default=90.0,
+        default=30.0,
         help=(
             "How long to wait after launching the passive Android peer before starting the sender. "
-            "This gate is intentionally wider than the fastest smoke because some attached Android pairs need more time to surface the transport-start marker before the sender launches. "
+            "Keep this short so passive transport startup fails fast when the app never reaches the transport-start marker. "
             "Treat the selected sender/passive pair as part of the environment contract; some attached devices advertise and scan but never discover each other. "
             "On this host, the stable pair that completed direct proof was Spacewar (sender) + DN2103 (passive), while Nokia X20 + DN2103 repeatedly failed to discover until the screen stayed awake. "
             "The Nokia X20 runs Android 14 and was observed in Dozing with quick-doze enabled, so keep the screen awake, disable battery optimization if discovery stalls, and rely on the live-proof foreground wake-lock mitigation when the reference app starts it."

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -36,6 +36,7 @@ from run_headless_reference_live_proof import (
     force_stop_reference_app,
     grant_android_runtime_permissions,
     install_android_app,
+    uninstall_android_package,
     read_android_app_file,
     run,
     shell_join,
@@ -1035,6 +1036,7 @@ def install_android_proof_app(
         print("==> Android install stderr:")
         print(result.stderr.rstrip() or "(empty)")
 
+    uninstall_android_package(android_serial, ANDROID_PROOF_PACKAGE)
     try:
         run_install_once()
     except (TimeoutError, subprocess.TimeoutExpired) as error:
@@ -1045,8 +1047,7 @@ def install_android_proof_app(
         details = (error.stderr or error.stdout or "").strip()
         detail_suffix = f": {details}" if details else ""
         print("==> Android install failed; retrying once after uninstalling the existing package")
-        uninstall_result = run(["adb", "-s", android_serial, "uninstall", ANDROID_PROOF_PACKAGE], capture_output=True)
-        print("==> Android uninstall result:", uninstall_result.stdout.strip() or uninstall_result.stderr.strip() or "(empty)")
+        uninstall_android_package(android_serial, ANDROID_PROOF_PACKAGE)
         try:
             run_install_once()
         except (TimeoutError, subprocess.TimeoutExpired) as retry_error:

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -327,24 +327,31 @@ def render_summary_html(payload: dict[str, Any]) -> str:
         )
 
     failure_diagnostics_html = ""
-    if status != "passed" or payload.get("failureReason") or payload.get("failureStage"):
-        failure_diagnostics_html = kv_table(
-            "Failure diagnostics",
-            [
-                ("Failure stage", payload.get("failureStage")),
-                ("Failure reason", payload.get("failureReason")),
-                ("Startup state", payload.get("startupState")),
-                ("Startup evidence", payload.get("startupStateEvidence")),
-                ("Route stage", payload.get("routeStage")),
-                ("Route evidence", route_evidence),
-                ("Sender route stage", payload.get("senderRouteStage")),
-                ("Sender route evidence", payload.get("senderRouteEvidence")),
-                ("Passive route stage", payload.get("passiveRouteStage")),
-                ("Passive route evidence", payload.get("passiveRouteEvidence")),
-                ("Sender completion", sender_completion),
-                ("Passive completion", passive_completion),
-            ],
+    foreign_scan_note = None
+    passive_foreign_scan_ignored_count = passive_discovery_focus.get("foreignScanIgnoredCount")
+    if passive_foreign_scan_ignored_count is not None and int(passive_foreign_scan_ignored_count or 0) > 0:
+        foreign_scan_note = (
+            "Passive discovery is dropping foreign payloads; inspect the Passive discovery focus section "
+            f"and foreign scan summary (passive ignored {passive_foreign_scan_ignored_count})."
         )
+    if status != "passed" or payload.get("failureReason") or payload.get("failureStage"):
+        failure_rows = [
+            ("Failure stage", payload.get("failureStage")),
+            ("Failure reason", payload.get("failureReason")),
+            ("Startup state", payload.get("startupState")),
+            ("Startup evidence", payload.get("startupStateEvidence")),
+            ("Route stage", payload.get("routeStage")),
+            ("Route evidence", route_evidence),
+            ("Sender route stage", payload.get("senderRouteStage")),
+            ("Sender route evidence", payload.get("senderRouteEvidence")),
+            ("Passive route stage", payload.get("passiveRouteStage")),
+            ("Passive route evidence", payload.get("passiveRouteEvidence")),
+            ("Sender completion", sender_completion),
+            ("Passive completion", passive_completion),
+        ]
+        if foreign_scan_note is not None:
+            failure_rows.append(("Foreign scan note", foreign_scan_note))
+        failure_diagnostics_html = kv_table("Failure diagnostics", failure_rows)
 
     html_parts = [
         "<!doctype html>",

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -291,7 +291,9 @@ def render_summary_html(payload: dict[str, Any]) -> str:
     route_evidence = payload.get("routeEvidence")
     transport_evidence = payload.get("transportEvidence")
     sender_discovery_focus = payload.get("senderDiscoveryFocus", {}) or {}
+    passive_discovery_focus = payload.get("passiveDiscoveryFocus", {}) or {}
     sender_discovery_focus_lines = sender_discovery_focus.get("lines") or []
+    passive_discovery_focus_lines = passive_discovery_focus.get("lines") or []
 
     execution_timeline_html = ""
     if any(
@@ -428,6 +430,15 @@ def render_summary_html(payload: dict[str, Any]) -> str:
             ],
         ),
         f"<section><h2>Sender discovery lines</h2><pre>{esc('\n'.join(sender_discovery_focus_lines) if sender_discovery_focus_lines else '—')}</pre></section>",
+        kv_table(
+            "Passive discovery focus",
+            [
+                ("Peer id", passive_discovery_focus.get("peerId")),
+                ("Foreign scan ignored count", passive_discovery_focus.get("foreignScanIgnoredCount")),
+                ("Matching line count", len(passive_discovery_focus_lines)),
+            ],
+        ),
+        f"<section><h2>Passive discovery lines</h2><pre>{esc('\n'.join(passive_discovery_focus_lines) if passive_discovery_focus_lines else '—')}</pre></section>",
         "<section><h2>Completion lines</h2>",
         f"<h3>Sender</h3><pre>{esc(sender_completion)}</pre>",
         f"<h3>Passive</h3><pre>{esc(passive_completion)}</pre>",
@@ -491,9 +502,18 @@ def count_foreign_scan_ignored_lines(log_text: str) -> int:
     )
 
 
-def extract_sender_discovery_focus_lines(log_text: str, peer_id: str | None) -> list[str]:
+def extract_discovery_focus_lines(log_text: str, peer_id: str | None) -> list[str]:
     focus_lines: list[str] = []
-    peer_id_tokens = tuple(token for token in [peer_id, f"peerId={peer_id}" if peer_id else None, f"hintPeerId={peer_id}" if peer_id else None, f"targetPeerId={peer_id}" if peer_id else None] if token is not None)
+    peer_id_tokens = tuple(
+        token
+        for token in [
+            peer_id,
+            f"peerId={peer_id}" if peer_id else None,
+            f"hintPeerId={peer_id}" if peer_id else None,
+            f"targetPeerId={peer_id}" if peer_id else None,
+        ]
+        if token is not None
+    )
     for line in log_text.splitlines():
         normalized = line.strip()
         if "REFERENCE_AUTOMATION startup.meshHashSummary" in normalized or "discovery.summary" in normalized:
@@ -1711,9 +1731,11 @@ def failure_summary(
     transport_mode = timings.get("transportMode") or (timings.get("sender") or {}).get("transportMode") or (timings.get("passive") or {}).get("transportMode")
     transport_evidence = timings.get("transportEvidence") or (timings.get("sender") or {}).get("transportEvidence") or (timings.get("passive") or {}).get("transportEvidence")
     sender_log_text = read_text(sender_log_path(run_dir))
-    discovered_peer_id = extract_discovered_peer_id(read_text(passive_log_path(run_dir)))
+    passive_log_text = read_text(passive_log_path(run_dir))
+    discovered_peer_id = extract_discovered_peer_id(passive_log_text)
     target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
-    sender_discovery_focus_lines = extract_sender_discovery_focus_lines(sender_log_text, target_peer_id)
+    sender_discovery_focus_lines = extract_discovery_focus_lines(sender_log_text, target_peer_id)
+    passive_discovery_focus_lines = extract_discovery_focus_lines(passive_log_text, target_peer_id)
     return {
         "status": "failed",
         "scenario": DIRECT_GUIDED_SCENARIO,
@@ -1733,6 +1755,11 @@ def failure_summary(
             "peerId": target_peer_id,
             "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(sender_log_text),
             "lines": sender_discovery_focus_lines,
+        },
+        "passiveDiscoveryFocus": {
+            "peerId": target_peer_id,
+            "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(passive_log_text),
+            "lines": passive_discovery_focus_lines,
         },
         "startupState": completions.startup_state,
         "startupStateEvidence": completions.startup_evidence,
@@ -2025,14 +2052,19 @@ def main(argv: list[str] | None = None) -> int:
         )
         summary["discoveredPeerId"] = discovered_peer_id
         sender_log_text = read_text(sender_log_path(run_dir))
-        sender_discovery_focus_lines = extract_sender_discovery_focus_lines(
-            sender_log_text,
-            discovered_peer_id,
-        )
+        passive_log_text = read_text(passive_log_path(run_dir))
+        target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
+        sender_discovery_focus_lines = extract_discovery_focus_lines(sender_log_text, target_peer_id)
+        passive_discovery_focus_lines = extract_discovery_focus_lines(passive_log_text, target_peer_id)
         summary["senderDiscoveryFocus"] = {
-            "peerId": discovered_peer_id,
+            "peerId": target_peer_id,
             "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(sender_log_text),
             "lines": sender_discovery_focus_lines,
+        }
+        summary["passiveDiscoveryFocus"] = {
+            "peerId": target_peer_id,
+            "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(passive_log_text),
+            "lines": passive_discovery_focus_lines,
         }
         summary["timings"].update(
             {

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -369,6 +369,7 @@ def render_summary_html(payload: dict[str, Any]) -> str:
         "<body>",
         f"<h1>Android direct-proof summary <span class=\"badge {badge_class}\">{esc(status)}</span></h1>",
         f"<p class=\"muted\">App ID: {esc(payload.get('appId'))} · Scenario: {esc(payload.get('scenario'))} · Report: {esc(payload.get('htmlReportPath'))}</p>",
+        f"<p class=\"muted\">Foreign scan summary: sender ignored {esc((payload.get('senderDiscoveryFocus') or {}).get('foreignScanIgnoredCount'))} · passive ignored {esc((payload.get('passiveDiscoveryFocus') or {}).get('foreignScanIgnoredCount'))}</p>",
         kv_table(
             "Overview",
             [
@@ -502,7 +503,12 @@ def count_foreign_scan_ignored_lines(log_text: str) -> int:
     )
 
 
-def extract_discovery_focus_lines(log_text: str, peer_id: str | None) -> list[str]:
+def extract_discovery_focus_lines(
+    log_text: str,
+    peer_id: str | None,
+    *,
+    include_peer_lines: bool = True,
+) -> list[str]:
     focus_lines: list[str] = []
     peer_id_tokens = tuple(
         token
@@ -519,7 +525,7 @@ def extract_discovery_focus_lines(log_text: str, peer_id: str | None) -> list[st
         if "REFERENCE_AUTOMATION startup.meshHashSummary" in normalized or "discovery.summary" in normalized:
             focus_lines.append(normalized)
             continue
-        if peer_id is None:
+        if not include_peer_lines or peer_id is None:
             continue
         if any(token in normalized for token in peer_id_tokens):
             focus_lines.append(normalized)
@@ -1735,7 +1741,11 @@ def failure_summary(
     discovered_peer_id = extract_discovered_peer_id(passive_log_text)
     target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
     sender_discovery_focus_lines = extract_discovery_focus_lines(sender_log_text, target_peer_id)
-    passive_discovery_focus_lines = extract_discovery_focus_lines(passive_log_text, target_peer_id)
+    passive_discovery_focus_lines = extract_discovery_focus_lines(
+        passive_log_text,
+        target_peer_id,
+        include_peer_lines=False,
+    )
     return {
         "status": "failed",
         "scenario": DIRECT_GUIDED_SCENARIO,
@@ -2055,7 +2065,11 @@ def main(argv: list[str] | None = None) -> int:
         passive_log_text = read_text(passive_log_path(run_dir))
         target_peer_id = discovered_peer_id or extract_target_peer_id(sender_log_text)
         sender_discovery_focus_lines = extract_discovery_focus_lines(sender_log_text, target_peer_id)
-        passive_discovery_focus_lines = extract_discovery_focus_lines(passive_log_text, target_peer_id)
+        passive_discovery_focus_lines = extract_discovery_focus_lines(
+            passive_log_text,
+            target_peer_id,
+            include_peer_lines=False,
+        )
         summary["senderDiscoveryFocus"] = {
             "peerId": target_peer_id,
             "foreignScanIgnoredCount": count_foreign_scan_ignored_lines(sender_log_text),

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -336,6 +336,7 @@ def render_summary_html(payload: dict[str, Any]) -> str:
         )
 
     failure_diagnostics_html = ""
+    capture_stall_note_html = ""
     foreign_scan_note = None
     passive_foreign_scan_ignored_count = passive_discovery_focus.get("foreignScanIgnoredCount")
     if passive_foreign_scan_ignored_count is not None and int(passive_foreign_scan_ignored_count or 0) > 0:
@@ -369,6 +370,16 @@ def render_summary_html(payload: dict[str, Any]) -> str:
         ]
         if foreign_scan_note is not None:
             failure_rows.append(("Foreign scan note", foreign_scan_note))
+        if payload.get("failureStage") == "capture" or payload.get("routeStage") == "discovery-stalled":
+            capture_stall_note = (
+                "Capture stalled before route establishment; the passive side is still absorbing foreign payloads "
+                "so check the Top foreign peers table for the dominant noisy addresses."
+            )
+            failure_rows.append(("Capture stall note", capture_stall_note))
+            capture_stall_note_html = (
+                "<section><h2>Capture stall note</h2>"
+                f"<p>{esc(capture_stall_note)}</p></section>"
+            )
         failure_diagnostics_html = kv_table("Failure diagnostics", failure_rows)
 
     html_parts = [
@@ -436,6 +447,7 @@ def render_summary_html(payload: dict[str, Any]) -> str:
         ),
         execution_timeline_html,
         failure_diagnostics_html,
+        capture_stall_note_html,
         kv_table(
             "Evidence",
             [

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -89,12 +89,19 @@ PASSIVE_PROOF_COMPLETE_NEEDLE = "REFERENCE_AUTOMATION proof.complete role=passiv
 SENDER_REQUIRED_LOG_MARKERS = [
     "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER",
     f"scenario={DIRECT_GUIDED_SCENARIO}",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.init",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoStartMesh.requested",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.begin",
     "REFERENCE_AUTOMATION peer.discovered role=SENDER",
     "REFERENCE_AUTOMATION send.requested role=sender",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.requested",
 ]
 PASSIVE_REQUIRED_LOG_MARKERS = [
     "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE",
     f"scenario={DIRECT_GUIDED_SCENARIO}",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.init",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoStartMesh.requested",
+    "REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.begin",
 ]
 PASSIVE_PROOF_REQUIRED_LOG_MARKERS = [
     "MeshLink proof app ready on",
@@ -469,14 +476,17 @@ def extract_sender_failure(log_text: str) -> str | None:
 
 
 def extract_startup_state(log_text: str) -> tuple[str | None, str | None]:
+    latest_state: str | None = None
+    latest_line: str | None = None
     for line in log_text.splitlines():
         if "startup-state=" not in line:
             continue
-        match = re.search(r"startup-state=([a-z-]+)", line)
+        match = re.search(r"startup-state=([a-z0-9_.-]+)", line)
         if match is None:
             continue
-        return match.group(1), line.strip()
-    return None, None
+        latest_state = match.group(1)
+        latest_line = line.strip()
+    return latest_state, latest_line
 
 
 def extract_route_observation(log_text: str) -> tuple[str | None, str | None]:
@@ -1666,7 +1676,7 @@ def main(argv: list[str] | None = None) -> int:
     run_dir.mkdir(parents=True, exist_ok=True)
     app_id = args.app_id or f"{DEFAULT_APP_ID_PREFIX}.{timestamp()}"
     storage_subdirectory = run_dir.name.replace("/", "_")
-    discovery_wait_seconds = max(args.android_ready_seconds * 2, 20.0)
+    peer_resolution_wait_seconds = min(max(args.android_ready_seconds, 1.0), 5.0)
     discovered_peer_id: str | None = args.target_peer_id
     stage = "input-validation"
     sender_process: BackgroundProcess | None = None
@@ -1789,11 +1799,11 @@ def main(argv: list[str] | None = None) -> int:
                     or read_passive_peer_id(
                         args.passive_android_serial,
                         app_id,
-                        retries=max(1, int(discovery_wait_seconds)),
+                        retries=max(1, int(peer_resolution_wait_seconds)),
                     )
                     or wait_for_discovered_peer_id(
                         passive_marker_path,
-                        discovery_wait_seconds,
+                        peer_resolution_wait_seconds,
                     )
                 )
                 print(f"==> Passive peer id resolved: {discovered_peer_id}")
@@ -1830,16 +1840,17 @@ def main(argv: list[str] | None = None) -> int:
             if sender_process is None:
                 sender_target_peer_id = resolve_sender_target_peer_id(
                     passive_marker_path,
-                    discovery_wait_seconds,
+                    peer_resolution_wait_seconds,
                     discovered_peer_id,
                     args.target_peer_id,
                 )
                 if sender_target_peer_id is None:
-                    raise SystemExit(
-                        "Android peer-resolution gate failed: passive peer id was not resolved from shared prefs or passive discovery markers before sender launch"
+                    print(
+                        "==> Passive peer id unavailable after short resolution wait; launching sender without a seeded target peer"
                     )
-                discovered_peer_id = sender_target_peer_id
-                print(f"==> Passive peer id resolved for sender launch: {sender_target_peer_id}")
+                else:
+                    discovered_peer_id = sender_target_peer_id
+                    print(f"==> Passive peer id resolved for sender launch: {sender_target_peer_id}")
                 sender_process = launch_android_sender_role_app(
                     run_dir=run_dir,
                     android_serial=args.sender_android_serial,
@@ -1855,10 +1866,11 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 print(f"==> Android sender launched at +{time.monotonic() - run_started_at:.1f}s")
             if discovered_peer_id is None:
-                raise SystemExit(
-                    "Android peer-resolution gate failed: passive peer id was not resolved from shared prefs or passive discovery markers before the route phase"
+                print(
+                    "==> Passive peer id unavailable before the route phase; proceeding without a seeded target peer"
                 )
-            print(f"==> Peer resolution gate resolved passive peer id {discovered_peer_id}")
+            else:
+                print(f"==> Peer resolution gate resolved passive peer id {discovered_peer_id}")
             sender_startup_observation = wait_for_log_marker_observation(
                 sender_log_path(run_dir),
                 "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER",

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -93,6 +93,7 @@ SENDER_REQUIRED_LOG_MARKERS = [
     "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoStartMesh.requested",
     "REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.begin",
     "REFERENCE_AUTOMATION peer.discovered role=SENDER",
+    "REFERENCE_AUTOMATION route.ready role=SENDER",
     "REFERENCE_AUTOMATION send.requested role=sender",
     "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.requested",
 ]
@@ -506,7 +507,10 @@ def extract_route_observation(log_text: str) -> tuple[str | None, str | None]:
         elif "NO_ROUTE_AVAILABLE" in line or "route-unavailable" in line or "routeAvailable=false" in line:
             stage = "route-unavailable"
             evidence = normalized
-        elif "GATT notify benchmark notifications enabled" in line:
+        elif "route.pending role=" in line:
+            stage = "route-pending"
+            evidence = normalized
+        elif "route.ready role=" in line or "GATT notify benchmark notifications enabled" in line:
             stage = "route-discovered"
             evidence = normalized
         elif "ROUTE_DISCOVERED" in line or "routeAvailable=true" in line:
@@ -690,13 +694,13 @@ def build_timing_snapshot(
     )
     sender_trust_line, sender_trust_seconds = extract_marker_timing(
         sender_log,
-        ("ROUTE_DISCOVERED", "HOP_SESSION_ESTABLISHED"),
+        ("route.ready role=SENDER", "ROUTE_DISCOVERED", "HOP_SESSION_ESTABLISHED"),
         after_seconds=sender_peer_seconds or sender_startup_seconds,
     )
     sender_send_line, sender_send_seconds = extract_marker_timing(
         sender_log,
         ("send.requested role=sender",),
-        after_seconds=sender_peer_seconds or sender_startup_seconds,
+        after_seconds=sender_trust_seconds or sender_peer_seconds or sender_startup_seconds,
     )
     sender_complete_line, sender_complete_seconds = extract_marker_timing(
         sender_log,
@@ -717,7 +721,7 @@ def build_timing_snapshot(
     )
     passive_trust_line, passive_trust_seconds = extract_marker_timing(
         passive_log,
-        ("ROUTE_DISCOVERED", "HOP_SESSION_ESTABLISHED"),
+        ("route.ready role=PASSIVE", "ROUTE_DISCOVERED", "HOP_SESSION_ESTABLISHED"),
         after_seconds=passive_peer_seconds or passive_startup_seconds,
     )
     passive_complete_line, passive_complete_seconds = extract_marker_timing(
@@ -843,7 +847,7 @@ def transport_failure_reason(run_dir: Path) -> str | None:
             )
     if all(marker in combined_log for marker in TRANSPORT_REQUIRED_MARKERS):
         return (
-            "Android transport reached scan/advertise startup but never emitted peer.discovered; "
+            "Android transport reached scan/advertise startup but never emitted peer.discovered or route.ready; "
             "classified as a capture stall"
         )
     return None

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -495,7 +495,13 @@ def extract_route_observation(log_text: str) -> tuple[str | None, str | None]:
     evidence: str | None = None
     for line in log_text.splitlines():
         normalized = line.strip()
-        if "discovery.stalled role=" in line:
+        if "sender.discovery.stalled role=" in line:
+            stage = "sender-discovery-stalled"
+            evidence = normalized
+        elif "sender.discovery.pending role=" in line:
+            stage = "sender-discovery-pending"
+            evidence = normalized
+        elif "discovery.stalled role=" in line:
             stage = "discovery-stalled"
             evidence = normalized
         elif "discovery.pending role=" in line:
@@ -838,7 +844,15 @@ def transport_failure_reason(run_dir: Path) -> str | None:
         or "peer.discovered role=sender" in combined_log_lower
     )
     route_stage = sender_route_stage or passive_route_stage
-    route_failure_stages = {"handshake-message1-send", "hop-failed", "route-unavailable", "discovery-stalled", "discovery-pending"}
+    route_failure_stages = {
+        "handshake-message1-send",
+        "hop-failed",
+        "route-unavailable",
+        "discovery-stalled",
+        "discovery-pending",
+        "sender-discovery-stalled",
+        "sender-discovery-pending",
+    }
     if peer_discovered:
         if sender_route_stage in route_failure_stages or passive_route_stage in route_failure_stages:
             return (
@@ -851,6 +865,11 @@ def transport_failure_reason(run_dir: Path) -> str | None:
                 "Android direct proof discovered a peer but never emitted a route-stage marker; "
                 "sender stalled before route stabilization"
             )
+    if "sender.discovery.stalled role=" in combined_log_lower or "sender.discovery.pending role=" in combined_log_lower:
+        return (
+            "Android direct proof sender stalled before peer discovery; "
+            "classified as a capture stall"
+        )
     if "discovery.stalled role=" in combined_log_lower or "discovery.pending role=" in combined_log_lower:
         return (
             "Android direct proof reached startup but discovery stalled before peer discovery or route readiness; "

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -844,7 +844,7 @@ def transport_failure_reason(run_dir: Path) -> str | None:
     if all(marker in combined_log for marker in TRANSPORT_REQUIRED_MARKERS):
         return (
             "Android transport reached scan/advertise startup but never emitted peer.discovered; "
-            "direct proof cannot proceed without a retained discovery seed"
+            "classified as a capture stall"
         )
     return None
 
@@ -1242,8 +1242,15 @@ def start_android_role_app(
 
 
 def read_passive_peer_id(android_serial: str, app_id: str, retries: int = 60, delay_s: float = 1.0) -> str | None:
+    discovery_seed_path = "automation-discovery-seed.txt"
     relative_path = f"../shared_prefs/meshlink-{app_id}.xml"
     for _ in range(retries):
+        try:
+            discovery_seed_text = read_android_app_file(android_serial, discovery_seed_path).strip()
+        except subprocess.CalledProcessError:
+            discovery_seed_text = ""
+        if discovery_seed_text:
+            return discovery_seed_text.splitlines()[0].strip()
         try:
             xml_text = read_android_app_file(android_serial, relative_path)
         except subprocess.CalledProcessError:

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -495,7 +495,13 @@ def extract_route_observation(log_text: str) -> tuple[str | None, str | None]:
     evidence: str | None = None
     for line in log_text.splitlines():
         normalized = line.strip()
-        if "peer.discovered role=" in line or "GATT notify benchmark discovered service" in line:
+        if "discovery.stalled role=" in line:
+            stage = "discovery-stalled"
+            evidence = normalized
+        elif "discovery.pending role=" in line:
+            stage = "discovery-pending"
+            evidence = normalized
+        elif "peer.discovered role=" in line or "GATT notify benchmark discovered service" in line:
             stage = "peer-discovered"
             evidence = normalized
         if "transport.handshake.message1.send" in line:
@@ -832,7 +838,7 @@ def transport_failure_reason(run_dir: Path) -> str | None:
         or "peer.discovered role=sender" in combined_log_lower
     )
     route_stage = sender_route_stage or passive_route_stage
-    route_failure_stages = {"handshake-message1-send", "hop-failed", "route-unavailable"}
+    route_failure_stages = {"handshake-message1-send", "hop-failed", "route-unavailable", "discovery-stalled", "discovery-pending"}
     if peer_discovered:
         if sender_route_stage in route_failure_stages or passive_route_stage in route_failure_stages:
             return (
@@ -845,6 +851,11 @@ def transport_failure_reason(run_dir: Path) -> str | None:
                 "Android direct proof discovered a peer but never emitted a route-stage marker; "
                 "sender stalled before route stabilization"
             )
+    if "discovery.stalled role=" in combined_log_lower or "discovery.pending role=" in combined_log_lower:
+        return (
+            "Android direct proof reached startup but discovery stalled before peer discovery or route readiness; "
+            "classified as a capture stall"
+        )
     if all(marker in combined_log for marker in TRANSPORT_REQUIRED_MARKERS):
         return (
             "Android transport reached scan/advertise startup but never emitted peer.discovered or route.ready; "

--- a/meshlink-reference/scripts/run_headless_reference_live_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_live_proof.py
@@ -657,6 +657,27 @@ def android_install_timeout_seconds(android_serial: str) -> float:
     return 240.0 if is_wireless_android_serial(android_serial) else 60.0
 
 
+def uninstall_android_package(android_serial: str, package_name: str) -> bool:
+    commands = [
+        ["adb", "-s", android_serial, "uninstall", package_name],
+        ["adb", "-s", android_serial, "shell", "pm", "uninstall", "--user", "0", package_name],
+        ["adb", "-s", android_serial, "shell", "cmd", "package", "uninstall", "--user", "0", package_name],
+    ]
+    for command in commands:
+        result = run(command, capture_output=True, check=False)
+        stdout = (result.stdout or "").strip()
+        stderr = (result.stderr or "").strip()
+        print(
+            "==> Android uninstall result ("
+            + shell_join(command)
+            + "): "
+            + (stdout or stderr or "(empty)")
+        )
+        if result.returncode == 0 and ("Success" in stdout or "Success" in stderr):
+            return True
+    return False
+
+
 def android_install_cache_path(run_dir: Path, android_serial: str) -> Path:
     safe_serial = re.sub(r"[^A-Za-z0-9._-]", "_", android_serial)
     return run_dir / f".android-install-cache-{safe_serial}.json"
@@ -720,6 +741,7 @@ def install_android_app(android_serial: str, run_dir: Path | None = None, *, ins
                 stderr=result.stderr,
             )
 
+    uninstall_android_package(android_serial, ANDROID_PACKAGE)
     try:
         run_install_once()
     except subprocess.TimeoutExpired as error:
@@ -733,14 +755,7 @@ def install_android_app(android_serial: str, run_dir: Path | None = None, *, ins
         print(
             "==> Android install failed; retrying once after uninstalling the existing package"
         )
-        uninstall_result = run(["adb", "-s", android_serial, "uninstall", ANDROID_PACKAGE], capture_output=True, check=False)
-        uninstall_stdout = (uninstall_result.stdout or "").strip()
-        uninstall_stderr = (uninstall_result.stderr or "").strip()
-        print(
-            "==> Android uninstall result: "
-            + (uninstall_stdout or "(no stdout)")
-            + (f" | stderr: {uninstall_stderr}" if uninstall_stderr else "")
-        )
+        uninstall_android_package(android_serial, ANDROID_PACKAGE)
         run_install_once()
     grant_android_runtime_permissions(android_serial)
     apk_path = android_apk_path()

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_matrix.py
@@ -167,7 +167,9 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                 ],
             )
 
-    def test_main_skips_final_pass_when_discovery_evidence_is_missing(self) -> None:
+    def test_main_runs_final_pass_without_seeded_peer_when_discovery_evidence_is_missing(
+        self,
+    ) -> None:
         # Arrange
         with tempfile.TemporaryDirectory() as temporary_directory:
             run_root = Path(temporary_directory) / "matrix"
@@ -188,8 +190,6 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                         "target_peer_id": kwargs["target_peer_id"],
                     }
                 )
-                if kwargs["skip_install"]:
-                    raise AssertionError("final pass should be skipped without discovery evidence")
                 return {
                     "status": "failed",
                     "failureStage": "capture",
@@ -227,10 +227,10 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
             rows = json.loads((run_root / "matrix-results.json").read_text(encoding="utf-8"))
             self.assertEqual(len(rows), 2)
             self.assertEqual(rows[0]["initial"]["status"], "failed")
-            self.assertEqual(rows[0]["final"]["status"], "skipped")
+            self.assertEqual(rows[0]["final"]["status"], "failed")
             self.assertIsNone(rows[0]["targetPeerId"])
             self.assertEqual(rows[1]["initial"]["status"], "failed")
-            self.assertEqual(rows[1]["final"]["status"], "skipped")
+            self.assertEqual(rows[1]["final"]["status"], "failed")
             self.assertIsNone(rows[1]["targetPeerId"])
             self.assertEqual(
                 peer_reads,
@@ -243,7 +243,9 @@ class AndroidDirectMatrixScriptTests(unittest.TestCase):
                 run_calls,
                 [
                     {"sender": "1f1dad34", "passive": "2ASVB21B09005117", "skip_install": "False", "target_peer_id": None},
+                    {"sender": "1f1dad34", "passive": "2ASVB21B09005117", "skip_install": "True", "target_peer_id": None},
                     {"sender": "2ASVB21B09005117", "passive": "1f1dad34", "skip_install": "False", "target_peer_id": None},
+                    {"sender": "2ASVB21B09005117", "passive": "1f1dad34", "skip_install": "True", "target_peer_id": None},
                 ],
             )
 

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
@@ -71,6 +71,7 @@ public fun ReferenceApp(
                         autoStartMesh = autoStartMesh,
                         autoSendHello = autoSendHello,
                         emitAutomationLog = emitAutomationLog,
+                        currentTimeMillis = currentTimeMillis,
                     )
                 }
             emitAutomationLog("REFERENCE_AUTOMATION startup-state=app.compose.afterRemember")

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
@@ -23,26 +23,38 @@ public fun ReferenceApp(
     meshLinkController: ReferenceMeshLinkController,
     stopPowerMitigation: () -> Unit,
     currentTimeMillis: () -> Long,
+    emitAutomationLog: (String) -> Unit = {},
+    diagnosticMinimalUi: Boolean = false,
 ) {
-    val guidedViewModel =
-        remember(
-            platformName,
-            readinessGuidance,
-            readinessBlockers,
-            powerMitigationStatus,
-            meshLinkController,
-        ) {
-            GuidedFirstExchangeViewModel(
-                platformName = platformName,
-                readinessGuidance = readinessGuidance,
-                readinessBlockers = readinessBlockers,
-                powerMitigationStatus = powerMitigationStatus,
-                meshLinkController = meshLinkController,
-            )
-        }
+    emitAutomationLog("REFERENCE_AUTOMATION app.compose.begin minimal=$diagnosticMinimalUi")
     ReferenceTheme {
-        Surface(modifier = Modifier.fillMaxSize()) {
-            GuidedFirstExchangeScreen(viewModel = guidedViewModel)
+        if (diagnosticMinimalUi) {
+            emitAutomationLog("REFERENCE_AUTOMATION app.compose.placeholder")
+            Surface(modifier = Modifier.fillMaxSize()) {
+                Unit
+            }
+        } else {
+            emitAutomationLog("REFERENCE_AUTOMATION app.compose.beforeRemember")
+            val guidedViewModel =
+                remember(
+                    platformName,
+                    readinessGuidance,
+                    readinessBlockers,
+                    powerMitigationStatus,
+                    meshLinkController,
+                ) {
+                    GuidedFirstExchangeViewModel(
+                        platformName = platformName,
+                        readinessGuidance = readinessGuidance,
+                        readinessBlockers = readinessBlockers,
+                        powerMitigationStatus = powerMitigationStatus,
+                        meshLinkController = meshLinkController,
+                    )
+                }
+            emitAutomationLog("REFERENCE_AUTOMATION app.compose.afterRemember")
+            Surface(modifier = Modifier.fillMaxSize()) {
+                GuidedFirstExchangeScreen(viewModel = guidedViewModel)
+            }
         }
     }
 }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
@@ -30,9 +30,7 @@ public fun ReferenceApp(
     ReferenceTheme {
         if (diagnosticMinimalUi) {
             emitAutomationLog("REFERENCE_AUTOMATION app.compose.placeholder")
-            Surface(modifier = Modifier.fillMaxSize()) {
-                Unit
-            }
+            Surface(modifier = Modifier.fillMaxSize()) { Unit }
         } else {
             emitAutomationLog("REFERENCE_AUTOMATION app.compose.beforeRemember")
             val guidedViewModel =

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/app/ReferenceApp.kt
@@ -23,10 +23,21 @@ public fun ReferenceApp(
     meshLinkController: ReferenceMeshLinkController,
     stopPowerMitigation: () -> Unit,
     currentTimeMillis: () -> Long,
+    automationMode: String? = null,
+    automationRole: String? = null,
+    automationScenario: String? = null,
+    automationTargetPeerId: String? = null,
+    autoStartMesh: Boolean = false,
+    autoSendHello: Boolean = false,
     emitAutomationLog: (String) -> Unit = {},
     diagnosticMinimalUi: Boolean = false,
 ) {
-    emitAutomationLog("REFERENCE_AUTOMATION app.compose.begin minimal=$diagnosticMinimalUi")
+    emitAutomationLog(
+        "REFERENCE_AUTOMATION app.compose.begin minimal=$diagnosticMinimalUi mode=${automationMode ?: "none"} role=${automationRole ?: "none"} scenario=${automationScenario ?: "none"} targetPeerId=${automationTargetPeerId ?: "none"} autoStartMesh=$autoStartMesh autoSendHello=$autoSendHello"
+    )
+    emitAutomationLog(
+        "REFERENCE_AUTOMATION startup-state=app.compose.begin mode=${automationMode ?: "none"} role=${automationRole ?: "none"} scenario=${automationScenario ?: "none"} autoStartMesh=$autoStartMesh autoSendHello=$autoSendHello"
+    )
     ReferenceTheme {
         if (diagnosticMinimalUi) {
             emitAutomationLog("REFERENCE_AUTOMATION app.compose.placeholder")
@@ -40,6 +51,12 @@ public fun ReferenceApp(
                     readinessBlockers,
                     powerMitigationStatus,
                     meshLinkController,
+                    automationMode,
+                    automationRole,
+                    automationScenario,
+                    automationTargetPeerId,
+                    autoStartMesh,
+                    autoSendHello,
                 ) {
                     GuidedFirstExchangeViewModel(
                         platformName = platformName,
@@ -47,12 +64,22 @@ public fun ReferenceApp(
                         readinessBlockers = readinessBlockers,
                         powerMitigationStatus = powerMitigationStatus,
                         meshLinkController = meshLinkController,
+                        automationMode = automationMode,
+                        automationRole = automationRole,
+                        automationScenario = automationScenario,
+                        automationTargetPeerId = automationTargetPeerId,
+                        autoStartMesh = autoStartMesh,
+                        autoSendHello = autoSendHello,
+                        emitAutomationLog = emitAutomationLog,
                     )
                 }
+            emitAutomationLog("REFERENCE_AUTOMATION startup-state=app.compose.afterRemember")
             emitAutomationLog("REFERENCE_AUTOMATION app.compose.afterRemember")
             Surface(modifier = Modifier.fillMaxSize()) {
                 GuidedFirstExchangeScreen(viewModel = guidedViewModel)
             }
+            emitAutomationLog("REFERENCE_AUTOMATION startup-state=app.compose.end")
+            emitAutomationLog("REFERENCE_AUTOMATION app.compose.end")
         }
     }
 }

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
@@ -3,6 +3,7 @@ package ch.trancee.meshlink.reference.guided
 import ch.trancee.meshlink.api.DeliveryPriority
 import ch.trancee.meshlink.reference.meshlink.ReferenceControllerSnapshot
 import ch.trancee.meshlink.reference.meshlink.ReferenceMeshLinkController
+import ch.trancee.meshlink.reference.model.PeerConnectionSnapshotState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -36,6 +37,8 @@ internal class GuidedFirstExchangeViewModel(
     private val powerMitigationLabelValue: String? = powerMitigationStatus
     private var autoSendTriggered: Boolean = false
     private var peerDiscoveryLogged: Boolean = false
+    private var routeReadyLogged: Boolean = false
+    private var routePendingLogged: Boolean = false
 
     public val powerMitigationLabel: String?
         get() = powerMitigationLabelValue
@@ -53,6 +56,7 @@ internal class GuidedFirstExchangeViewModel(
             meshLinkController.snapshot.collectLatest { snapshot ->
                 stateStore.applySnapshot(snapshot)
                 maybeLogPeerDiscovery(snapshot)
+                maybeLogRouteReadiness(snapshot)
                 maybeAutoSendHello(snapshot)
             }
         }
@@ -110,6 +114,34 @@ internal class GuidedFirstExchangeViewModel(
         )
     }
 
+    private fun maybeLogRouteReadiness(snapshot: ReferenceControllerSnapshot): Unit {
+        val peer = snapshot.peers.firstOrNull()
+        if (peer == null) {
+            if (routePendingLogged) return
+            routePendingLogged = true
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION route.pending role=${automationRole ?: "unknown"} count=0 selectedPeerId=none"
+            )
+            return
+        }
+        if (peer.connectionState == PeerConnectionSnapshotState.CONNECTED) {
+            if (routeReadyLogged) return
+            routeReadyLogged = true
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION route.ready role=${automationRole ?: "unknown"} peerId=${peer.peerId} peerSuffix=${peer.peerSuffix} trustState=${peer.trustState} connectionState=${peer.connectionState}"
+            )
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION startup-state=guided.viewModel.route.ready peerId=${peer.peerId} peerSuffix=${peer.peerSuffix} trustState=${peer.trustState} connectionState=${peer.connectionState}"
+            )
+            return
+        }
+        if (routePendingLogged) return
+        routePendingLogged = true
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION route.pending role=${automationRole ?: "unknown"} peerId=${peer.peerId} peerSuffix=${peer.peerSuffix} trustState=${peer.trustState} connectionState=${peer.connectionState}"
+        )
+    }
+
     private fun maybeAutoSendHello(snapshot: ReferenceControllerSnapshot): Unit {
         if (!autoSendHello || autoSendTriggered) return
         val targetPeerId = automationTargetPeerId
@@ -118,6 +150,7 @@ internal class GuidedFirstExchangeViewModel(
                 targetPeerId != null -> snapshot.peers.firstOrNull { it.peerId == targetPeerId }
                 else -> snapshot.peers.firstOrNull()
             } ?: return
+        if (peer.connectionState != PeerConnectionSnapshotState.CONNECTED) return
         autoSendTriggered = true
         emitAutomationLog(
             "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoSendHello.requested peerId=${peer.peerId} targetPeerId=${targetPeerId ?: "none"}"

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
@@ -7,6 +7,7 @@ import ch.trancee.meshlink.reference.model.PeerConnectionSnapshotState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -25,6 +26,7 @@ internal class GuidedFirstExchangeViewModel(
     private val autoStartMesh: Boolean = false,
     private val autoSendHello: Boolean = false,
     private val emitAutomationLog: (String) -> Unit = {},
+    private val currentTimeMillis: () -> Long,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     private val stateStore: GuidedFirstExchangeStateStore =
@@ -37,8 +39,11 @@ internal class GuidedFirstExchangeViewModel(
     private val powerMitigationLabelValue: String? = powerMitigationStatus
     private var autoSendTriggered: Boolean = false
     private var peerDiscoveryLogged: Boolean = false
+    private var discoveryPendingLogged: Boolean = false
+    private var discoveryStalledLogged: Boolean = false
     private var routeReadyLogged: Boolean = false
     private var routePendingLogged: Boolean = false
+    private val initAtEpochMillis: Long = currentTimeMillis()
 
     public val powerMitigationLabel: String?
         get() = powerMitigationLabelValue
@@ -55,10 +60,15 @@ internal class GuidedFirstExchangeViewModel(
             )
             meshLinkController.snapshot.collectLatest { snapshot ->
                 stateStore.applySnapshot(snapshot)
+                maybeLogDiscoveryPending(snapshot)
                 maybeLogPeerDiscovery(snapshot)
                 maybeLogRouteReadiness(snapshot)
                 maybeAutoSendHello(snapshot)
             }
+        }
+        scope.launch {
+            delay(3_000L)
+            maybeLogDiscoveryStalled()
         }
         if (autoStartMesh) {
             emitAutomationLog(
@@ -100,6 +110,30 @@ internal class GuidedFirstExchangeViewModel(
                 "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.end peerId=$peerId"
             )
         }
+    }
+
+    private fun maybeLogDiscoveryPending(snapshot: ReferenceControllerSnapshot): Unit {
+        if (discoveryPendingLogged || snapshot.peers.isNotEmpty()) return
+        discoveryPendingLogged = true
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION discovery.pending role=${automationRole ?: "unknown"} count=0 selectedPeerId=none elapsedSeconds=0.0"
+        )
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.discovery.pending role=${automationRole ?: "unknown"} count=0 selectedPeerId=none"
+        )
+    }
+
+    private fun maybeLogDiscoveryStalled(): Unit {
+        if (discoveryStalledLogged) return
+        val snapshot = uiState.value.snapshot
+        if (snapshot.peers.isNotEmpty()) return
+        discoveryStalledLogged = true
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION discovery.stalled role=${automationRole ?: "unknown"} count=0 selectedPeerId=none elapsedSeconds=3.0"
+        )
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.discovery.stalled role=${automationRole ?: "unknown"} count=0 selectedPeerId=none elapsedSeconds=3.0 initAt=$initAtEpochMillis"
+        )
     }
 
     private fun maybeLogPeerDiscovery(snapshot: ReferenceControllerSnapshot): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
@@ -115,12 +115,18 @@ internal class GuidedFirstExchangeViewModel(
     private fun maybeLogDiscoveryPending(snapshot: ReferenceControllerSnapshot): Unit {
         if (discoveryPendingLogged || snapshot.peers.isNotEmpty()) return
         discoveryPendingLogged = true
+        val role = automationRole ?: "unknown"
         emitAutomationLog(
-            "REFERENCE_AUTOMATION discovery.pending role=${automationRole ?: "unknown"} count=0 selectedPeerId=none elapsedSeconds=0.0"
+            "REFERENCE_AUTOMATION discovery.pending role=$role count=0 selectedPeerId=none elapsedSeconds=0.0"
         )
         emitAutomationLog(
-            "REFERENCE_AUTOMATION startup-state=guided.viewModel.discovery.pending role=${automationRole ?: "unknown"} count=0 selectedPeerId=none"
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.discovery.pending role=$role count=0 selectedPeerId=none"
         )
+        if (role.equals("sender", ignoreCase = true) || role.equals("SENDER", ignoreCase = true)) {
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION sender.discovery.pending role=$role count=0 selectedPeerId=none elapsedSeconds=0.0"
+            )
+        }
     }
 
     private fun maybeLogDiscoveryStalled(): Unit {
@@ -128,12 +134,18 @@ internal class GuidedFirstExchangeViewModel(
         val snapshot = uiState.value.snapshot
         if (snapshot.peers.isNotEmpty()) return
         discoveryStalledLogged = true
+        val role = automationRole ?: "unknown"
         emitAutomationLog(
-            "REFERENCE_AUTOMATION discovery.stalled role=${automationRole ?: "unknown"} count=0 selectedPeerId=none elapsedSeconds=3.0"
+            "REFERENCE_AUTOMATION discovery.stalled role=$role count=0 selectedPeerId=none elapsedSeconds=3.0"
         )
         emitAutomationLog(
-            "REFERENCE_AUTOMATION startup-state=guided.viewModel.discovery.stalled role=${automationRole ?: "unknown"} count=0 selectedPeerId=none elapsedSeconds=3.0 initAt=$initAtEpochMillis"
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.discovery.stalled role=$role count=0 selectedPeerId=none elapsedSeconds=3.0 initAt=$initAtEpochMillis"
         )
+        if (role.equals("sender", ignoreCase = true) || role.equals("SENDER", ignoreCase = true)) {
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION sender.discovery.stalled role=$role count=0 selectedPeerId=none elapsedSeconds=3.0"
+            )
+        }
     }
 
     private fun maybeLogPeerDiscovery(snapshot: ReferenceControllerSnapshot): Unit {

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/guided/GuidedFirstExchangeViewModel.kt
@@ -17,6 +17,13 @@ internal class GuidedFirstExchangeViewModel(
     private val readinessBlockers: List<String>,
     private val powerMitigationStatus: String?,
     private val meshLinkController: ReferenceMeshLinkController,
+    private val automationMode: String? = null,
+    private val automationRole: String? = null,
+    private val automationScenario: String? = null,
+    private val automationTargetPeerId: String? = null,
+    private val autoStartMesh: Boolean = false,
+    private val autoSendHello: Boolean = false,
+    private val emitAutomationLog: (String) -> Unit = {},
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     private val stateStore: GuidedFirstExchangeStateStore =
@@ -27,6 +34,8 @@ internal class GuidedFirstExchangeViewModel(
             initialSnapshot = meshLinkController.snapshot.value,
         )
     private val powerMitigationLabelValue: String? = powerMitigationStatus
+    private var autoSendTriggered: Boolean = false
+    private var peerDiscoveryLogged: Boolean = false
 
     public val powerMitigationLabel: String?
         get() = powerMitigationLabelValue
@@ -34,15 +43,34 @@ internal class GuidedFirstExchangeViewModel(
     public val uiState: StateFlow<GuidedFirstExchangeUiState> = stateStore.uiState
 
     init {
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.init mode=${automationMode ?: "none"} role=${automationRole ?: "none"} scenario=${automationScenario ?: "none"} autoStartMesh=$autoStartMesh autoSendHello=$autoSendHello targetPeerId=${automationTargetPeerId ?: "none"}"
+        )
         scope.launch {
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION startup-state=guided.viewModel.snapshot.collect.begin"
+            )
             meshLinkController.snapshot.collectLatest { snapshot ->
                 stateStore.applySnapshot(snapshot)
+                maybeLogPeerDiscovery(snapshot)
+                maybeAutoSendHello(snapshot)
             }
+        }
+        if (autoStartMesh) {
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoStartMesh.requested"
+            )
+            startMesh()
         }
     }
 
     public fun startMesh(): Unit {
-        scope.launch { meshLinkController.start() }
+        emitAutomationLog("REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.requested")
+        scope.launch {
+            emitAutomationLog("REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.begin")
+            meshLinkController.start()
+            emitAutomationLog("REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.end")
+        }
     }
 
     public fun sendHelloToFirstPeer(): Unit {
@@ -51,13 +79,50 @@ internal class GuidedFirstExchangeViewModel(
     }
 
     public fun sendHelloToPeer(peerId: String): Unit {
+        emitAutomationLog("REFERENCE_AUTOMATION send.requested role=sender peerId=$peerId")
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.requested peerId=$peerId"
+        )
         scope.launch {
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.begin peerId=$peerId"
+            )
             meshLinkController.sendPayload(
                 peerId = peerId,
                 payloadText = "hello mesh from $platformName",
                 priority = DeliveryPriority.NORMAL,
             )
+            emitAutomationLog(
+                "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.end peerId=$peerId"
+            )
         }
+    }
+
+    private fun maybeLogPeerDiscovery(snapshot: ReferenceControllerSnapshot): Unit {
+        if (peerDiscoveryLogged) return
+        val peer = snapshot.peers.firstOrNull() ?: return
+        peerDiscoveryLogged = true
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION peer.discovered role=${automationRole ?: "unknown"} peerId=${peer.peerId} peerSuffix=${peer.peerSuffix}"
+        )
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.peer.discovered peerId=${peer.peerId} peerSuffix=${peer.peerSuffix}"
+        )
+    }
+
+    private fun maybeAutoSendHello(snapshot: ReferenceControllerSnapshot): Unit {
+        if (!autoSendHello || autoSendTriggered) return
+        val targetPeerId = automationTargetPeerId
+        val peer =
+            when {
+                targetPeerId != null -> snapshot.peers.firstOrNull { it.peerId == targetPeerId }
+                else -> snapshot.peers.firstOrNull()
+            } ?: return
+        autoSendTriggered = true
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoSendHello.requested peerId=${peer.peerId} targetPeerId=${targetPeerId ?: "none"}"
+        )
+        sendHelloToPeer(peer.peerId)
     }
 }
 

--- a/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/session/ReferenceSessionController.kt
+++ b/meshlink-reference/src/commonMain/kotlin/ch/trancee/meshlink/reference/session/ReferenceSessionController.kt
@@ -41,21 +41,42 @@ internal class ReferenceSessionController(
 
     override suspend fun start(): Unit {
         emitAutomationLog(
-            "REFERENCE_AUTOMATION session.controller.start kind=$currentKind platform=$platformName"
+            "REFERENCE_AUTOMATION startup-state=session.controller.start.begin kind=$currentKind platform=$platformName"
         )
         runOnSupportedLiveController { controller -> controller.start() }
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.start.end kind=$currentKind platform=$platformName"
+        )
     }
 
     override suspend fun pause(): Unit {
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.pause.begin kind=$currentKind platform=$platformName"
+        )
         runOnSupportedLiveController { controller -> controller.pause() }
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.pause.end kind=$currentKind platform=$platformName"
+        )
     }
 
     override suspend fun resume(): Unit {
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.resume.begin kind=$currentKind platform=$platformName"
+        )
         runOnSupportedLiveController { controller -> controller.resume() }
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.resume.end kind=$currentKind platform=$platformName"
+        )
     }
 
     override suspend fun stop(): Unit {
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.stop.begin kind=$currentKind platform=$platformName"
+        )
         runOnSupportedLiveController { controller -> controller.stop() }
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.stop.end kind=$currentKind platform=$platformName"
+        )
     }
 
     override suspend fun sendPayload(
@@ -63,13 +84,25 @@ internal class ReferenceSessionController(
         payloadText: String,
         priority: DeliveryPriority,
     ): Unit {
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.sendPayload.begin kind=$currentKind platform=$platformName peerId=$peerId priority=$priority"
+        )
         runOnSupportedLiveController { controller ->
             controller.sendPayload(peerId = peerId, payloadText = payloadText, priority = priority)
         }
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.sendPayload.end kind=$currentKind platform=$platformName peerId=$peerId priority=$priority"
+        )
     }
 
     override suspend fun forgetPeer(peerId: String): Unit {
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.forgetPeer.begin kind=$currentKind platform=$platformName peerId=$peerId"
+        )
         runOnSupportedLiveController { controller -> controller.forgetPeer(peerId) }
+        emitAutomationLog(
+            "REFERENCE_AUTOMATION startup-state=session.controller.forgetPeer.end kind=$currentKind platform=$platformName peerId=$peerId"
+        )
     }
 
     override suspend fun close(): Unit {

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/BleTransportDiscoveryLifecycleTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/BleTransportDiscoveryLifecycleTest.kt
@@ -101,6 +101,7 @@ private class BleTransportDiscoveryLifecycleFixture {
             localKeyHash = ByteArray(12) { index -> (index + 1).toByte() },
             handleScanResult = {},
             ensurePermissionsGranted = {},
+            foreignScanIgnoredCount = { 0 },
             log = {},
         )
 }

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupportTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupportTest.kt
@@ -29,7 +29,10 @@ class ScanResultSupportTest {
 
         // Assert
         assertNull(discovery)
-        assertEquals(emptyList(), logMessages)
+        assertEquals(
+            listOf("ignoring scan result without discovery payload addr=$DEVICE_ADDRESS"),
+            logMessages,
+        )
     }
 
     @Test

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/api/android/MeshLinkBootstrap.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/api/android/MeshLinkBootstrap.kt
@@ -1,12 +1,34 @@
 package ch.trancee.meshlink.api.android
 
 import android.content.Context
+import android.util.Log
 import ch.trancee.meshlink.api.MeshLinkBootstrap
+
+private const val MESH_LINK_BOOTSTRAP_LOG_TAG: String = "MeshLinkBootstrap"
+
+internal interface AndroidBootstrapContextCarrier {
+    val context: Context
+}
 
 /** Creates a typed MeshLink bootstrap handle from an Android application context. */
 public fun meshLinkBootstrap(context: Context): MeshLinkBootstrap {
-    return ContextBootstrap(context.applicationContext)
+    Log.i(
+        MESH_LINK_BOOTSTRAP_LOG_TAG,
+        "meshLinkBootstrap.begin thread=${Thread.currentThread().name}",
+    )
+    Log.i(MESH_LINK_BOOTSTRAP_LOG_TAG, "meshLinkBootstrap.applicationContext.begin")
+    val appContext = context.applicationContext
+    Log.i(
+        MESH_LINK_BOOTSTRAP_LOG_TAG,
+        "meshLinkBootstrap.applicationContext.end thread=${Thread.currentThread().name}",
+    )
+    val bootstrap =
+        object : MeshLinkBootstrap(), AndroidBootstrapContextCarrier {
+            override val context: Context = appContext
+        }
+    Log.i(
+        MESH_LINK_BOOTSTRAP_LOG_TAG,
+        "meshLinkBootstrap.end thread=${Thread.currentThread().name}",
+    )
+    return bootstrap
 }
-
-internal class ContextBootstrap internal constructor(internal val context: Context) :
-    MeshLinkBootstrap()

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/api/android/MeshLinkBootstrap.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/api/android/MeshLinkBootstrap.kt
@@ -1,10 +1,7 @@
 package ch.trancee.meshlink.api.android
 
 import android.content.Context
-import android.util.Log
 import ch.trancee.meshlink.api.MeshLinkBootstrap
-
-private const val MESH_LINK_BOOTSTRAP_LOG_TAG: String = "MeshLinkBootstrap"
 
 internal interface AndroidBootstrapContextCarrier {
     val context: Context
@@ -12,23 +9,8 @@ internal interface AndroidBootstrapContextCarrier {
 
 /** Creates a typed MeshLink bootstrap handle from an Android application context. */
 public fun meshLinkBootstrap(context: Context): MeshLinkBootstrap {
-    Log.i(
-        MESH_LINK_BOOTSTRAP_LOG_TAG,
-        "meshLinkBootstrap.begin thread=${Thread.currentThread().name}",
-    )
-    Log.i(MESH_LINK_BOOTSTRAP_LOG_TAG, "meshLinkBootstrap.applicationContext.begin")
     val appContext = context.applicationContext
-    Log.i(
-        MESH_LINK_BOOTSTRAP_LOG_TAG,
-        "meshLinkBootstrap.applicationContext.end thread=${Thread.currentThread().name}",
-    )
-    val bootstrap =
-        object : MeshLinkBootstrap(), AndroidBootstrapContextCarrier {
-            override val context: Context = appContext
-        }
-    Log.i(
-        MESH_LINK_BOOTSTRAP_LOG_TAG,
-        "meshLinkBootstrap.end thread=${Thread.currentThread().name}",
-    )
-    return bootstrap
+    return object : MeshLinkBootstrap(), AndroidBootstrapContextCarrier {
+        override val context: Context = appContext
+    }
 }

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/MeshLinkFactory.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/MeshLinkFactory.kt
@@ -4,7 +4,7 @@ import ch.trancee.meshlink.api.FactoryTestBootstrap
 import ch.trancee.meshlink.api.MeshLink
 import ch.trancee.meshlink.api.MeshLinkBootstrap
 import ch.trancee.meshlink.api.MeshLinkException
-import ch.trancee.meshlink.api.android.ContextBootstrap
+import ch.trancee.meshlink.api.android.AndroidBootstrapContextCarrier
 import ch.trancee.meshlink.config.MeshLinkConfig
 import ch.trancee.meshlink.engine.MeshEngine
 import ch.trancee.meshlink.platform.android.BleTransportAdapter
@@ -25,7 +25,7 @@ internal actual fun createMeshLink(config: MeshLinkConfig, bootstrap: MeshLinkBo
     }
 
     val androidContext =
-        (bootstrap as? ContextBootstrap)?.context
+        (bootstrap as? AndroidBootstrapContextCarrier)?.context
             ?: throw MeshLinkException.InvalidConfiguration(ANDROID_BOOTSTRAP_REQUIRED_MESSAGE)
     val secureStorage = PreferencesSecureStorage(androidContext, config.appId)
     val cryptoProvider = JcaCryptoProviderFactory.create()

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapter.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapter.kt
@@ -19,6 +19,7 @@ import ch.trancee.meshlink.transport.TransportMode
 import ch.trancee.meshlink.transport.TransportSendResult
 import ch.trancee.meshlink.transport.shouldUseMixedPlatformGattNotifyBearer
 import java.io.Closeable
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -95,12 +96,14 @@ internal class BleTransportAdapter(
     internal var l2capServerSocket: android.bluetooth.BluetoothServerSocket? = null
     internal var acceptLoopJob: Job? = null
     internal var started: Boolean = false
+    internal val foreignScanIgnoredCount = AtomicInteger(0)
     internal val discoveryLifecycle =
         BleTransportDiscoveryLifecycle(
             appId = appId,
             localKeyHash = localKeyHash,
             handleScanResult = ::handleScanResult,
             ensurePermissionsGranted = ::ensurePermissionsGranted,
+            foreignScanIgnoredCount = { foreignScanIgnoredCount.get() },
             log = ::log,
         )
 

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterScanSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterScanSupport.kt
@@ -12,6 +12,9 @@ import ch.trancee.meshlink.transport.evaluateRediscoveryWithoutLink
 import ch.trancee.meshlink.transport.shouldLocalPeerInitiateL2capConnection
 
 internal fun BleTransportAdapter.handleScanResult(result: ScanResult): Unit {
+    log(
+        "scan result addr=${result.device.address} rssi=${result.rssi} uuids=${result.scanRecord?.serviceUuids?.size ?: 0}"
+    )
     val discovery =
         parseDiscoveryScanResultOrNull(
             serviceUuids =
@@ -37,21 +40,29 @@ internal fun BleTransportAdapter.handleScanResult(result: ScanResult): Unit {
             "scan found ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} psm=${discovery.payload.l2capPsm} platform=${discovery.payload.platformFamily} addr=${result.device.address}"
         )
     }
-    val resolvedPeer =
-        peerRegistry
-            .upsertDiscovery(
-                hintPeerId = discovery.hintPeerId,
-                discovery =
-                    DiscoveredPeerDiscovery(
-                        address = result.device.address,
-                        keyHash = discovery.payload.keyHash,
-                        l2capPsm = discovery.payload.l2capPsm.toInt(),
-                        transportMode = discovery.transportMode,
-                        platformFamily = discovery.payload.platformFamily,
-                    ),
-            )
-            .also { update -> update.events.forEach(mutableEvents::tryEmit) }
-            .peer
+    val update =
+        peerRegistry.upsertDiscovery(
+            hintPeerId = discovery.hintPeerId,
+            discovery =
+                DiscoveredPeerDiscovery(
+                    address = result.device.address,
+                    keyHash = discovery.payload.keyHash,
+                    l2capPsm = discovery.payload.l2capPsm.toInt(),
+                    transportMode = discovery.transportMode,
+                    platformFamily = discovery.payload.platformFamily,
+                ),
+        )
+    if (update.events.isEmpty()) {
+        log(
+            "scan accepted ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} emitted=no-events"
+        )
+    } else {
+        log(
+            "scan accepted ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} emitted=${update.events.size}"
+        )
+    }
+    update.events.forEach(mutableEvents::tryEmit)
+    val resolvedPeer = update.peer
     maybeLogRediscoveryWithoutLink(
         peer = resolvedPeer,
         transportMode = discovery.transportMode,

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterScanSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterScanSupport.kt
@@ -23,7 +23,11 @@ internal fun BleTransportAdapter.handleScanResult(result: ScanResult): Unit {
             localMeshHash = currentDiscoveryPayload.meshHash,
             localKeyHash = localKeyHash,
             log = ::log,
-        ) ?: return
+        )
+            ?: run {
+                log("scan discovery skipped addr=${result.device.address} rssi=${result.rssi}")
+                return
+            }
 
     if (discovery.transportMode == TransportMode.L2CAP) {
         promoteTemporaryLink(address = result.device.address, hintPeerId = discovery.hintPeerId)
@@ -54,11 +58,11 @@ internal fun BleTransportAdapter.handleScanResult(result: ScanResult): Unit {
         )
     if (update.events.isEmpty()) {
         log(
-            "scan accepted ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} emitted=no-events"
+            "scan accepted ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} emitted=no-events peerId=${discovery.hintPeerId.value} addr=${result.device.address}"
         )
     } else {
         log(
-            "scan accepted ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} emitted=${update.events.size}"
+            "scan accepted ${discovery.hintPeerId.value.takeLast(6)} mode=${discovery.transportMode} emitted=${update.events.size} peerId=${discovery.hintPeerId.value} addr=${result.device.address}"
         )
     }
     update.events.forEach(mutableEvents::tryEmit)

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterScanSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterScanSupport.kt
@@ -22,6 +22,7 @@ internal fun BleTransportAdapter.handleScanResult(result: ScanResult): Unit {
             deviceAddress = result.device.address,
             localMeshHash = currentDiscoveryPayload.meshHash,
             localKeyHash = localKeyHash,
+            onForeignScanIgnored = { foreignScanIgnoredCount.incrementAndGet() },
             log = ::log,
         )
             ?: run {

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportDiscoveryLifecycle.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportDiscoveryLifecycle.kt
@@ -5,6 +5,7 @@ import android.bluetooth.le.AdvertiseSettings
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
 import ch.trancee.meshlink.power.PowerPolicy
+import ch.trancee.meshlink.transport.BleDiscoveryContract
 import ch.trancee.meshlink.transport.BleDiscoveryPayload
 
 internal data class BleTransportDiscoveryHardware(
@@ -104,7 +105,10 @@ internal class BleTransportDiscoveryLifecycle(
 
     fun refresh(started: Boolean, hardware: BleTransportDiscoveryHardware): Unit {
         log(
-            "refreshDiscoveryState started=$started suspended=$isDiscoverySuspended scanner=${hardware.hasScanner} advertiser=${hardware.hasAdvertiser} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name}"
+            "refreshDiscoveryState started=$started suspended=$isDiscoverySuspended scanner=${hardware.hasScanner} advertiser=${hardware.hasAdvertiser} activeMeshHash=${BleDiscoveryContract.computeMeshHash(appId)} advertisedMeshHash=${currentDiscoveryPayload.meshHash} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name}"
+        )
+        log(
+            "discovery.summary activeMeshHash=${BleDiscoveryContract.computeMeshHash(appId)} advertisedMeshHash=${currentDiscoveryPayload.meshHash} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name}"
         )
         stop(hardware)
         if (!started || isDiscoverySuspended) {

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportDiscoveryLifecycle.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportDiscoveryLifecycle.kt
@@ -24,10 +24,12 @@ internal class BleTransportDiscoveryLifecycle(
     localKeyHash: ByteArray,
     private val handleScanResult: (ScanResult) -> Unit,
     private val ensurePermissionsGranted: () -> Unit,
+    private val foreignScanIgnoredCount: () -> Int,
     private val log: (String) -> Unit,
 ) {
     private val appId: String = appId
     private val localKeyHash: ByteArray = localKeyHash.copyOf()
+    private val localMeshHash: UShort = BleDiscoveryContract.computeMeshHash(appId)
 
     var currentPowerProfile: PowerProfile = PowerMonitor.defaultProfile()
         private set
@@ -105,10 +107,10 @@ internal class BleTransportDiscoveryLifecycle(
 
     fun refresh(started: Boolean, hardware: BleTransportDiscoveryHardware): Unit {
         log(
-            "refreshDiscoveryState started=$started suspended=$isDiscoverySuspended scanner=${hardware.hasScanner} advertiser=${hardware.hasAdvertiser} activeMeshHash=${BleDiscoveryContract.computeMeshHash(appId)} advertisedMeshHash=${currentDiscoveryPayload.meshHash} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name}"
+            "refreshDiscoveryState started=$started suspended=$isDiscoverySuspended scanner=${hardware.hasScanner} advertiser=${hardware.hasAdvertiser} activeMeshHash=$localMeshHash advertisedMeshHash=${currentDiscoveryPayload.meshHash} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name} foreignScanIgnoredCount=${foreignScanIgnoredCount()}"
         )
         log(
-            "discovery.summary activeMeshHash=${BleDiscoveryContract.computeMeshHash(appId)} advertisedMeshHash=${currentDiscoveryPayload.meshHash} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name}"
+            "discovery.summary activeMeshHash=$localMeshHash advertisedMeshHash=${currentDiscoveryPayload.meshHash} psm=${currentDiscoveryPayload.l2capPsm} carrier=${AndroidDiscoveryAdvertisementConfig.carrier.name} foreignScanIgnoredCount=${foreignScanIgnoredCount()}"
         )
         stop(hardware)
         if (!started || isDiscoverySuspended) {

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupport.kt
@@ -43,13 +43,26 @@ internal fun parseDiscoveryScanResultOrNull(
 ): DiscoveryScanResult? {
     val payloadUuid =
         serviceUuids?.firstOrNull { uuid -> !BleDiscoveryContract.isAdvertisementServiceUuid(uuid) }
-            ?: return null
+            ?: run {
+                log("ignoring scan result without discovery payload addr=$deviceAddress")
+                return null
+            }
     val payload =
-        runCatching { BleDiscoveryPayload.fromUuidString(payloadUuid) }.getOrNull() ?: return null
+        runCatching { BleDiscoveryPayload.fromUuidString(payloadUuid) }.getOrNull()
+            ?: run {
+                log(
+                    "ignoring discovery payload with invalid encoding addr=$deviceAddress payloadUuid=$payloadUuid"
+                )
+                return null
+            }
     if (payload.meshHash != localMeshHash) {
+        log(
+            "ignoring discovery payload with mismatched meshHash addr=$deviceAddress payloadUuid=$payloadUuid localMeshHash=$localMeshHash remoteMeshHash=${payload.meshHash}"
+        )
         return null
     }
     if (payload.keyHash.contentEquals(localKeyHash)) {
+        log("ignoring self-discovery payload addr=$deviceAddress payloadUuid=$payloadUuid")
         return null
     }
     if (!BleDiscoveryContract.isSupportedProtocolVersion(payload.protocolVersion)) {

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupport.kt
@@ -39,6 +39,7 @@ internal fun parseDiscoveryScanResultOrNull(
     deviceAddress: String,
     localMeshHash: UShort,
     localKeyHash: ByteArray,
+    onForeignScanIgnored: () -> Unit = {},
     log: (String) -> Unit,
 ): DiscoveryScanResult? {
     val payloadUuid =
@@ -56,6 +57,7 @@ internal fun parseDiscoveryScanResultOrNull(
                 return null
             }
     if (payload.meshHash != localMeshHash) {
+        onForeignScanIgnored()
         log(
             "ignoring discovery payload with mismatched meshHash addr=$deviceAddress payloadUuid=$payloadUuid localMeshHash=$localMeshHash remoteMeshHash=${payload.meshHash}"
         )

--- a/reports/android-direct-proof-fleet/README.md
+++ b/reports/android-direct-proof-fleet/README.md
@@ -1,0 +1,14 @@
+# Android direct-proof fleet outputs
+
+Canonical artifacts for a matrix run live under `runs/<timestamp>/`.
+
+## Read these first
+
+- `matrix-report.md` — fleet overview, foreign-scan summary, and run setup notes.
+- `matrix-results.json` — machine-readable per-pair results.
+- `fleet.json` — fleet inventory plus `foreignScanSummary` for downstream tooling.
+- `progress.json` — resumable checkpoint payload; includes `results` and `foreignScanSummary`.
+
+## Pair reports
+
+Each pair run writes `01_<pair>_report.md` with the per-run foreign-scan breakdown and the pair-specific explanation block.


### PR DESCRIPTION
## Summary
- Add foreign-scan diagnostics to the Android direct-proof reporting flow, including sender/passive focus sections, top foreign peers, and a capture-stall note when passive discovery is flooded with mismatched mesh hashes.
- Export the foreign-scan summary in machine-readable form (`fleet.json`, `progress.json`) and surface it in the fleet / pair report prose so downstream tooling and humans see the same totals.
- Fix the matrix timestamp parsing warning and add a small README in `reports/android-direct-proof-fleet/` that points to the canonical outputs and explains how to read the new summaries.

## Verification
- python -m py_compile on the updated scripts
- Fresh direct-proof matrix reruns completed successfully enough to render the new summaries and diagnostics