### PR TITLE
fix(transport): keep gatt active with l2cap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ If you are not sure where to start, use one of these short paths.
 3. [About how MeshLink works](explanation/about-how-meshlink-works.md)
 4. [The trust model](explanation/trust-model.md)
 5. [The peer lifecycle model](explanation/peer-lifecycle.md)
-6. [About the L2CAP-first transport posture](explanation/why-l2cap-first.md)
+6. [About the L2CAP-preferred transport posture](explanation/why-l2cap-first.md)
 
 ### Contributor architecture
 
@@ -147,7 +147,7 @@ guessing which page owns which model.
 
 ### Routing and transport
 
-- [About the L2CAP-first transport posture](explanation/why-l2cap-first.md) — why MeshLink still thinks in L2CAP-first terms.
+- [About the L2CAP-preferred transport posture](explanation/why-l2cap-first.md) — why MeshLink prefers L2CAP while keeping GATT available alongside it.
 - [Cut-through relay](explanation/cut-through-relay.md) — why relays prefer forwarding without full reassembly.
 - [Physical reference-app integration findings](explanation/reference-app-physical-integration-findings.md) — what recent real-device runs taught us.
 - [Understanding Babel routing](explanation/understanding-babel-routing.md) — the routing ideas MeshLink borrows and adapts.

--- a/docs/explanation/about-how-meshlink-works.md
+++ b/docs/explanation/about-how-meshlink-works.md
@@ -283,5 +283,5 @@ That model explains most of the library's behavior:
 - [Understanding Babel routing](understanding-babel-routing.md)
 - [Cut-through relay](cut-through-relay.md)
 - [Power management](power-management.md)
-- [About the L2CAP-first transport posture](why-l2cap-first.md)
+- [About the L2CAP-preferred transport posture](why-l2cap-first.md)
 - [Discovery identity hash and privacy trade-offs](privacy-pseudonyms.md)

--- a/docs/explanation/cut-through-relay.md
+++ b/docs/explanation/cut-through-relay.md
@@ -87,4 +87,4 @@ large multi-hop transfers over BLE.
 - [Understanding Babel routing](understanding-babel-routing.md)
 - [About how MeshLink works](about-how-meshlink-works.md)
 - [MeshLink runtime behavior reference](../reference/meshlink-runtime-behavior.md)
-- [About the L2CAP-first transport posture](why-l2cap-first.md)
+- [About the L2CAP-preferred transport posture](why-l2cap-first.md)

--- a/docs/explanation/privacy-pseudonyms.md
+++ b/docs/explanation/privacy-pseudonyms.md
@@ -80,4 +80,4 @@ rotating-pseudonym design.
 - [The trust model](trust-model.md)
 - [MeshLink runtime behavior reference](../reference/meshlink-runtime-behavior.md)
 - [Regulatory compliance and region clamping](regulatory-compliance.md)
-- [About the L2CAP-first transport posture](why-l2cap-first.md)
+- [About the L2CAP-preferred transport posture](why-l2cap-first.md)

--- a/docs/explanation/why-l2cap-first.md
+++ b/docs/explanation/why-l2cap-first.md
@@ -1,13 +1,15 @@
-# About the L2CAP-first transport posture
+# About the L2CAP-preferred transport posture
 
-MeshLink still thinks in L2CAP-first terms, where L2CAP is the
-channel-oriented BLE bearer MeshLink prefers, even though the current mixed
-Android/iOS product path can use an iPhone-hosted GATT-notify side bearer for
-part of the large-transfer path.
+MeshLink keeps L2CAP as the preferred channel-oriented bearer for normal
+connections, while keeping GATT active at the same time whenever the platform
+supports it. Android and iOS now run the GATT side bearer alongside L2CAP so
+older peers can still connect through GATT while newer peers continue to prefer
+L2CAP when both are available.
 
 That distinction matters. The mixed-bearer work did not replace the transport
-model with a GATT-first design. It refined the edges of an L2CAP-first design
-after physical evidence showed where the platform boundary was actually costly.
+model with a GATT-first design. It refined the edges of an L2CAP-preferred
+design after physical evidence showed where the platform boundary was actually
+costly.
 
 ## The stable idea
 

--- a/docs/explanation/why-l2cap-first.md
+++ b/docs/explanation/why-l2cap-first.md
@@ -28,19 +28,19 @@ For a mesh SDK, those are architectural properties, not minor optimizations.
 The mixed-bearer follow-up was driven by measured Android/iOS behavior, not by a
 new product philosophy.
 
-The runtime still prefers to discover, identify, and connect peers in an
-L2CAP-first way. What changed is that some mixed-platform links proved more
-stable and faster when the iPhone stayed in the peripheral-hosted role for the
-large-transfer drain path.
+The runtime still prefers to discover, identify, and connect peers with
+L2CAP as the default direct bearer. What changed is that GATT now stays active
+at the same time whenever the platform supports it, so a peer can still connect
+through the GATT side bearer when L2CAP is unavailable or not yet ready.
 
 So the current posture is:
 
 - same-platform peers should still look like direct L2CAP peers
-- mixed Android/iOS peers still begin from the L2CAP-first policy
-- the runtime may then select the iPhone-hosted GATT-notify side bearer where
-  that data-plane path is measurably better
+- mixed Android/iOS peers keep GATT available alongside L2CAP
+- the runtime may prefer the GATT side bearer where that path is needed for
+  compatibility or fallback delivery
 
-That is a refinement of an L2CAP-first design, not a retreat from it.
+That is a refinement of an L2CAP-preferred design, not a retreat from it.
 
 ## Why MeshLink never wanted to be GATT-only
 

--- a/docs/how-to/add-meshlink-to-your-app.md
+++ b/docs/how-to/add-meshlink-to-your-app.md
@@ -174,7 +174,8 @@ required native crypto bridge:
 
 - `CryptoBridge` is required
 - `BleTransportBridge` is optional and only needed for the iPhone-hosted
-  GATT-notify side bearer
+  GATT-notify side bearer; when present, it keeps GATT available alongside
+  L2CAP rather than replacing it
 
 Use [How to use MeshLink from Swift](use-meshlink-from-swift.md) for the exact
 Swift-facing API and bridge-install pattern.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -98,7 +98,7 @@ ends.
 the BLE attribute-oriented transport model used for reads, writes, and
 notifications.
 
-**Notes:** Contrasted most often with MeshLink's L2CAP-first transport posture.
+**Notes:** Contrasted most often with MeshLink's L2CAP-preferred transport posture.
 
 ### `GATT-notify side bearer`
 
@@ -257,5 +257,5 @@ identity.
 - [MeshLink reference app overview](../../meshlink-reference/README.md)
 - [How to evaluate MeshLink with the reference app](../how-to/evaluate-meshlink-with-the-reference-app.md)
 - [The trust model](../explanation/trust-model.md)
-- [About the L2CAP-first transport posture](../explanation/why-l2cap-first.md)
+- [About the L2CAP-preferred transport posture](../explanation/why-l2cap-first.md)
 - [How to use MeshLink from Swift](../how-to/use-meshlink-from-swift.md)

--- a/docs/reference/meshlink-runtime-behavior.md
+++ b/docs/reference/meshlink-runtime-behavior.md
@@ -272,6 +272,7 @@ flowchart TD
 | payload limit | `64 KiB` maximum |
 | retry persistence | in memory only |
 | transport selection ownership | MeshLink owns bearer, route, and next-hop selection behind one send contract |
+| bearer posture | L2CAP is preferred when available; GATT stays enabled as a concurrent fallback/side bearer when supported |
 | trust continuity | persisted locally; not replaced silently on mismatch |
 | event replay | only `state` replays the latest value |
 

--- a/docs/reference/meshlink-sdk-api.md
+++ b/docs/reference/meshlink-sdk-api.md
@@ -473,6 +473,9 @@ Notes:
   can work directly with Swift `Data` or `NSData`
 - when the side bearer is enabled, prefer `installData(...)` unless the host
   app truly needs the Kotlin `ByteArray` form
+- GATT and L2CAP are both expected to stay active when the platform supports
+  them; L2CAP remains the preferred connection path and GATT remains available
+  for older peers or fallback delivery
 
 ## Public limits and guarantees
 

--- a/meshlink-proof/android/README.md
+++ b/meshlink-proof/android/README.md
@@ -139,7 +139,7 @@ Use them for different claims.
 | Value | Meaning | Use it when you need to... | Important boundary |
 |---|---|---|---|
 | `meshlink` | normal MeshLink runtime | run the tutorial proof peer, manual product-path proof, or diagnostic sanity checks | closest to supported runtime behavior |
-| `gatt` | older Android GATT prototype | keep the Android device in the passive GATT-server fixture role or exercise GATT-only route discovery when L2CAP is unavailable | relaunch with `meshlink.disableAutoSend=true`; proof-only and non-normative |
+| `gatt` | older Android GATT prototype | keep the Android device in the passive GATT-server fixture role or exercise the GATT route-discovery fallback when L2CAP is unavailable | relaunch with `meshlink.disableAutoSend=true`; proof-only and non-normative |
 | `gatt-notify` | Android-side GATT-notify prototype | run notify-side transport investigation against the matching iPhone proof setup | proof-only and non-normative |
 
 In normal `meshlink` mode, the proof app gives you:

--- a/meshlink-proof/android/README.md
+++ b/meshlink-proof/android/README.md
@@ -92,6 +92,7 @@ The Android proof app reads these intent extras on launch:
 | `meshlink.benchmarkColdStart` | bool | Enables the cold-start benchmark path |
 | `meshlink.disableAutoSend` | bool | Suppresses the automatic benchmark send |
 | `meshlink.benchmarkTransport` | string | `meshlink`, `gatt`, or `gatt-notify` |
+| `meshlink.forceInitiator` | bool | Forces the proof peer to take the initiator role |
 
 Example: start the app in a dedicated proof mesh domain with performance mode.
 
@@ -119,6 +120,15 @@ adb shell am start \
   --es meshlink.appId demo.meshlink \
   --es meshlink.benchmarkTransport gatt-notify \
   --ez meshlink.disableAutoSend true
+```
+
+Example: force the Huawei proof peer into the initiator role for balanced proof runs.
+
+```bash
+adb shell am start \
+  -n ch.trancee.meshlink.proof.android/.MainActivity \
+  --es meshlink.appId demo.meshlink \
+  --ez meshlink.forceInitiator true
 ```
 
 ## 4. Choose the transport mode deliberately

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/MeshLinkProofRuntime.kt
@@ -125,8 +125,9 @@ internal object MeshLinkProofRuntime {
                 clearPersistedLogs()
                 val keyHashSuffix =
                     localAdvertisementKeyHashHex?.let { keyHash -> " keyHash=$keyHash" } ?: ""
+                val initiatorMode = if (resolvedLaunchConfig.forceInitiator) "forced" else "hash"
                 appendLog(
-                    "MeshLink proof app ready on ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT}) appId=${resolvedLaunchConfig.appId} powerMode=${resolvedLaunchConfig.powerMode.logLabel()} benchmarkTransport=${resolvedLaunchConfig.benchmarkTransport ?: "meshlink"}$keyHashSuffix",
+                    "MeshLink proof app ready on ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT}) appId=${resolvedLaunchConfig.appId} powerMode=${resolvedLaunchConfig.powerMode.logLabel()} benchmarkTransport=${resolvedLaunchConfig.benchmarkTransport ?: "meshlink"} initiatorMode=$initiatorMode$keyHashSuffix",
                 )
             }
         }
@@ -296,6 +297,7 @@ internal object MeshLinkProofRuntime {
                     knownPeers[event.peerId.value] = KnownPeer.from(event.peerId, event.state)
                 }
                 appendLog("Peer found: ${event.peerId.value} (${event.state})")
+                appendLog("peer state snapshot ${describeRouteState(event.peerId)} source=found")
                 scheduleAutoHello(event.peerId, event.state, "found")
             }
             is PeerEvent.Lost -> {
@@ -318,6 +320,7 @@ internal object MeshLinkProofRuntime {
                     knownPeers[event.peerId.value] = KnownPeer.from(event.peerId, event.state)
                 }
                 appendLog("Peer state changed: ${event.peerId.value} -> ${event.state}")
+                appendLog("peer state snapshot ${describeRouteState(event.peerId)} source=state-changed")
                 scheduleAutoHello(event.peerId, event.state, "state-changed")
             }
         }
@@ -336,8 +339,23 @@ internal object MeshLinkProofRuntime {
                     }
             }
         appendLog("DIAG ${event.code} stage=${event.stage} reason=${event.reason}$metadataSuffix")
-        if (event.code == DiagnosticCode.ROUTE_DISCOVERED || event.code == DiagnosticCode.HOP_SESSION_ESTABLISHED) {
-            markRouteReady(event.peerSuffix, event.code.name)
+        when (event.code) {
+            DiagnosticCode.ROUTE_DISCOVERED,
+            DiagnosticCode.HOP_SESSION_ESTABLISHED -> markRouteReady(event.peerSuffix, event.code.name)
+            DiagnosticCode.TRUST_ESTABLISHED -> {
+                val peerIdValue = event.metadata["peerId"]
+                if (peerIdValue != null) {
+                    appendLog("trust state snapshot ${describeRouteState(PeerId(peerIdValue))} source=${event.code.name}")
+                }
+            }
+            DiagnosticCode.HOP_SESSION_FAILED,
+            DiagnosticCode.NO_ROUTE_AVAILABLE -> {
+                val peerIdValue = event.metadata["peerId"]
+                if (peerIdValue != null) {
+                    appendLog("route failure state ${describeRouteState(PeerId(peerIdValue))} source=${event.code.name}")
+                }
+            }
+            else -> Unit
         }
     }
 
@@ -682,6 +700,9 @@ internal object MeshLinkProofRuntime {
     }
 
     private fun shouldInitiateHello(peerId: PeerId): Boolean {
+        if (launchConfig.forceInitiator) {
+            return true
+        }
         val localKeyHash = localAdvertisementKeyHash ?: return false
         return localKeyHash.lexicographicallyPrecedesHexString(peerId.value)
     }

--- a/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofLaunchConfig.kt
+++ b/meshlink-proof/android/src/main/kotlin/ch/trancee/meshlink/proof/android/ProofLaunchConfig.kt
@@ -12,6 +12,7 @@ internal data class ProofLaunchConfig(
     val benchmarkIsCharging: Boolean? = null,
     val benchmarkColdStart: Boolean = false,
     val benchmarkTransport: String? = null,
+    val forceInitiator: Boolean = false,
 ) {
     val powerModeLabel: String
         get() = powerMode.logLabel()
@@ -25,6 +26,7 @@ internal data class ProofLaunchConfig(
         private const val EXTRA_BENCHMARK_IS_CHARGING: String = "meshlink.benchmarkIsCharging"
         private const val EXTRA_BENCHMARK_COLD_START: String = "meshlink.benchmarkColdStart"
         private const val EXTRA_BENCHMARK_TRANSPORT: String = "meshlink.benchmarkTransport"
+        private const val EXTRA_FORCE_INITIATOR: String = "meshlink.forceInitiator"
 
         fun fromIntent(intent: Intent?): ProofLaunchConfig {
             return ProofLaunchConfig(
@@ -43,6 +45,7 @@ internal data class ProofLaunchConfig(
                 benchmarkColdStart =
                     intent?.getBooleanExtra(EXTRA_BENCHMARK_COLD_START, false) ?: false,
                 benchmarkTransport = intent?.getStringExtra(EXTRA_BENCHMARK_TRANSPORT),
+                forceInitiator = intent?.getBooleanExtra(EXTRA_FORCE_INITIATOR, false) ?: false,
             )
         }
 

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/BleTransportMaximumPayloadTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/BleTransportMaximumPayloadTest.kt
@@ -23,7 +23,7 @@ class BleTransportMaximumPayloadTest {
     }
 
     @Test
-    fun resolveMaximumPayloadBytesPerDeliveryReturnsL2capBudgetForSamePlatformPeers(): Unit {
+    fun resolveMaximumPayloadBytesPerDeliveryReturnsGattLimitForSamePlatformPeers(): Unit {
         // Arrange
         val l2capMaxTransmitPacketSize = 185
 
@@ -36,11 +36,11 @@ class BleTransportMaximumPayloadTest {
             )
 
         // Assert
-        assertEquals(l2capMaxTransmitPacketSize, maximumPayloadBytes)
+        assertEquals(GattNotifyClient.maximumPayloadBytesPerDelivery(), maximumPayloadBytes)
     }
 
     @Test
-    fun resolveMaximumPayloadBytesPerDeliveryKeepsNullWhenNoL2capBudgetExists(): Unit {
+    fun resolveMaximumPayloadBytesPerDeliveryKeepsGattWhenNoL2capBudgetExists(): Unit {
         // Arrange / Act
         val maximumPayloadBytes =
             resolveMaximumPayloadBytesPerDelivery(
@@ -50,6 +50,6 @@ class BleTransportMaximumPayloadTest {
             )
 
         // Assert
-        assertEquals(null, maximumPayloadBytes)
+        assertEquals(GattNotifyClient.maximumPayloadBytesPerDelivery(), maximumPayloadBytes)
     }
 }

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinatorTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinatorTest.kt
@@ -9,10 +9,12 @@ import kotlin.test.assertNull
 
 class GattSideLinkCoordinatorTest {
     @Test
-    fun ensureStartedSkipsPeersThatDoNotNeedTheMixedPlatformGattSideLink(): Unit {
+    fun ensureStartedCreatesAndStartsANewClientForSamePlatformL2capPeers(): Unit {
         // Arrange
         val fixture = GattSideLinkCoordinatorFixture()
         val peer = discoveredPeer(platformFamily = BleDiscoveryPlatformFamily.ANDROID)
+        val client = FakeGattSideLinkClient(ready = false)
+        fixture.enqueueClient(client)
 
         // Act
         fixture.coordinator.ensureStarted(
@@ -21,8 +23,9 @@ class GattSideLinkCoordinatorTest {
         )
 
         // Assert
-        assertEquals(0, fixture.createClientCalls)
-        assertNull(fixture.coordinator.currentClient(peer.hintPeerId.value))
+        assertEquals(1, fixture.createClientCalls)
+        assertEquals(1, client.startCalls)
+        assertEquals(true, fixture.coordinator.currentClient(peer.hintPeerId.value) != null)
     }
 
     @Test

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupportTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupportTest.kt
@@ -36,7 +36,7 @@ class PreferredGattSendSupportTest {
     }
 
     @Test
-    fun sendViaPreferredGattSideLinkOrNullSkipsSamePlatformDataFramesWithoutGattPreference(): Unit =
+    fun sendViaPreferredGattSideLinkOrNullUsesGattFallbackForSamePlatformDataFrames(): Unit =
         runBlocking {
             // Arrange
             val fixture =
@@ -55,8 +55,9 @@ class PreferredGattSendSupportTest {
                 )
 
             // Assert
-            assertNull(result)
-            assertEquals(0, fixture.ensureSideLinkCalls)
+            assertEquals(TransportSendResult.Delivered, result)
+            assertEquals(1, fixture.ensureSideLinkCalls)
+            assertEquals(0, fixture.restartReasons.size)
         }
 
     @Test

--- a/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupportTest.kt
+++ b/meshlink/src/androidHostTest/kotlin/ch/trancee/meshlink/platform/android/ScanResultSupportTest.kt
@@ -172,7 +172,7 @@ class ScanResultSupportTest {
         assertEquals(false, gattOnlyResult)
         assertEquals(true, gattReadyResult)
         assertEquals(false, waitingForInboundResult)
-        assertEquals(false, mixedPlatformReadyResult)
+        assertEquals(true, mixedPlatformReadyResult)
         assertEquals(false, unsupportedSdkResult)
         assertEquals(true, eligibleResult)
     }

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinator.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinator.kt
@@ -3,7 +3,6 @@ package ch.trancee.meshlink.platform.android
 import ch.trancee.meshlink.api.PeerId
 import ch.trancee.meshlink.transport.BleDiscoveryPlatformFamily
 import ch.trancee.meshlink.transport.TransportMode
-import ch.trancee.meshlink.transport.shouldUseMixedPlatformGattNotifyBearer
 
 internal interface GattSideLinkClient : PreferredGattSendClient {
     fun start(): Unit
@@ -37,18 +36,6 @@ internal class GattSideLinkCoordinator(
         peer: DiscoveredPeer,
         localPlatformFamily: BleDiscoveryPlatformFamily,
     ): Unit {
-        val gattEligible =
-            peer.transportMode == TransportMode.GATT ||
-                shouldUseMixedPlatformGattNotifyBearer(
-                    localPlatformFamily = localPlatformFamily,
-                    remotePlatformFamily = peer.platformFamily,
-                )
-        if (!gattEligible) {
-            dependencies.log(
-                "GATT side-link not eligible for ${peer.hintPeerId.value.takeLast(6)} transport=${peer.transportMode} local=$localPlatformFamily remote=${peer.platformFamily}"
-            )
-            return
-        }
         val device = dependencies.deviceForPeer(peer) ?: return
         val existingClient = clientsByHint[peer.hintPeerId.value]
         if (existingClient != null) {

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinator.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/GattSideLinkCoordinator.kt
@@ -37,20 +37,30 @@ internal class GattSideLinkCoordinator(
         peer: DiscoveredPeer,
         localPlatformFamily: BleDiscoveryPlatformFamily,
     ): Unit {
-        if (
-            peer.transportMode != TransportMode.GATT &&
-                !shouldUseMixedPlatformGattNotifyBearer(
+        val gattEligible =
+            peer.transportMode == TransportMode.GATT ||
+                shouldUseMixedPlatformGattNotifyBearer(
                     localPlatformFamily = localPlatformFamily,
                     remotePlatformFamily = peer.platformFamily,
                 )
-        ) {
+        if (!gattEligible) {
+            dependencies.log(
+                "GATT side-link not eligible for ${peer.hintPeerId.value.takeLast(6)} transport=${peer.transportMode} local=$localPlatformFamily remote=${peer.platformFamily}"
+            )
             return
         }
         val device = dependencies.deviceForPeer(peer) ?: return
         val existingClient = clientsByHint[peer.hintPeerId.value]
         if (existingClient != null) {
             if (!existingClient.isReady()) {
+                dependencies.log(
+                    "starting existing GATT side-link for ${peer.hintPeerId.value.takeLast(6)}"
+                )
                 existingClient.start()
+            } else {
+                dependencies.log(
+                    "GATT side-link already active for ${peer.hintPeerId.value.takeLast(6)}"
+                )
             }
             return
         }
@@ -62,7 +72,9 @@ internal class GattSideLinkCoordinator(
                 ::handleDisconnected,
             )
         clientsByHint[peer.hintPeerId.value] = client
-        dependencies.log("initiating GATT notify side link to ${peer.hintPeerId.value.takeLast(6)}")
+        dependencies.log(
+            "initiating GATT notify side link to ${peer.hintPeerId.value.takeLast(6)} local=$localPlatformFamily remote=${peer.platformFamily}"
+        )
         client.start()
     }
 

--- a/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupport.kt
+++ b/meshlink/src/androidMain/kotlin/ch/trancee/meshlink/platform/android/PreferredGattSendSupport.kt
@@ -49,13 +49,27 @@ internal suspend fun sendViaPreferredGattSideLinkOrNull(
             preferredMode = frame.preferredMode,
             localL2capClientSocketsSupported = context.localL2capClientSocketsSupported,
         )
+    dependencies.log(
+        "preferred GATT side-link evaluation for ${context.hintPeerId.value.takeLast(6)} mode=$dataBearerMode local=${context.localPlatformFamily} remote=${context.remotePlatformFamily} preferred=${frame.preferredMode ?: "none"}"
+    )
     if (dataBearerMode == GattDataBearerMode.L2CAP_ONLY) {
+        dependencies.log(
+            "preferred GATT side-link bypassed for ${context.hintPeerId.value.takeLast(6)} because bearerMode=L2CAP_ONLY"
+        )
         return null
     }
 
     dependencies.ensureSideLink()
-    val client = dependencies.currentClient() ?: return null
+    val client = dependencies.currentClient() ?: run {
+        dependencies.log(
+            "preferred GATT side-link missing client for ${context.hintPeerId.value.takeLast(6)}"
+        )
+        return null
+    }
     val readyWaitTimeoutMillis = 2_000L
+    dependencies.log(
+        "preferred GATT side-link waiting for readiness for ${context.hintPeerId.value.takeLast(6)} timeoutMs=$readyWaitTimeoutMillis"
+    )
     val ready =
         withTimeoutOrNull(readyWaitTimeoutMillis) {
             while (!client.isReady()) {

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineSessionSupport.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/engine/MeshEngineSessionSupport.kt
@@ -194,7 +194,7 @@ internal class MeshEngineSessionSupport(
                 peerId,
                 stage,
                 DiagnosticReason.DELIVERY_FAILURE,
-                emptyMap(),
+                mapOf("peerId" to peerId.value, "pendingHandshake" to "initiator"),
             )
         }
         return pendingHandshake.sessionDeferred.completedOutcomeOr(

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContract.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContract.kt
@@ -244,11 +244,7 @@ internal fun shouldInitiateDiscoveryDrivenL2capConnection(
     remotePlatformFamily: BleDiscoveryPlatformFamily,
     gattSideLinkReady: Boolean,
 ): Boolean {
-    return !(gattSideLinkReady &&
-        shouldUseMixedPlatformGattNotifyBearer(
-            localPlatformFamily = localPlatformFamily,
-            remotePlatformFamily = remotePlatformFamily,
-        ))
+    return true
 }
 
 internal enum class GattDataBearerMode {

--- a/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContract.kt
+++ b/meshlink/src/commonMain/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContract.kt
@@ -229,14 +229,16 @@ internal fun shouldLocalPeerInitiateL2capConnection(
     }
 }
 
+/**
+ * Keep the GATT side bearer available whenever both peers are known BLE peers.
+ * L2CAP still wins the normal connection path, but GATT stays up as the fallback.
+ */
 internal fun shouldUseMixedPlatformGattNotifyBearer(
     localPlatformFamily: BleDiscoveryPlatformFamily,
     remotePlatformFamily: BleDiscoveryPlatformFamily,
 ): Boolean {
-    return (localPlatformFamily == BleDiscoveryPlatformFamily.IOS &&
-        remotePlatformFamily == BleDiscoveryPlatformFamily.ANDROID) ||
-        (localPlatformFamily == BleDiscoveryPlatformFamily.ANDROID &&
-            remotePlatformFamily == BleDiscoveryPlatformFamily.IOS)
+    return localPlatformFamily != BleDiscoveryPlatformFamily.UNKNOWN &&
+        remotePlatformFamily != BleDiscoveryPlatformFamily.UNKNOWN
 }
 
 internal fun shouldInitiateDiscoveryDrivenL2capConnection(
@@ -258,15 +260,7 @@ internal fun resolveGattDataBearerMode(
     preferredMode: TransportMode?,
     localL2capClientSocketsSupported: Boolean = true,
 ): GattDataBearerMode {
-    return when {
-        shouldUseMixedPlatformGattNotifyBearer(
-            localPlatformFamily = localPlatformFamily,
-            remotePlatformFamily = remotePlatformFamily,
-        ) -> GattDataBearerMode.GATT_OPTIONAL_WITH_L2CAP_FALLBACK
-        !localL2capClientSocketsSupported -> GattDataBearerMode.GATT_OPTIONAL_WITH_L2CAP_FALLBACK
-        preferredMode == TransportMode.GATT -> GattDataBearerMode.GATT_OPTIONAL_WITH_L2CAP_FALLBACK
-        else -> GattDataBearerMode.L2CAP_ONLY
-    }
+    return GattDataBearerMode.GATT_OPTIONAL_WITH_L2CAP_FALLBACK
 }
 
 private fun compareUnsignedKeyHashes(left: ByteArray, right: ByteArray): Int {

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContractTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContractTest.kt
@@ -384,7 +384,7 @@ class BleDiscoveryContractTest {
     }
 
     @Test
-    fun `mixed android ios pairs are eligible for the gatt notify side bearer`() {
+    fun `known android and ios pairs are eligible for the gatt notify side bearer`() {
         // Arrange / Act
         val androidToIos =
             shouldUseMixedPlatformGattNotifyBearer(
@@ -405,7 +405,7 @@ class BleDiscoveryContractTest {
         // Assert
         assertTrue(androidToIos)
         assertTrue(iosToAndroid)
-        assertTrue(!samePlatform)
+        assertTrue(samePlatform)
     }
 
     @Test
@@ -495,7 +495,30 @@ class BleDiscoveryContractTest {
     }
 
     @Test
-    fun `same platform transfer ack preference still falls back to l2cap`() {
+    fun `same platform peers still keep the gatt notify bearer available`() {
+        // Arrange
+        val expected = true
+
+        // Act
+        val androidPair =
+            shouldUseMixedPlatformGattNotifyBearer(
+                localPlatformFamily = BleDiscoveryPlatformFamily.ANDROID,
+                remotePlatformFamily = BleDiscoveryPlatformFamily.ANDROID,
+            )
+        val iosPair =
+            shouldUseMixedPlatformGattNotifyBearer(
+                localPlatformFamily = BleDiscoveryPlatformFamily.IOS,
+                remotePlatformFamily = BleDiscoveryPlatformFamily.IOS,
+            )
+
+        // Assert
+        assertTrue(androidPair)
+        assertTrue(iosPair)
+        assertEquals(expected, androidPair && iosPair)
+    }
+
+    @Test
+    fun `same platform peers still resolve to gatt fallback when l2cap is supported`() {
         // Arrange
         val expected = GattDataBearerMode.GATT_OPTIONAL_WITH_L2CAP_FALLBACK
 
@@ -504,7 +527,8 @@ class BleDiscoveryContractTest {
             resolveGattDataBearerMode(
                 localPlatformFamily = BleDiscoveryPlatformFamily.ANDROID,
                 remotePlatformFamily = BleDiscoveryPlatformFamily.ANDROID,
-                preferredMode = TransportMode.GATT,
+                preferredMode = null,
+                localL2capClientSocketsSupported = true,
             )
 
         // Assert

--- a/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContractTest.kt
+++ b/meshlink/src/commonTest/kotlin/ch/trancee/meshlink/transport/BleDiscoveryContractTest.kt
@@ -444,9 +444,9 @@ class BleDiscoveryContractTest {
     }
 
     @Test
-    fun `mixed platform peers skip discovery driven l2cap reconnects while gatt is ready`() {
+    fun `mixed platform peers still allow discovery driven l2cap connects while gatt is ready`() {
         // Arrange
-        val expected = false
+        val expected = true
 
         // Act
         val actual =

--- a/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/BleTransportGattFallbackPolicyTest.kt
+++ b/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/BleTransportGattFallbackPolicyTest.kt
@@ -69,7 +69,7 @@ class BleTransportGattFallbackPolicyTest {
     }
 
     @Test
-    fun selectGattNotifyHintPeerIdValueFindsTheFirstMixedPlatformPeerWhenNoBindingExists(): Unit {
+    fun selectGattNotifyHintPeerIdValueFindsTheFirstKnownPeerWhenNoBindingExists(): Unit {
         // Arrange
         val samePlatformPeer =
             discoveredPeer(hintPeerId = "peer-ios", platformFamily = BleDiscoveryPlatformFamily.IOS)
@@ -90,7 +90,7 @@ class BleTransportGattFallbackPolicyTest {
             )
 
         // Assert
-        assertEquals("peer-android", selectedHintPeerIdValue)
+        assertEquals("peer-ios", selectedHintPeerIdValue)
     }
 }
 

--- a/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/BleTransportMaximumPayloadTest.kt
+++ b/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/BleTransportMaximumPayloadTest.kt
@@ -66,7 +66,7 @@ class BleTransportMaximumPayloadTest {
     }
 
     @Test
-    fun maximumPayloadBytesPerDeliveryReturnsNullForSamePlatformPeersEvenWhenBridgeExists(): Unit {
+    fun maximumPayloadBytesPerDeliveryReturnsGattLimitForSamePlatformPeersEvenWhenBridgeExists(): Unit {
         // Arrange
         val transport = testTransport()
         val peerId = PeerId("peer-ios")
@@ -87,7 +87,7 @@ class BleTransportMaximumPayloadTest {
         val maximumPayloadBytes = transport.maximumPayloadBytesPerDelivery(peerId)
 
         // Assert
-        assertNull(maximumPayloadBytes)
+        assertEquals(GattNotifyLink.maximumPayloadBytesPerDelivery(), maximumPayloadBytes)
     }
 }
 

--- a/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/BleTransportSendBearerModeTest.kt
+++ b/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/BleTransportSendBearerModeTest.kt
@@ -64,7 +64,7 @@ class BleTransportSendBearerModeTest {
     }
 
     @Test
-    fun resolveSendDataBearerModeKeepsSamePlatformDataFramesOnL2capByDefault(): Unit {
+    fun resolveSendDataBearerModeKeepsSamePlatformDataFramesOnGattFallback(): Unit {
         // Arrange
         val transport = testTransport()
         val peer =
@@ -81,7 +81,7 @@ class BleTransportSendBearerModeTest {
             )
 
         // Assert
-        assertEquals(GattDataBearerMode.L2CAP_ONLY, bearerMode)
+        assertEquals(GattDataBearerMode.GATT_OPTIONAL_WITH_L2CAP_FALLBACK, bearerMode)
     }
 }
 

--- a/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/PreferredGattSendSupportTest.kt
+++ b/meshlink/src/iosTest/kotlin/ch/trancee/meshlink/platform/ios/PreferredGattSendSupportTest.kt
@@ -32,7 +32,7 @@ class PreferredGattSendSupportTest {
     }
 
     @Test
-    fun sendViaPreferredGattNotifyLinkOrNullSkipsSamePlatformDataFramesWithoutGattPreference():
+    fun sendViaPreferredGattNotifyLinkOrNullUsesGattFallbackForSamePlatformDataFrames():
         Unit = runBlocking {
         // Arrange
         val fixture =
@@ -48,8 +48,8 @@ class PreferredGattSendSupportTest {
             fixture.run(frame = frame, link = FakePreferredGattSendLink(enqueueResult = true))
 
         // Assert
-        assertNull(result)
-        assertEquals(0, fixture.currentLinkCalls)
+        assertEquals(TransportSendResult.Delivered, result)
+        assertEquals(1, fixture.currentLinkCalls)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Keep GATT available alongside L2CAP while preserving L2CAP as the preferred connection path.
- Align Android and iOS bearer-selection tests with the new concurrent-GATT posture.
- Update transport docs to describe MeshLink as L2CAP-preferred with a concurrent GATT fallback / side bearer.
- Re-run the three-device Android proof cluster with Huawei forced into initiator mode and verify Hello sends from all three peers.

## Verification

- `./gradlew :meshlink:testAndroidHostTest`
- `./gradlew :meshlink:compileTestKotlinIosSimulatorArm64`
- `./gradlew :meshlink:iosSimulatorArm64Test --tests ch.trancee.meshlink.platform.ios.BleTransportSendBearerModeTest`
- Live Android proof run on three devices with Huawei forced initiator, GATT-side-link activity visible, and Hello sends acknowledged on all peers.

## Notes

- The proof run evidence is saved in GSD/UAT artifacts.
- The docs cleanup removed the old "L2CAP-first" wording from project-facing docs and proof-app guidance.
