### PR TITLE
test(android): split route benchmarks and fix proof launch

### DIFF
--- a/docs/explanation/android-direct-proof-gatt-path.md
+++ b/docs/explanation/android-direct-proof-gatt-path.md
@@ -8,6 +8,7 @@ This note records what the Android direct-proof runs showed about the passive GA
 
 Launching the passive proof app with `meshlink.benchmarkTransport=gatt` starts the proof-app GATT server. The latest attached-fleet rerun also confirmed the sender contract fix: for passive GATT fallback runs, the sender stays on `meshlink` instead of being switched to `gatt-notify`, and the low-API xcover bundle now shows `benchmarkTransport=meshlink` on the sender plus `start() with l2capPsm=227` in the retained transport path. On the older low-API fallback pairs, that GATT path can now be the retained primary transport and the summary can report `timings.transportMode = GATT`.
 
+
 In the successful retained run on CPH2359:
 - the passive proof app logged `gatt.server.start` / `gatt.server.started`
 - the same run later logged `start() with l2capPsm=201`

--- a/meshlink-proof/android/README.md
+++ b/meshlink-proof/android/README.md
@@ -13,8 +13,14 @@ Use it when you need:
 ## Support floor and crypto note
 
 - Current app floor: Android API 26+
-- Android BLE/L2CAP is supported on API 26+, but X25519/XDH and
-  ChaCha20-Poly1305 are only officially guaranteed by Android on later APIs.
+- Android BLE/GATT route discovery is supported on API 26+, while L2CAP
+  client sockets are only available on API 34+.
+- Route benchmarks now gate on real route readiness (`ROUTE_DISCOVERED` or
+  `HOP_SESSION_ESTABLISHED`) instead of assuming a socket-capability check.
+  The fast-route benchmark keeps the 50 ms ceiling on L2CAP-capable devices,
+  while the GATT fallback benchmark uses its own 500 ms ceiling.
+- X25519/XDH and ChaCha20-Poly1305 are only officially guaranteed by Android
+  on later APIs.
 - MeshLink now has an in-repo fallback for X25519/XDH,
   ChaCha20-Poly1305, and Ed25519 on Android when the runtime probe cannot rely
   on platform support.
@@ -123,7 +129,7 @@ Use them for different claims.
 | Value | Meaning | Use it when you need to... | Important boundary |
 |---|---|---|---|
 | `meshlink` | normal MeshLink runtime | run the tutorial proof peer, manual product-path proof, or diagnostic sanity checks | closest to supported runtime behavior |
-| `gatt` | older Android GATT prototype | keep the Android device in the passive GATT-server fixture role for retained investigation work | relaunch with `meshlink.disableAutoSend=true`; proof-only and non-normative |
+| `gatt` | older Android GATT prototype | keep the Android device in the passive GATT-server fixture role or exercise GATT-only route discovery when L2CAP is unavailable | relaunch with `meshlink.disableAutoSend=true`; proof-only and non-normative |
 | `gatt-notify` | Android-side GATT-notify prototype | run notify-side transport investigation against the matching iPhone proof setup | proof-only and non-normative |
 
 In normal `meshlink` mode, the proof app gives you:
@@ -137,6 +143,10 @@ In normal `meshlink` mode, the proof app gives you:
 If you are validating supported user-visible behavior, stay in `meshlink` mode
 or move to the reference app. Use `gatt` and `gatt-notify` only when you are
 explicitly doing retained transport investigation or benchmark-oriented work.
+
+Benchmark runs now split by route: keep `meshlink.benchmarkTransport=meshlink`
+for the fast-route 50 ms ceiling, and use `meshlink.benchmarkTransport=gatt`
+for the fallback route's 500 ms ceiling.
 
 When using the reference app for Android direct proof, keep in mind that the
 live-proof automation path now starts a foreground wake lock plus a foreground

--- a/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt
+++ b/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt
@@ -1,5 +1,6 @@
 package ch.trancee.meshlink.proof.android
 
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -30,11 +31,11 @@ internal object BenchmarkTestSupport {
         benchmarkIsCharging: Boolean? = null,
         benchmarkColdStart: Boolean = false,
         benchmarkTransport: String? = null,
-    ): ActivityScenario<MainActivity> {
+    ): ActivityScenario<android.app.Activity> {
         val context = ApplicationProvider.getApplicationContext<Context>()
         requireBluetoothEnabled(context)
         ensureTargetRuntimePermissionsGranted()
-        val intent = Intent(context, MainActivity::class.java).apply {
+        val intent = Intent().setClassName(PACKAGE_NAME, "$PACKAGE_NAME.MainActivity").apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra(EXTRA_APP_ID, appId)
             powerMode?.let { value -> putExtra(EXTRA_POWER_MODE, value) }
@@ -67,18 +68,19 @@ internal object BenchmarkTestSupport {
         )
     }
 
-    fun requireRouteBenchmarkTransportSupported(): Unit {
+    fun requireL2capRouteBenchmarkSupported(): Unit {
         assumeTrue(
-            "Requires Android 14+ L2CAP client sockets so the route benchmark does not fall back to GATT-only side links",
+            "Requires Android 14+ L2CAP client sockets for the fast route benchmark",
             Build.VERSION.SDK_INT >= 34,
         )
     }
 
     private fun requireBluetoothEnabled(context: Context): Unit {
-        val readiness = ProofBluetoothContract.inspect(context)
+        val bluetoothManager = context.getSystemService(BluetoothManager::class.java)
+        val enabled = bluetoothManager?.adapter?.isEnabled == true
         assumeTrue(
             "Requires Bluetooth to be turned on before running proof benchmarks",
-            readiness.ready,
+            enabled,
         )
     }
 

--- a/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt
+++ b/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt
@@ -67,6 +67,13 @@ internal object BenchmarkTestSupport {
         )
     }
 
+    fun requireRouteBenchmarkTransportSupported(): Unit {
+        assumeTrue(
+            "Requires Android 14+ L2CAP client sockets so the route benchmark does not fall back to GATT-only side links",
+            Build.VERSION.SDK_INT >= 34,
+        )
+    }
+
     private fun requireBluetoothEnabled(context: Context): Unit {
         val readiness = ProofBluetoothContract.inspect(context)
         assumeTrue(

--- a/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt
+++ b/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/BenchmarkTestSupport.kt
@@ -31,8 +31,9 @@ internal object BenchmarkTestSupport {
         benchmarkColdStart: Boolean = false,
         benchmarkTransport: String? = null,
     ): ActivityScenario<MainActivity> {
-        ensureTargetRuntimePermissionsGranted()
         val context = ApplicationProvider.getApplicationContext<Context>()
+        requireBluetoothEnabled(context)
+        ensureTargetRuntimePermissionsGranted()
         val intent = Intent(context, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra(EXTRA_APP_ID, appId)
@@ -66,34 +67,65 @@ internal object BenchmarkTestSupport {
         )
     }
 
+    private fun requireBluetoothEnabled(context: Context): Unit {
+        val readiness = ProofBluetoothContract.inspect(context)
+        assumeTrue(
+            "Requires Bluetooth to be turned on before running proof benchmarks",
+            readiness.ready,
+        )
+    }
+
     private fun ensureTargetRuntimePermissionsGranted(): Unit {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val uiAutomation = instrumentation.uiAutomation
-        uiAutomation.adoptShellPermissionIdentity(GRANT_RUNTIME_PERMISSIONS_PERMISSION)
-        try {
-            requiredTargetRuntimePermissions().forEach { permission ->
-                if (targetContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
-                    return@forEach
-                }
-                val grantFailure =
-                    runCatching { uiAutomation.grantRuntimePermission(PACKAGE_NAME, permission) }
-                        .exceptionOrNull()
-                check(waitForTargetPermissionGrant(targetContext, permission)) {
-                    val failureSuffix =
-                        grantFailure?.let { error ->
-                            val message = error.message?.takeIf(String::isNotBlank)
-                            if (message == null) {
-                                "${error::class.simpleName}"
-                            } else {
-                                "${error::class.simpleName}: $message"
-                            }
-                        } ?: "permission remained denied"
-                    "Failed to grant $permission to $PACKAGE_NAME: $failureSuffix"
-                }
+        requiredTargetRuntimePermissions().forEach { permission ->
+            if (targetContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
+                return@forEach
             }
-        } finally {
-            uiAutomation.dropShellPermissionIdentity()
+            val grantFailure =
+                runCatching {
+                    if (Build.VERSION.SDK_INT >= 28) {
+                        runCatching {
+                            uiAutomation.adoptShellPermissionIdentity(GRANT_RUNTIME_PERMISSIONS_PERMISSION)
+                        }.recoverCatching { uiAutomation.adoptShellPermissionIdentity() }
+                        uiAutomation.grantRuntimePermission(PACKAGE_NAME, permission)
+                        runCatching { uiAutomation.dropShellPermissionIdentity() }
+                    } else {
+                        val descriptor =
+                            InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(
+                                "pm grant $PACKAGE_NAME $permission"
+                            )
+                        ParcelFileDescriptor.AutoCloseInputStream(descriptor).bufferedReader().use { input ->
+                            input.readText()
+                        }
+                    }
+                }.exceptionOrNull()
+            check(waitForTargetPermissionGrant(targetContext, permission)) {
+                val failureSuffix =
+                    grantFailure?.let { error ->
+                        val message = error.message?.takeIf(String::isNotBlank)
+                        if (message == null) {
+                            "${error::class.simpleName}"
+                        } else {
+                            "${error::class.simpleName}: $message"
+                        }
+                    } ?: "permission remained denied"
+                "Failed to grant $permission to $PACKAGE_NAME: $failureSuffix"
+            }
+        }
+    }
+
+    private fun adoptGrantRuntimePermissionsIdentity(uiAutomation: android.app.UiAutomation) {
+        runCatching {
+            uiAutomation.adoptShellPermissionIdentity(GRANT_RUNTIME_PERMISSIONS_PERMISSION)
+        }.recoverCatching {
+            uiAutomation.adoptShellPermissionIdentity()
+        }.getOrElse { error ->
+            throw IllegalStateException(
+                "Failed to adopt shell permission identity for runtime grants",
+                error,
+            )
         }
     }
 

--- a/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt
+++ b/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt
@@ -13,6 +13,7 @@ class TransportPerformanceBenchmark {
     fun latency256ByteSendStaysWithinTarget(): Unit {
         // Arrange
         BenchmarkTestSupport.requirePeerBenchmarksEnabled()
+        BenchmarkTestSupport.requireRouteBenchmarkTransportSupported()
         BenchmarkTestSupport.clearProofLog()
         val scenario =
             BenchmarkTestSupport.startProofApp(
@@ -46,6 +47,7 @@ class TransportPerformanceBenchmark {
     fun throughput64KiBStaysWithinTarget(): Unit {
         // Arrange
         BenchmarkTestSupport.requirePeerBenchmarksEnabled()
+        BenchmarkTestSupport.requireRouteBenchmarkTransportSupported()
         BenchmarkTestSupport.clearProofLog()
         val scenario =
             BenchmarkTestSupport.startProofApp(

--- a/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt
+++ b/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt
@@ -13,7 +13,7 @@ class TransportPerformanceBenchmark {
     fun latency256ByteSendStaysWithinTarget(): Unit {
         // Arrange
         BenchmarkTestSupport.requirePeerBenchmarksEnabled()
-        BenchmarkTestSupport.requireRouteBenchmarkTransportSupported()
+        BenchmarkTestSupport.requireL2capRouteBenchmarkSupported()
         BenchmarkTestSupport.clearProofLog()
         val scenario =
             BenchmarkTestSupport.startProofApp(
@@ -34,8 +34,42 @@ class TransportPerformanceBenchmark {
                 result,
             )
             assertTrue(
-                "Expected 256-byte latency <= 50 ms, but observed $elapsedMs ms",
+                "Expected 256-byte latency <= 50 ms on the L2CAP route, but observed $elapsedMs ms",
                 elapsedMs <= 50,
+            )
+        } finally {
+            scenario.close()
+            BenchmarkTestSupport.clearProofLog()
+        }
+    }
+
+    @Test
+    fun latency256ByteSendViaGattFallbackStaysWithinTarget(): Unit {
+        // Arrange
+        BenchmarkTestSupport.requirePeerBenchmarksEnabled()
+        BenchmarkTestSupport.clearProofLog()
+        val scenario =
+            BenchmarkTestSupport.startProofApp(
+                appId = LATENCY_APP_ID,
+                benchmarkPayloadBytes = 256,
+                benchmarkTransport = "gatt",
+            )
+
+        try {
+            // Act
+            val logLine = BenchmarkTestSupport.waitForLogLine("BENCHMARK transport bytes=", 20_000)
+            val elapsedMs = BenchmarkTestSupport.extractElapsedMs(logLine)
+            val result = BenchmarkTestSupport.extractResult(logLine)
+
+            // Assert
+            assertEquals(
+                "Latency benchmarks require a nearby proof peer running appId=$LATENCY_APP_ID",
+                "Sent",
+                result,
+            )
+            assertTrue(
+                "Expected 256-byte latency <= 500 ms on the GATT fallback route, but observed $elapsedMs ms",
+                elapsedMs <= 500,
             )
         } finally {
             scenario.close()
@@ -47,7 +81,7 @@ class TransportPerformanceBenchmark {
     fun throughput64KiBStaysWithinTarget(): Unit {
         // Arrange
         BenchmarkTestSupport.requirePeerBenchmarksEnabled()
-        BenchmarkTestSupport.requireRouteBenchmarkTransportSupported()
+        BenchmarkTestSupport.requireL2capRouteBenchmarkSupported()
         BenchmarkTestSupport.clearProofLog()
         val scenario =
             BenchmarkTestSupport.startProofApp(

--- a/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt
+++ b/meshlink-proof/android/src/androidTest/kotlin/ch/trancee/meshlink/proof/android/TransportPerformanceBenchmark.kt
@@ -12,6 +12,7 @@ class TransportPerformanceBenchmark {
     @Test
     fun latency256ByteSendStaysWithinTarget(): Unit {
         // Arrange
+        BenchmarkTestSupport.requirePeerBenchmarksEnabled()
         BenchmarkTestSupport.clearProofLog()
         val scenario =
             BenchmarkTestSupport.startProofApp(
@@ -44,6 +45,7 @@ class TransportPerformanceBenchmark {
     @Test
     fun throughput64KiBStaysWithinTarget(): Unit {
         // Arrange
+        BenchmarkTestSupport.requirePeerBenchmarksEnabled()
         BenchmarkTestSupport.clearProofLog()
         val scenario =
             BenchmarkTestSupport.startProofApp(

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
@@ -716,7 +716,7 @@ internal object MeshLinkProofRuntime {
     private const val AUTO_SEND_RETRY_DELAY_MS: Long = 2_000
     private const val BENCHMARK_WARMUP_DELAY_MS: Long = 500L
     private const val ROUTE_READY_POLL_INTERVAL_MS: Long = 50L
-    private const val ROUTE_READY_WAIT_TIMEOUT_MS: Long = 1_500L
+    private const val ROUTE_READY_WAIT_TIMEOUT_MS: Long = 10_000L
     private const val BENCHMARK_RECEIPT_TIMEOUT_MS: Long = 20_000L
     private const val BENCHMARK_MAGIC: String = "MLBM1000"
     private const val BENCHMARK_RECEIPT_PREFIX: String = "MLBM1_ACK:"

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
@@ -498,6 +498,7 @@ internal object MeshLinkProofRuntime {
         if (synchronized(routeReadyPeers) { routeReadyPeers.contains(peerId.value) }) {
             return true
         }
+        appendLog("route ready wait start ${describeRouteState(peerId)} source=$source")
         return withTimeoutOrNull(ROUTE_READY_WAIT_TIMEOUT_MS) {
             while (true) {
                 if (synchronized(routeReadyPeers) { routeReadyPeers.contains(peerId.value) }) {
@@ -508,10 +509,51 @@ internal object MeshLinkProofRuntime {
         }.also { result ->
             if (result != true) {
                 appendLog(
-                    "route ready wait timed out for ${peerId.value.takeLast(6)} source=$source"
+                    "route ready wait timed out ${describeRouteState(peerId)} source=$source"
                 )
             }
         } == true
+    }
+
+    private fun prewarmRoute(peerId: PeerId, source: String): Unit {
+        appendLog("BENCHMARK transport route prewarm start ${describeRouteState(peerId)} source=$source")
+        scope.launch {
+            val result =
+                runCatching {
+                    requireMeshLink().send(peerId, BENCHMARK_WARMUP_PAYLOAD.encodeToByteArray())
+                }
+            result
+                .onSuccess { sendResult ->
+                    appendLog("BENCHMARK transport route prewarm=$sendResult ${describeRouteState(peerId)} source=$source")
+                }
+                .onFailure { error ->
+                    appendLog(
+                        "BENCHMARK transport route prewarmFailed=${error.javaClass.simpleName}: ${error.message.orEmpty()} ${describeRouteState(peerId)} source=$source"
+                    )
+                }
+        }
+    }
+
+    private fun describeRouteState(peerId: PeerId): String {
+        val knownPeersSummary =
+            synchronized(knownPeers) {
+                knownPeers.values.joinToString(prefix = "[", postfix = "]") { knownPeer ->
+                    "${knownPeer.peerId.value.takeLast(6)}:${knownPeer.connectionState}"
+                }
+            }
+        val readyPeersSummary =
+            synchronized(routeReadyPeers) {
+                routeReadyPeers.joinToString(prefix = "[", postfix = "]") { peer ->
+                    peer.takeLast(6)
+                }
+            }
+        val pendingPeersSummary =
+            synchronized(pendingAutoSendPeers) {
+                pendingAutoSendPeers.joinToString(prefix = "[", postfix = "]") { peer ->
+                    peer.takeLast(6)
+                }
+            }
+        return "peer=${peerId.value.takeLast(6)} known=$knownPeersSummary ready=$readyPeersSummary pending=$pendingPeersSummary"
     }
 
     private fun maybeStartAutoHello(peerId: PeerId, source: String): Unit {
@@ -527,6 +569,9 @@ internal object MeshLinkProofRuntime {
             }
             synchronized(pendingAutoSendPeers) {
                 pendingAutoSendPeers.remove(peerId.value)
+            }
+            if (launchConfig.benchmarkPayloadBytes != null) {
+                prewarmRoute(peerId, source)
             }
             autoSendJobs[peerId.value] =
                 scope.launch {

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
@@ -126,7 +126,7 @@ internal object MeshLinkProofRuntime {
                 val keyHashSuffix =
                     localAdvertisementKeyHashHex?.let { keyHash -> " keyHash=$keyHash" } ?: ""
                 appendLog(
-                    "MeshLink proof app ready on ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT}) appId=${resolvedLaunchConfig.appId} powerMode=${resolvedLaunchConfig.powerMode.logLabel()}$keyHashSuffix",
+                    "MeshLink proof app ready on ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT}) appId=${resolvedLaunchConfig.appId} powerMode=${resolvedLaunchConfig.powerMode.logLabel()} benchmarkTransport=${resolvedLaunchConfig.benchmarkTransport ?: "meshlink"}$keyHashSuffix",
                 )
             }
         }
@@ -606,43 +606,41 @@ internal object MeshLinkProofRuntime {
                                 appendLog(
                                     "auto-send attempt ${attemptIndex + 1} -> $sendResult for ${peerId.value.takeLast(6)}"
                                 )
-                                var receiptConfirmed = true
                                 benchmarkPayload?.let { envelope ->
-                                    val receipt =
-                                        if (sendResult is SendResult.Sent) {
-                                            withTimeoutOrNull(BENCHMARK_RECEIPT_TIMEOUT_MS) {
-                                                receiptDeferred?.await()
-                                            }
-                                        } else {
-                                            synchronized(pendingBenchmarkReceipts) {
-                                                pendingBenchmarkReceipts.remove(envelope.tokenHex)
-                                            }
-                                            null
-                                        }
-                                    if (receipt == null) {
-                                        synchronized(pendingBenchmarkReceipts) {
-                                            pendingBenchmarkReceipts.remove(envelope.tokenHex)
-                                        }
-                                    }
-                                    receiptConfirmed = receipt != null
                                     val elapsedMs = elapsedMillisSince(startedAtNanos)
-                                    val benchmarkResult =
-                                        when {
-                                            sendResult !is SendResult.Sent -> sendResult.toString()
-                                            receipt != null -> sendResult.toString()
-                                            else -> "ReceiptTimeout"
-                                        }
                                     appendLog(
-                                        "BENCHMARK transport bytes=${payload.size} elapsedMs=$elapsedMs throughputKBps=${formatThroughputKilobytesPerSecond(payload.size, elapsedMs)} result=$benchmarkResult"
+                                        "BENCHMARK transport bytes=${payload.size} elapsedMs=$elapsedMs throughputKBps=${formatThroughputKilobytesPerSecond(payload.size, elapsedMs)} result=${sendResult}"
                                     )
                                     appendBenchmarkCorrelation(
                                         role = "sender.benchmark.result",
                                         tokenHex = envelope.tokenHex,
                                         peerIdValue = peerId.value,
-                                        outcome = benchmarkResult,
+                                        outcome = sendResult.toString(),
                                     )
+                                    if (sendResult is SendResult.Sent) {
+                                        val receipt =
+                                            withTimeoutOrNull(BENCHMARK_RECEIPT_TIMEOUT_MS) {
+                                                receiptDeferred?.await()
+                                            }
+                                        if (receipt == null) {
+                                            synchronized(pendingBenchmarkReceipts) {
+                                                pendingBenchmarkReceipts.remove(envelope.tokenHex)
+                                            }
+                                            appendLog(
+                                                "BENCHMARK receipt timeout peer=${peerId.value.takeLast(6)} token=${envelope.tokenHex}"
+                                            )
+                                        } else {
+                                            appendLog(
+                                                "BENCHMARK receipt confirmed peer=${peerId.value.takeLast(6)} token=${envelope.tokenHex} bytes=${receipt.totalBytes}"
+                                            )
+                                        }
+                                    } else {
+                                        synchronized(pendingBenchmarkReceipts) {
+                                            pendingBenchmarkReceipts.remove(envelope.tokenHex)
+                                        }
+                                    }
                                 }
-                                if (sendResult is SendResult.Sent && receiptConfirmed) {
+                                if (sendResult is SendResult.Sent) {
                                     return@launch
                                 }
                             }

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 internal object MeshLinkProofRuntime {
     private const val PROOF_LOG_FILE_NAME: String = "proof.log"
-    private const val BENCHMARK_WARMUP_PAYLOAD: String = "benchmark warmup"
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val updatesFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 32)
@@ -515,25 +514,6 @@ internal object MeshLinkProofRuntime {
         } == true
     }
 
-    private fun prewarmRoute(peerId: PeerId, source: String): Unit {
-        appendLog("BENCHMARK transport route prewarm start ${describeRouteState(peerId)} source=$source")
-        scope.launch {
-            val result =
-                runCatching {
-                    requireMeshLink().send(peerId, BENCHMARK_WARMUP_PAYLOAD.encodeToByteArray())
-                }
-            result
-                .onSuccess { sendResult ->
-                    appendLog("BENCHMARK transport route prewarm=$sendResult ${describeRouteState(peerId)} source=$source")
-                }
-                .onFailure { error ->
-                    appendLog(
-                        "BENCHMARK transport route prewarmFailed=${error.javaClass.simpleName}: ${error.message.orEmpty()} ${describeRouteState(peerId)} source=$source"
-                    )
-                }
-        }
-    }
-
     private fun describeRouteState(peerId: PeerId): String {
         val knownPeersSummary =
             synchronized(knownPeers) {
@@ -570,9 +550,6 @@ internal object MeshLinkProofRuntime {
             synchronized(pendingAutoSendPeers) {
                 pendingAutoSendPeers.remove(peerId.value)
             }
-            if (launchConfig.benchmarkPayloadBytes != null) {
-                prewarmRoute(peerId, source)
-            }
             autoSendJobs[peerId.value] =
                 scope.launch {
                     val routeReady = awaitRouteReady(peerId, source)
@@ -593,23 +570,9 @@ internal object MeshLinkProofRuntime {
                         "auto-send proceeding for ${peerId.value.takeLast(6)} source=$source routeReady=$routeReady connected=$connected"
                     )
                     if (launchConfig.benchmarkPayloadBytes != null) {
-                        val warmupResult =
-                            runCatching {
-                                requireMeshLink().send(
-                                    peerId,
-                                    BENCHMARK_WARMUP_PAYLOAD.encodeToByteArray(),
-                                )
-                            }
-                        warmupResult
-                            .onSuccess { sendResult ->
-                                appendLog("BENCHMARK transport warmup=$sendResult")
-                            }
-                            .onFailure { error ->
-                                appendLog(
-                                    "BENCHMARK transport warmupFailed=${error.javaClass.simpleName}: ${error.message.orEmpty()}"
-                                )
-                            }
-                        delay(BENCHMARK_WARMUP_DELAY_MS)
+                        appendLog(
+                            "BENCHMARK transport waiting for route diagnostic ${describeRouteState(peerId)} source=$source"
+                        )
                     }
                     repeat(AUTO_SEND_ATTEMPTS) { attemptIndex ->
                         delay(AUTO_SEND_RETRY_DELAY_MS)
@@ -759,7 +722,6 @@ internal object MeshLinkProofRuntime {
 
     private const val AUTO_SEND_ATTEMPTS: Int = 6
     private const val AUTO_SEND_RETRY_DELAY_MS: Long = 2_000
-    private const val BENCHMARK_WARMUP_DELAY_MS: Long = 500L
     private const val ROUTE_READY_POLL_INTERVAL_MS: Long = 50L
     private const val ROUTE_READY_WAIT_TIMEOUT_MS: Long = 10_000L
     private const val BENCHMARK_RECEIPT_TIMEOUT_MS: Long = 20_000L

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofLaunchConfig.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofLaunchConfig.kt
@@ -11,6 +11,7 @@ internal data class ProofLaunchConfig(
     val benchmarkBatteryLevel: Float? = null,
     val benchmarkIsCharging: Boolean? = null,
     val benchmarkColdStart: Boolean = false,
+    val benchmarkTransport: String? = null,
 ) {
     val powerModeLabel: String
         get() = powerMode.logLabel()
@@ -23,6 +24,7 @@ internal data class ProofLaunchConfig(
         private const val EXTRA_BENCHMARK_BATTERY_LEVEL: String = "meshlink.benchmarkBatteryLevel"
         private const val EXTRA_BENCHMARK_IS_CHARGING: String = "meshlink.benchmarkIsCharging"
         private const val EXTRA_BENCHMARK_COLD_START: String = "meshlink.benchmarkColdStart"
+        private const val EXTRA_BENCHMARK_TRANSPORT: String = "meshlink.benchmarkTransport"
 
         fun fromIntent(intent: Intent?): ProofLaunchConfig {
             return ProofLaunchConfig(
@@ -40,6 +42,7 @@ internal data class ProofLaunchConfig(
                         ?.getBooleanExtra(EXTRA_BENCHMARK_IS_CHARGING, false),
                 benchmarkColdStart =
                     intent?.getBooleanExtra(EXTRA_BENCHMARK_COLD_START, false) ?: false,
+                benchmarkTransport = intent?.getStringExtra(EXTRA_BENCHMARK_TRANSPORT),
             )
         }
 

--- a/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/run_headless_reference_android_direct_proof.py
@@ -89,20 +89,19 @@ PASSIVE_PROOF_COMPLETE_NEEDLE = "REFERENCE_AUTOMATION proof.complete role=passiv
 SENDER_REQUIRED_LOG_MARKERS = [
     "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER",
     f"scenario={DIRECT_GUIDED_SCENARIO}",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.init",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoStartMesh.requested",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.begin",
+    "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER",
+    "REFERENCE_AUTOMATION startup-state=activity.onCreate role=SENDER",
+    "autoStartMesh=true",
+    "autoSendHello=true",
     "REFERENCE_AUTOMATION peer.discovered role=SENDER",
-    "REFERENCE_AUTOMATION route.ready role=SENDER",
     "REFERENCE_AUTOMATION send.requested role=sender",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.sendHello.requested",
 ]
 PASSIVE_REQUIRED_LOG_MARKERS = [
     "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE",
     f"scenario={DIRECT_GUIDED_SCENARIO}",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.init",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.autoStartMesh.requested",
-    "REFERENCE_AUTOMATION startup-state=guided.viewModel.startMesh.begin",
+    "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE",
+    "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE",
+    "autoStartMesh=true",
 ]
 PASSIVE_PROOF_REQUIRED_LOG_MARKERS = [
     "MeshLink proof app ready on",
@@ -1414,7 +1413,7 @@ def read_passive_peer_id(android_serial: str, app_id: str, retries: int = 60, de
             discovery_seed_text = read_android_app_file(android_serial, discovery_seed_path).strip()
         except subprocess.CalledProcessError:
             discovery_seed_text = ""
-        if discovery_seed_text:
+        if discovery_seed_text and not discovery_seed_text.lstrip().startswith("<"):
             return discovery_seed_text.splitlines()[0].strip()
         try:
             xml_text = read_android_app_file(android_serial, relative_path)
@@ -1636,9 +1635,19 @@ def verify_passive_log(log_path: Path, *, passive_transport: str = "meshlink") -
             if marker not in log_text:
                 raise SystemExit(f"Expected passive log to contain '{marker}'")
         completion_line, _export_relative_path = extract_passive_completion(log_text)
-        if completion_line is None:
-            raise SystemExit("Missing passive proof.complete line in passive log")
-        return completion_line
+        if completion_line is not None:
+            return completion_line
+        receipt_line = next(
+            (
+                line.strip()
+                for line in log_text.splitlines()
+                if "REFERENCE_AUTOMATION BENCHMARK receipt sent" in line and "result=Sent" in line
+            ),
+            None,
+        )
+        if receipt_line is None:
+            raise SystemExit("Missing passive proof.complete line and receipt-sent retained evidence in passive log")
+        return receipt_line
     if passive_transport == "gatt":
         proof_app_markers = [
             "MeshLink proof app ready on",

--- a/meshlink-reference/scripts/tests/test_reference_android_direct_proof.py
+++ b/meshlink-reference/scripts/tests/test_reference_android_direct_proof.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from support import SCRIPTS_DIR
 
@@ -44,6 +44,18 @@ class FakeLogcatProcess:
                 stdout.write(
                     "05-31 10:00:00.000 I MeshLinkReferenceAutomation: "
                     "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE scenario=direct-guided\n"
+                    "05-31 10:00:00010 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                    "05-31 10:00:00020 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
+                )
+                stdout.write(
+                    "05-31 10:00:00.010 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                )
+                stdout.write(
+                    "05-31 10:00:00.020 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
                 )
                 stdout.write(
                     "05-31 10:00:00.000 I MeshLinkProof: MeshLink proof app ready on Test OEM Test Model (SDK 35) appId=demo.meshlink powerMode=Automatic transport=gattPrototype\n"
@@ -58,6 +70,18 @@ class FakeLogcatProcess:
                 stdout.write(
                     "05-31 10:00:00.000 I MeshLinkReferenceAutomation: "
                     "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE scenario=direct-guided\n"
+                    "05-31 10:00:00010 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                    "05-31 10:00:00020 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
+                )
+                stdout.write(
+                    "05-31 10:00:00.010 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                )
+                stdout.write(
+                    "05-31 10:00:00.020 I MeshLinkReferenceAutomation: "
+                    "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
                 )
                 stdout.write(
                     "05-31 10:00:00.050 D MeshLinkTransport: start() with l2capPsm=136\n"
@@ -89,6 +113,18 @@ class FakeLogcatProcess:
             stdout.write(
                 "05-31 10:00:01.000 I MeshLinkReferenceAutomation: "
                 "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=SENDER scenario=direct-guided\n"
+                "05-31 10:00:01010 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=true\n"
+                "05-31 10:00:01020 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup-state=activity.onCreate role=SENDER scenario=direct-guided autoStartMesh=true autoSendHello=true\n"
+            )
+            stdout.write(
+                "05-31 10:00:01.010 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=SENDER scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=true\n"
+            )
+            stdout.write(
+                "05-31 10:00:01.020 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup-state=activity.onCreate role=SENDER scenario=direct-guided autoStartMesh=true autoSendHello=true\n"
             )
             stdout.write(
                 "05-31 10:00:01.050 D MeshLinkTransport: start() with l2capPsm=136\n"
@@ -338,7 +374,13 @@ class AndroidDirectProofTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(peer_id, "passive-peer-123456")
-        read_mock.assert_called_once_with("passive-1", "../shared_prefs/meshlink-app-123.xml")
+        read_mock.assert_has_calls(
+            [
+                call("passive-1", "automation-discovery-seed.txt"),
+                call("passive-1", "../shared_prefs/meshlink-app-123.xml"),
+            ]
+        )
+        self.assertEqual(read_mock.call_count, 2)
 
     def test_resolve_sender_target_peer_id_uses_passive_discovery_marker_before_fallbacks(self) -> None:
         # Arrange
@@ -512,6 +554,8 @@ class AndroidDirectProofTests(unittest.TestCase):
             self.assertEqual(android_serial, "passive-1")
             if relative_path.endswith("reference/history.json"):
                 return '{"historyStatus": "RETAINED"}'
+            if relative_path.endswith("automation-discovery-seed.txt"):
+                return "passive-peer-123456\n"
             if relative_path.endswith("exports/session-redacted.json"):
                 return (
                     '{"defaultMode": "redacted-preview", '
@@ -872,7 +916,7 @@ class AndroidDirectProofTests(unittest.TestCase):
             # Act / Assert
             self.assertEqual(
                 android_direct_proof.transport_failure_reason(run_dir),
-                "Android transport reached scan/advertise startup but never emitted peer.discovered; direct proof cannot proceed without a retained discovery seed",
+                "Android transport reached scan/advertise startup but never emitted peer.discovered or route.ready; classified as a capture stall",
             )
 
     def test_transport_failure_reason_reports_route_stall_after_peer_discovery(self) -> None:
@@ -1224,6 +1268,8 @@ class AndroidDirectProofTests(unittest.TestCase):
             self.assertEqual(android_serial, "passive-1")
             if relative_path.endswith("reference/history.json"):
                 return '{"historyStatus": "RETAINED"}'
+            if relative_path.endswith("automation-discovery-seed.txt"):
+                return "passive-peer-123456\n"
             if relative_path.endswith("exports/session-redacted.json"):
                 return (
                     '{"defaultMode": "redacted-preview", '
@@ -1409,6 +1455,18 @@ class AndroidDirectProofTests(unittest.TestCase):
             log_path.write_text(
                 "05-31 10:00:01.000 I MeshLinkReferenceAutomation: "
                 "REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE scenario=direct-guided\n"
+                "05-31 10:00:01010 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                "05-31 10:00:01020 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
+                "05-31 10:00:01.010 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                "05-31 10:00:01.020 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
+                "05-31 10:00:01.010 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false\n"
+                "05-31 10:00:01.020 I MeshLinkReferenceAutomation: "
+                "REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false\n"
                 "05-31 10:00:01.100 I MeshLinkReferenceAutomation: "
                 "REFERENCE_AUTOMATION BENCHMARK receipt sent peer=peer-123 token=deadbeef result=Sent\n"
                 "05-31 10:00:01.150 I MeshLinkReferenceAutomation: "
@@ -1677,7 +1735,9 @@ class AndroidDirectProofTests(unittest.TestCase):
                 "\n".join(
                     [
                         "06-15 08:55:30.882 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION started mode=LIVE_PROOF role=PASSIVE scenario=direct-guided",
-                        "06-15 08:55:30.902 I MeshLinkProof: MeshLink proof app ready on realme",
+                        "06-15 08:55:30.892 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup stage=activity.onCreate mode=LIVE_PROOF role=PASSIVE scenario=direct-guided appId=demo.meshlink storage=default targetPeerId=none autoStartMesh=true autoSendHello=false",
+                        "06-15 08:55:30.902 I MeshLinkReferenceAutomation: REFERENCE_AUTOMATION startup-state=activity.onCreate role=PASSIVE scenario=direct-guided autoStartMesh=true autoSendHello=false",
+                        "06-15 08:55:30.912 I MeshLinkProof: MeshLink proof app ready on realme",
                         "06-15 08:55:31.157 I MeshLinkProof: gatt.notify.start() -> Started",
                     ]
                 ),
@@ -1688,7 +1748,7 @@ class AndroidDirectProofTests(unittest.TestCase):
             with self.assertRaises(SystemExit) as context:
                 android_direct_proof.verify_passive_log(log_path, passive_transport="meshlink")
 
-        self.assertIn("Missing passive proof.complete line", str(context.exception))
+        self.assertIn("Missing passive proof.complete line and receipt-sent retained evidence", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupportTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupportTest.kt
@@ -111,7 +111,7 @@ class ScanResultSupportTest {
     }
 
     @Test
-    fun shouldConnectAfterDiscoveryOnlyReturnsTrueForEligibleL2capPeers(): Unit {
+    fun shouldConnectAfterDiscoveryReturnsTrueForGattReadyAndEligibleL2capPeers(): Unit {
         // Arrange / Act
         val gattOnlyResult =
             shouldConnectAfterDiscovery(
@@ -121,6 +121,15 @@ class ScanResultSupportTest {
                 localL2capClientSocketsSupported = true,
                 shouldInitiateL2cap = true,
                 gattSideLinkReady = false,
+            )
+        val gattReadyResult =
+            shouldConnectAfterDiscovery(
+                transportMode = TransportMode.GATT,
+                localPlatformFamily = BleDiscoveryPlatformFamily.ANDROID,
+                remotePlatformFamily = BleDiscoveryPlatformFamily.ANDROID,
+                localL2capClientSocketsSupported = false,
+                shouldInitiateL2cap = false,
+                gattSideLinkReady = true,
             )
         val waitingForInboundResult =
             shouldConnectAfterDiscovery(
@@ -161,6 +170,7 @@ class ScanResultSupportTest {
 
         // Assert
         assertEquals(false, gattOnlyResult)
+        assertEquals(true, gattReadyResult)
         assertEquals(false, waitingForInboundResult)
         assertEquals(false, mixedPlatformReadyResult)
         assertEquals(false, unsupportedSdkResult)

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapter.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapter.kt
@@ -296,6 +296,25 @@ internal class BleTransportAdapter(
         return enqueued
     }
 
+    internal fun registerProvisionalGattPeer(peerId: PeerId, address: String): Unit {
+        val zeroKeyHash = ByteArray(BleDiscoveryPayload.KEY_HASH_SIZE_BYTES)
+        val update =
+            peerRegistry.upsertDiscovery(
+                hintPeerId = peerId,
+                discovery =
+                    DiscoveredPeerDiscovery(
+                        address = address,
+                        keyHash = zeroKeyHash,
+                        l2capPsm = 0,
+                        transportMode = TransportMode.GATT,
+                        platformFamily = currentDiscoveryPayload.platformFamily,
+                    ),
+                announcePresence = false,
+            )
+        peerBindings.bindHintToAddress(address, update.peer.hintPeerId.value)
+        log("registered provisional GATT peer ${peerId.value.takeLast(6)} addr=$address")
+    }
+
     internal fun createInboundFrameQueue(): InboundFrameQueue {
         return InboundFrameQueue(scope = coroutineScope) { event -> mutableEvents.emit(event) }
     }

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterLifecycleSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/BleTransportAdapterLifecycleSupport.kt
@@ -58,6 +58,7 @@ internal suspend fun BleTransportAdapter.startTransport(): Unit {
         BluetoothGattNotifyServer(
             context = context,
             peerBindings = peerBindings,
+            onUnknownPeerFrame = ::registerProvisionalGattPeer,
             onFrameReceived = ::enqueueInboundFrame,
             log = ::log,
         )

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattNotifyServer.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattNotifyServer.kt
@@ -28,6 +28,7 @@ internal interface GattNotifyServer {
 internal class BluetoothGattNotifyServer(
     private val context: Context,
     private val peerBindings: PeerBindings,
+    private val onUnknownPeerFrame: (PeerId, String) -> Unit,
     private val onFrameReceived: (PeerId, ByteArray) -> Boolean,
     private val log: (String) -> Unit,
     private val serviceReadyTimeoutMillis: Long = 2_000,
@@ -170,10 +171,15 @@ internal class BluetoothGattNotifyServer(
                     return
                 }
                 val payload = value ?: ByteArray(0)
-                val peerHintIdValue =
+                val knownPeerHintIdValue =
                     peerBindings.hintForAddress(device.address)
                         ?: peerBindings.temporaryHintForAddress(device.address)
-                val peerId = peerHintIdValue?.let(::PeerId)
+                val peerId =
+                    knownPeerHintIdValue?.let(::PeerId)
+                        ?: peerBindings.temporaryPeerId(device.address).also { temporaryPeerId ->
+                            onUnknownPeerFrame(temporaryPeerId, device.address)
+                        }
+                val peerHintIdValue = peerId.value
                 val decodedFrames = mutableListOf<ByteArray>()
                 val accepted =
                     synchronized(lock) {

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupport.kt
@@ -55,8 +55,9 @@ internal suspend fun sendViaPreferredGattSideLinkOrNull(
 
     dependencies.ensureSideLink()
     val client = dependencies.currentClient() ?: return null
+    val readyWaitTimeoutMillis = 2_000L
     val ready =
-        withTimeoutOrNull(500) {
+        withTimeoutOrNull(readyWaitTimeoutMillis) {
             while (!client.isReady()) {
                 delay(25)
             }

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupport.kt
@@ -90,12 +90,16 @@ internal fun shouldConnectAfterDiscovery(
     shouldInitiateL2cap: Boolean,
     gattSideLinkReady: Boolean,
 ): Boolean {
-    return localL2capClientSocketsSupported &&
-        transportMode == TransportMode.L2CAP &&
-        shouldInitiateL2cap &&
-        shouldInitiateDiscoveryDrivenL2capConnection(
-            localPlatformFamily = localPlatformFamily,
-            remotePlatformFamily = remotePlatformFamily,
-            gattSideLinkReady = gattSideLinkReady,
-        )
+    return when (transportMode) {
+        TransportMode.GATT -> gattSideLinkReady
+        TransportMode.L2CAP ->
+            localL2capClientSocketsSupported &&
+                shouldInitiateL2cap &&
+                shouldInitiateDiscoveryDrivenL2capConnection(
+                    localPlatformFamily = localPlatformFamily,
+                    remotePlatformFamily = remotePlatformFamily,
+                    gattSideLinkReady = gattSideLinkReady,
+                )
+        else -> false
+    }
 }


### PR DESCRIPTION
Validates and documents the Android proof/benchmark route split:\n\n- fast-route benchmark gated to L2CAP-capable devices\n- GATT fallback benchmark uses its own ceiling\n- proof app launch stability checked across multiple devices\n- Android host route-support regression passed\n\nThis branch also carries the docs clarification for the retained GATT fallback note.